### PR TITLE
Remove classifier dependency section

### DIFF
--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -124,7 +124,7 @@ jobs:
         uses: astral-sh/setup-uv@v1
 
       - name: Install Dependencies
-        run: uv pip install --system -e .[node,test,bh,activator,classifier,cache-redis,node,login-ldap,login-pam,login-radius,prod-tools,testing,ping]
+        run: uv pip install --system -e .[node,test,bh,activator,cache-redis,node,login-ldap,login-pam,login-radius,prod-tools,testing,sender-kafka,ping]
 
       - name: Run Tests (with coverage)
         run: pytest --maxfail=10 --cov --cov-branch --cov-report=xml tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ COPY --from=build-ui /opt/noc/ui/dist/ /www/
 WORKDIR /opt/noc/
 RUN \
     set -x \
-    && uv pip install --system -e .[bh,activator,classifier,cache-redis,node,login-ldap,login-pam,login-radius,prod-tools,testing,ping] \
+    && uv pip install --system -e .[bh,activator,cache-redis,node,login-ldap,login-pam,login-radius,prod-tools,testing,sender-kafka,ping] \
     && (curl -L https://raw.githubusercontent.com/static-web-server/static-web-server/refs/tags/v2.40.1/scripts/installer.sh | sed 's/sudo //g' | sh) \
     && find /opt/noc/ -type f -name "*.py" -print0 | xargs -0 python3 -m py_compile \
     && uv cache clean \
@@ -93,7 +93,7 @@ RUN \
     && apt-get install -y --no-install-recommends \
     snmp \
     git \
-    && uv pip install --system -e .[bh,activator,classifier,cache-redis,dev,docs,lint,node,test,login-ldap,login-pam,login-radius,prod-tools,testing,ping] \
+    && uv pip install --system -e .[bh,activator,cache-redis,dev,docs,lint,node,test,login-ldap,login-pam,login-radius,prod-tools,testing,sender-kafka,ping] \
     && uv cache clean \
     && (curl -fsSL https://deb.nodesource.com/setup_24.x | bash -)\
     && apt-get install -y --no-install-recommends nodejs \

--- a/ansible/noc_roles/noc/tasks/init_venv_python3.yml
+++ b/ansible/noc_roles/noc/tasks/init_venv_python3.yml
@@ -216,14 +216,6 @@
   tags:
     - requirements
 
-- name: Add -classifier- python packages
-  set_fact:
-    python_deps: "{{ python_deps + ['classifier'] }}"
-  when:
-    - "'svc-classifier-exec' in groups and inventory_hostname in groups['svc-classifier-exec']"
-  tags:
-    - requirements
-
 - name: Add -login- python packages 1
   set_fact:
     python_deps: "{{ python_deps + ['login-ldap'] }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ bh = [
 ]
 cache-memcached = ["pylibmc==1.6.3"]
 cache-redis = ["hiredis==3.1.0", "redis==4.6.0"]
-classifier = ["bitarray==3.7.1"]
 dev = [
   "Babel==2.13.1",
   "ipython==9.5.0",


### PR DESCRIPTION
The experimental ESM mode of the classifier service has been removed. The classifier extras (bitarray==3.7.1) is no longer needed since no code imports it anymore — verified across all ansible roles, py-tests workflow, Dockerfile, and molecule inventories.
    
## Changes:
- pyproject.toml: remove classifier = ["bitarray==3.7.1"] extras key
- .github/workflows/py-tests.yml: remove classifier from CI install command
- Dockerfile: remove classifier from both uv pip install stages (base + dev)
- ansible/noc_roles/noc/tasks/init_venv_python3.yml: remove set_fact that installed classifier-extras on svc-classifier-exec nodes