### PR TITLE
Add more events to Cisco modules errors

### DIFF
--- a/collections/fm.eventclassificationrules/Cisco/IOS/Chassis/Hardware/Module/Invalid_Module_3_SYSLOG_.json
+++ b/collections/fm.eventclassificationrules/Cisco/IOS/Chassis/Hardware/Module/Invalid_Module_3_SYSLOG_.json
@@ -1,0 +1,29 @@
+{
+    "name": "Cisco | IOS | Chassis | Hardware | Module | Invalid Module #3 (SYSLOG)",
+    "$collection": "fm.eventclassificationrules",
+    "uuid": "e530b58f-a9b8-4fc5-9cb7-01c06bcae43f",
+    "description": "%PHY-4-UNSUPPORTED_TRANSCEIVER: Unsupported transceiver found in Gi1/0/10",
+    "event_class__name": "Chassis | Hardware | Module | Invalid Module",
+    "preference": 1000,
+    "vars": [
+        {
+            "name": "module",
+            "value": "SFP/GBIC"
+        },
+        {
+            "name": "reason",
+            "value": "module is not supported"
+        }
+    ],
+    "patterns": [],
+    "labels": [],
+    "message_rx": "%PHY-4-UNSUPPORTED_TRANSCEIVER: Unsupported transceiver found in (?P<interface>\\S+)",
+    "profiles": ["Cisco.IOS"],
+    "sources": ["syslog"],
+    "test_cases": [
+        {
+            "message": "%PHY-4-UNSUPPORTED_TRANSCEIVER: Unsupported transceiver found in Gi1/0/10",
+            "raw_vars": []
+        }
+    ]
+}

--- a/collections/fm.eventclassificationrules/Cisco/IOS/Chassis/Hardware/Module/Module_Error_10_SYSLOG_.json
+++ b/collections/fm.eventclassificationrules/Cisco/IOS/Chassis/Hardware/Module/Module_Error_10_SYSLOG_.json
@@ -1,0 +1,19 @@
+{
+    "name": "Cisco | IOS | Chassis | Hardware | Module | Module Error #10 (SYSLOG)",
+    "$collection": "fm.eventclassificationrules",
+    "uuid": "d7d9facd-ebcc-408b-b6e1-a23f332dfced",
+    "description": "%GBIC_SECURITY_CRYPT-4-ID_MISMATCH: Identification check failed for GBIC in port Gi1/0/12",
+    "event_class__name": "Chassis | Hardware | Module | Module Error",
+    "preference": 1000,
+    "patterns": [],
+    "labels": [],
+    "message_rx": "%GBIC_SECURITY_CRYPT-4-ID_MISMATCH: (?P<reason>.+) for (?P<module>\\S+) in port (?P<interface>\\S+)",
+    "profiles": ["Cisco.IOS"],
+    "sources": ["syslog"],
+    "test_cases": [
+        {
+            "message": "%GBIC_SECURITY_CRYPT-4-ID_MISMATCH: Identification check failed for GBIC in port Gi1/0/12",
+            "raw_vars": []
+        }
+    ]
+}

--- a/collections/fm.eventclassificationrules/Cisco/IOS/Chassis/Hardware/Module/Module_Error_9_SYSLOG_.json
+++ b/collections/fm.eventclassificationrules/Cisco/IOS/Chassis/Hardware/Module/Module_Error_9_SYSLOG_.json
@@ -1,0 +1,19 @@
+{
+    "name": "Cisco | IOS | Chassis | Hardware | Module | Module Error #9 (SYSLOG)",
+    "$collection": "fm.eventclassificationrules",
+    "uuid": "275c5ab6-cfb9-4315-be84-d5635eac595f",
+    "description": "%GBIC_SECURITY_CRYPT-4-VN_DATA_CRC_ERROR: GBIC in port Gi1/0/10 has bad crc",
+    "event_class__name": "Chassis | Hardware | Module | Module Error",
+    "preference": 1000,
+    "patterns": [],
+    "labels": [],
+    "message_rx": "%GBIC_SECURITY_CRYPT-4-VN_DATA_CRC_ERROR: (?P<module>\\S+) in port (?P<interface>\\S+) has (?P<reason>.+)",
+    "profiles": ["Cisco.IOS"],
+    "sources": ["syslog"],
+    "test_cases": [
+        {
+            "message": "%GBIC_SECURITY_CRYPT-4-VN_DATA_CRC_ERROR: GBIC in port Gi1/0/10 has bad crc",
+            "raw_vars": []
+        }
+    ]
+}


### PR DESCRIPTION
Научились парсить следующие сообщения `syslog` для  профиля `Cisco.IOS`:
```
%PHY-4-UNSUPPORTED_TRANSCEIVER: Unsupported transceiver found in Gi1/0/10
%GBIC_SECURITY_CRYPT-4-ID_MISMATCH: Identification check failed for GBIC in port Gi1/0/12
%GBIC_SECURITY_CRYPT-4-VN_DATA_CRC_ERROR: GBIC in port Gi1/0/10 has bad crc
```
