### PR TITLE
Add first part of xPON event/alarm classes

### DIFF
--- a/collections/fm.alarmclasses/Network/xPON/Laser_Always_On.json
+++ b/collections/fm.alarmclasses/Network/xPON/Laser_Always_On.json
@@ -1,0 +1,38 @@
+{
+    "name": "Network | xPON | Laser Always On",
+    "$collection": "fm.alarmclasses",
+    "uuid": "1b17fee4-5978-4c55-aa22-e861b03a5b14",
+    "is_unique": true,
+    "reference": ["interface"],
+    "is_ephemeral": false,
+    "user_clearable": true,
+    "components": [
+        {
+            "name": "interface",
+            "model": "inv.Interface",
+            "args": [{
+                "param": "interface",
+                "var": "interface"
+            }]
+        }
+    ],
+    "vars": [
+        {
+            "name": "interface",
+            "description": "interface name"
+        },
+        {
+            "name": "description",
+            "description": "Interface description",
+            "default": "=components.interface.description"
+        }
+    ],
+    "subject_template": "\"Laser always on\" error on {{interface}}{% if description %} ({{description}}){% endif %}",
+    "body_template": "\"Laser always on\" error on {{interface}}{% if description %} ({{description}}){% endif %}",
+    "symptoms": "Connection lost, some ONU are not registered",
+    "probable_causes": "The optical splitter is not connected correctly, ONU laser is damaged, third-party active optical equipment in the network",
+    "recommended_actions": "Check optical links and hardware",
+    "recover_time": 300,
+    "affected_service": true,
+    "labels": ["noc::severity::warning"]
+}

--- a/collections/fm.alarmclasses/Network/xPON/ONU/Power_Failed.json
+++ b/collections/fm.alarmclasses/Network/xPON/ONU/Power_Failed.json
@@ -1,0 +1,29 @@
+{
+    "name": "Network | xPON | ONU | Power Failed",
+    "$collection": "fm.alarmclasses",
+    "uuid": "fe63a499-afd5-475a-b10e-4854daba20de",
+    "is_unique": true,
+    "reference": ["mac"],
+    "is_ephemeral": false,
+    "user_clearable": true,
+    "vars": [
+        {
+            "name": "interface",
+            "description": "xPON interface"
+        },
+        {
+            "name": "mac",
+            "description": "ONU MAC"
+        },
+        {
+            "name": "vendor",
+            "description": "ONU vendor"
+        }
+    ],
+    "subject_template": "ONU {% if vendor %}{{vendor}}:{% endif %}{{mac}} power failed on {{interface}}",
+    "body_template": "ONU {% if vendor %}{{vendor}}:{% endif %}{{mac}} power failed on {{interface}}",
+    "symptoms": "Subscriber connection loss",
+    "probable_causes": "",
+    "recommended_actions": "",
+    "labels": ["noc::severity::info"]
+}

--- a/collections/fm.eventclasses/Network/xPON/Laser_Always_On.json
+++ b/collections/fm.eventclasses/Network/xPON/Laser_Always_On.json
@@ -1,0 +1,31 @@
+{
+    "name": "Network | xPON | Laser Always On",
+    "$collection": "fm.eventclasses",
+    "uuid": "13a2bc9b-4baa-4cfa-bc7e-391b2570e82d",
+    "description": "Laser always on",
+    "action": "A",
+    "vars": [
+        {
+            "name": "interface",
+            "description": "xPON interface",
+            "type": "interface_name",
+            "required": true
+        }
+    ],
+    "deduplication_window": 3,
+    "suppression_window": 120,
+    "ttl": 86400,
+    "subject_template": "\"Laser always on\" error on {{interface}}",
+    "body_template": "\"Laser always on\" error on {{interface}}",
+    "symptoms": "",
+    "probable_causes": "",
+    "recommended_actions": "",
+    "disposition": [
+        {
+            "name": "dispose",
+            "condition": "True",
+            "action": "raise",
+            "alarm_class__name": "Network | xPON | Laser Always On"
+        }
+    ]
+}

--- a/collections/fm.eventclasses/Network/xPON/ONU/Activated.json
+++ b/collections/fm.eventclasses/Network/xPON/ONU/Activated.json
@@ -1,0 +1,32 @@
+{
+    "name": "Network | xPON | ONU | Activated",
+    "$collection": "fm.eventclasses",
+    "uuid": "e2b8adeb-8ed4-4274-bb09-c59b6c2cfc7f",
+    "description": "ONU activated successfully",
+    "action": "A",
+    "vars": [
+        {
+            "name": "interface",
+            "description": "xPON interface",
+            "type": "interface_name",
+            "required": true
+        },
+        {
+            "name": "mac",
+            "description": "ONU MAC",
+            "type": "mac",
+            "required": true
+        },
+        {
+            "name": "vendor",
+            "description": "ONU vendor",
+            "type": "str",
+            "required": false
+        }
+    ],
+    "subject_template": "ONU {% if vendor %}{{vendor}}:{% endif %}{{mac}} activated on {{interface}}",
+    "body_template": "ONU {% if vendor %}{{vendor}}:{% endif %}{{mac}} activated on {{interface}}",
+    "symptoms": "",
+    "probable_causes": "",
+    "recommended_actions": ""
+}

--- a/collections/fm.eventclasses/Network/xPON/ONU/Discovered.json
+++ b/collections/fm.eventclasses/Network/xPON/ONU/Discovered.json
@@ -1,0 +1,40 @@
+{
+    "name": "Network | xPON | ONU | Discovered",
+    "$collection": "fm.eventclasses",
+    "uuid": "8612d710-2828-4b7a-8f4e-e3c24bb0bfe2",
+    "description": "ONU discovered/registered",
+    "action": "A",
+    "vars": [
+        {
+            "name": "interface",
+            "description": "xPON interface",
+            "type": "interface_name",
+            "required": true
+        },
+        {
+            "name": "mac",
+            "description": "ONU MAC",
+            "type": "mac",
+            "required": true
+        },
+        {
+            "name": "vendor",
+            "description": "ONU vendor",
+            "type": "str",
+            "required": false
+        }
+    ],
+    "subject_template": "ONU {% if vendor %}{{vendor}}:{% endif %}{{mac}} discovered on {{interface}}",
+    "body_template": "ONU {% if vendor %}{{vendor}}:{% endif %}{{mac}} discovered on {{interface}}",
+    "symptoms": "",
+    "probable_causes": "",
+    "recommended_actions": "",
+    "disposition": [
+        {
+            "name": "dispose",
+            "condition": "True",
+            "action": "clear",
+            "alarm_class__name": "Network | xPON | ONU | Power Failed"
+        }
+    ]
+}

--- a/collections/fm.eventclasses/Network/xPON/ONU/Offline.json
+++ b/collections/fm.eventclasses/Network/xPON/ONU/Offline.json
@@ -1,0 +1,32 @@
+{
+    "name": "Network | xPON | ONU | Offline",
+    "$collection": "fm.eventclasses",
+    "uuid": "d1227cc9-0f85-4297-b8c5-649e0d5ce48e",
+    "description": "ONU deregistered or offline",
+    "action": "A",
+    "vars": [
+        {
+            "name": "interface",
+            "description": "xPON interface",
+            "type": "interface_name",
+            "required": true
+        },
+        {
+            "name": "mac",
+            "description": "ONU MAC",
+            "type": "mac",
+            "required": true
+        },
+        {
+            "name": "vendor",
+            "description": "ONU vendor",
+            "type": "str",
+            "required": false
+        }
+    ],
+    "subject_template": "ONU {% if vendor %}{{vendor}}:{% endif %}{{mac}} offline on {{interface}}",
+    "body_template": "ONU {% if vendor %}{{vendor}}:{% endif %}{{mac}} offline on {{interface}}",
+    "symptoms": "",
+    "probable_causes": "",
+    "recommended_actions": ""
+}

--- a/collections/fm.eventclasses/Network/xPON/ONU/Power_Failed.json
+++ b/collections/fm.eventclasses/Network/xPON/ONU/Power_Failed.json
@@ -1,0 +1,40 @@
+{
+    "name": "Network | xPON | ONU | Power Failed",
+    "$collection": "fm.eventclasses",
+    "uuid": "a3b3fb8e-cbaa-4bbc-b610-0ba22b1ca344",
+    "description": "ONU Power failed",
+    "action": "A",
+    "vars": [
+        {
+            "name": "interface",
+            "description": "xPON interface",
+            "type": "interface_name",
+            "required": true
+        },
+        {
+            "name": "mac",
+            "description": "ONU MAC",
+            "type": "mac",
+            "required": true
+        },
+        {
+            "name": "vendor",
+            "description": "ONU vendor",
+            "type": "str",
+            "required": false
+        }
+    ],
+    "subject_template": "ONU {% if vendor %}{{vendor}}:{% endif %}{{mac}} power failed on {{interface}}",
+    "body_template": "ONU {% if vendor %}{{vendor}}:{% endif %}{{mac}} power failed on {{interface}}",
+    "symptoms": "",
+    "probable_causes": "",
+    "recommended_actions": "",
+    "disposition": [
+        {
+            "name": "dispose",
+            "condition": "True",
+            "action": "raise",
+            "alarm_class__name": "Network | xPON | ONU | Power Failed"
+        }
+    ]
+}


### PR DESCRIPTION
Добавлены ивентклассы:
```
"Network | xPON | ONU | Activated"
"Network | xPON | ONU | Discovered"
"Network | xPON | ONU | Offline"
"Network | xPON | ONU | Power Failed"
"Network | xPON | Laser Always On"
```
Добавлены алармклассы:
```
"Network | xPON | ONU | Power Failed"
"Network | xPON | Laser Always On"
```