### PR TITLE
Add FQDN field to ApplicationModel and managed object table

### DIFF
--- a/services/web/apps/sa/managedobject/views.py
+++ b/services/web/apps/sa/managedobject/views.py
@@ -322,6 +322,7 @@ class ManagedObjectApplication(ExtModelApplication):
             "version": o.version.version if o.version else "",
             "vrf": o.vrf.name if o.vrf else "",
             "description": o.description or "",
+            "fqdn": o.fqdn or "",
             "row_class": o.object_profile.get_css_class() or "" if o.object_profile else "",
             "link_count": len(o.links),
             "labels": sorted(

--- a/ui/web/sa/managedobject/Application.js
+++ b/ui/web/sa/managedobject/Application.js
@@ -101,6 +101,11 @@ const defaultColumns = [
     flex: 1,
   },
   {
+    text: __('FQDN'),
+    dataIndex: 'fqdn',
+    flex: 1,
+  },   
+  {
     text: __("Interfaces"),
     dataIndex: "interface_count",
     width: 50,

--- a/ui/web/sa/managedobject/Application.js
+++ b/ui/web/sa/managedobject/Application.js
@@ -101,8 +101,8 @@ const defaultColumns = [
     flex: 1,
   },
   {
-    text: __('FQDN'),
-    dataIndex: 'fqdn',
+    text: __("FQDN"),
+    dataIndex: "fqdn",
     width: 200,
     hidden: true
   },

--- a/ui/web/sa/managedobject/Application.js
+++ b/ui/web/sa/managedobject/Application.js
@@ -104,7 +104,7 @@ const defaultColumns = [
     text: __("FQDN"),
     dataIndex: "fqdn",
     width: 200,
-    hidden: true
+    hidden: true,
   },
   {
     text: __("Interfaces"),

--- a/ui/web/sa/managedobject/Application.js
+++ b/ui/web/sa/managedobject/Application.js
@@ -105,7 +105,7 @@ const defaultColumns = [
     dataIndex: 'fqdn',
     width: 200,
     hidden: true
-  },   
+  },
   {
     text: __("Interfaces"),
     dataIndex: "interface_count",

--- a/ui/web/sa/managedobject/Application.js
+++ b/ui/web/sa/managedobject/Application.js
@@ -103,7 +103,8 @@ const defaultColumns = [
   {
     text: __('FQDN'),
     dataIndex: 'fqdn',
-    flex: 1,
+    width: 200,
+    hidden: true
   },   
   {
     text: __("Interfaces"),

--- a/ui/web/sa/managedobject/ApplicationModel.js
+++ b/ui/web/sa/managedobject/ApplicationModel.js
@@ -72,6 +72,10 @@ Ext.define("NOC.sa.managedobject.ApplicationModel", {
       type: "string",
     },
     {
+      name: "fqdn",
+      type: "string"
+    },    
+    {
       name: "interface_count",
       type: "int",
     },

--- a/ui/web/sa/managedobject/ApplicationModel.js
+++ b/ui/web/sa/managedobject/ApplicationModel.js
@@ -74,7 +74,7 @@ Ext.define("NOC.sa.managedobject.ApplicationModel", {
     {
       name: "fqdn",
       type: "string"
-    },    
+    },
     {
       name: "interface_count",
       type: "int",

--- a/ui/web/sa/managedobject/ApplicationModel.js
+++ b/ui/web/sa/managedobject/ApplicationModel.js
@@ -73,7 +73,7 @@ Ext.define("NOC.sa.managedobject.ApplicationModel", {
     },
     {
       name: "fqdn",
-      type: "string"
+      type: "string",
     },
     {
       name: "interface_count",


### PR DESCRIPTION
Includes backend model field, ExtJS data model declaration, and UI grid column (hidden by default — user can enable via column menu).