### PR TITLE
Batch MO resolution in map metrics api

### DIFF
--- a/services/web/apps/inv/map/views.py
+++ b/services/web/apps/inv/map/views.py
@@ -602,26 +602,31 @@ class MapApplication(ExtApplication):
         def qt(t):
             return "|".join(["%s=%s" % (v, t[v]) for v in sorted(t)])
 
+        # Filter misformated metrics
+        filtered_metrics = [
+            m
+            for m in metrics
+            if "tags" in m and m["tags"].get("object") and "interface" in m["tags"]
+        ]
+        if not filtered_metrics:
+            return {}
+        # Bulk resolve managed objects by name
+        # @todo: May break if mo name became non-unique
+        mo_names = [m["tags"]["object"] for m in filtered_metrics]
+        mo_map = {mo.name: mo for mo in ManagedObject.objects.filter(name__in=mo_names)}
+        if not mo_map:
+            return {}
         # Build query
         tag_id = {}  # object, interface -> id
         if_ids = {}  # id -> port id
         mlst = []  # (metric, object, interface)
-        for m in metrics:
-            if "object" in m["tags"] and "interface" in m["tags"]:
-                if not m["tags"]["object"]:
-                    continue
-                try:
-                    if_ids[
-                        self.interface_tags_to_id(m["tags"]["object"], m["tags"]["interface"])
-                    ] = m["id"]
-                    object = ManagedObject.objects.get(name=m["tags"]["object"])
-                    tag_id[object, m["tags"]["interface"]] = m["id"]
-                    mlst += [(m["metric"], object, m["tags"]["interface"])]
-                except KeyError:
-                    pass
-                # @todo: Get last values from cache
-        if not mlst:
-            return {}
+        for m in filtered_metrics:
+            object = mo_map.get(m["tags"]["object"])
+            if not object:
+                continue
+            if_ids[self.interface_tags_to_id(m["tags"]["object"], m["tags"]["interface"])] = m["id"]
+            tag_id[object, m["tags"]["interface"]] = m["id"]
+            mlst.append((m["metric"], object, m["tags"]["interface"]))
 
         r = {}
         # Apply interface statuses
@@ -632,7 +637,7 @@ class MapApplication(ExtApplication):
                 "admin_status": d.get("admin_status", True),
                 "oper_status": d.get("oper_status", True),
             }
-        metric_map, last_ts = get_interface_metrics([m[1] for m in mlst])
+        metric_map, _last_ts = get_interface_metrics([m[1] for m in mlst])
         # Apply metrics
         for rq_mo, rq_iface in tag_id:
             pid = tag_id.get((rq_mo, rq_iface))

--- a/services/web/apps/inv/map/views.py
+++ b/services/web/apps/inv/map/views.py
@@ -563,7 +563,17 @@ class MapApplication(ExtApplication):
 
     @classmethod
     @cachedmethod(key="managedobject-name-to-id-%s", lock=lambda _: tags_lock)
-    def managedobject_name_to_id(cls, name):
+    def managedobject_name_to_id(cls, name: str) -> int | None:
+        """
+        Get managed object's id by name.
+
+        Args:
+            name: Managed Object's name.
+
+        Returns:
+            ManagedObject id: if found.
+            None: otherwise.
+        """
         r = ManagedObject.objects.filter(name=name).values_list("id")
         if r:
             return r[0][0]
@@ -571,9 +581,22 @@ class MapApplication(ExtApplication):
 
     @classmethod
     @cachedmethod(key="interface-tags-to-id-%s-%s", lock=lambda _: tags_lock)
-    def interface_tags_to_id(cls, object_name, interface_name):
+    def interface_tags_to_id(cls, object_name: str, interface_name: str) -> ObjectId | None:
+        """
+        Get interface id.
+
+        Args:
+            object_name: Managed object name.
+            interface_name: Interface name.
+
+        Returns:
+            Interface id: if found.
+            None: if interface is not found.
+        """
         mo = cls.managedobject_name_to_id(object_name)
-        i = Interface._get_collection().find_one({"managed_object": mo, "name": interface_name})
+        i = Interface._get_collection().find_one(
+            {"managed_object": mo, "name": interface_name}, {"_id": 1}
+        )
         if i:
             return i["_id"]
         return None


### PR DESCRIPTION
Batch Managed Object resolution in /map/api/metrics endpoints
    
## What changed?
 
Optimized managed object lookup in services/web/apps/inv/map/views.py: replaced N+1 per-row ManagedObject.objects.get() calls with a single filter(name__in=...) batch query + dict lookup.
    
## Why?
Map metrics endpoint handles thousands of interface metric tags per request. Each tag previously triggered its own database query for the target ManagedObject. With the new approach, all unique MO names are fetched in one query and looked up from an in-memory dict. Significant I/O reduction on map/dashboard loads with 50+ interfaces.
    
 ## Changes
  - Added inline filtering to drop malformed metrics early (object or interface key missing)  
  - Batch-resolved targets via ManagedObject.objects.filter(name__in=...) and built mo_map dictionary  
  - Converted per-row DB lookups to dict .get() calls inside the loop 