### PR TITLE
discovery: MAC range sanity check in id discovery

### DIFF
--- a/config.py
+++ b/config.py
@@ -277,6 +277,7 @@ class Config(BaseConfig):
             default=True,
             help="Add service field to metric request",
         )
+        max_id_mac_range = IntParameter(default=0)
 
     class dns(ConfigSection):
         warn_before_expired = SecondsParameter(default="30d")

--- a/config.py
+++ b/config.py
@@ -278,6 +278,7 @@ class Config(BaseConfig):
             default=True,
             help="Add service field to metric request",
         )
+        max_id_mac_range = IntParameter(default=0)
 
     class dns(ConfigSection):
         warn_before_expired = SecondsParameter(default="30d")

--- a/config.py
+++ b/config.py
@@ -278,7 +278,7 @@ class Config(BaseConfig):
             default=True,
             help="Add service field to metric request",
         )
-        max_id_mac_range = IntParameter(default=0)
+        max_id_mac_range = IntParameter(default=0, min=0)
 
     class dns(ConfigSection):
         warn_before_expired = SecondsParameter(default="30d")

--- a/docs/config-reference/discovery.md
+++ b/docs/config-reference/discovery.md
@@ -19,3 +19,17 @@
 | YAML Path      | `discovery.sample`     |
 | Key-Value Path | `discovery/sample`     |
 | Environment    | `NOC_DISCOVERY_SAMPLE` |
+
+## max_id_mac_range
+
+Maximal allowed MAC range for id discovery. 
+
+* `0` - disable check (default)
+* `>0` - skip too broad ranges
+
+|                |                                  |
+| -------------- | -------------------------------- |
+| Default value  | `0`                              |
+| YAML Path      | `discovery.max_id_mac_range`     |
+| Key-Value Path | `discovery/max_id_mac_range`     |
+| Environment    | `NOC_DISCOVERY_MAX_ID_MAC_RANGE` |

--- a/services/discovery/jobs/box/id.py
+++ b/services/discovery/jobs/box/id.py
@@ -1,11 +1,13 @@
 # ---------------------------------------------------------------------
 # ID check
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2025 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
 # NOC modules
+from noc.config import config
+from noc.core.mac import MAC
 from noc.services.discovery.jobs.base import DiscoveryCheck
 from noc.inv.models.discoveryid import DiscoveryID, MACRange
 
@@ -22,21 +24,30 @@ class IDCheck(DiscoveryCheck):
         self.logger.info("Checking chassis id")
         result = self.object.scripts.get_discovery_id()
         cm = result.get("chassis_mac")
-        chassis_mac = (
-            [MACRange(first_mac=m["first_chassis_mac"], last_mac=m["last_chassis_mac"]) for m in cm]
-            if cm
-            else None
-        )
         interface_macs = self.get_artefact("interface_macs")
         self.logger.info(
             "Identity found: "
             "Chassis MACs = %s, hostname = %s, router-id = %s, "
             "additional MACs = %s",
-            ", ".join(str(r) for r in chassis_mac) if chassis_mac else "None",
+            self.format_range(cm),
             result.get("hostname"),
             result.get("router_id"),
             ", ".join(interface_macs or []),
         )
+        # Sanitize MAC ranges, may be too broad and consume large amount of memory
+        chassis_mac = []
+        if cm:
+            for item in cm:
+                try:
+                    chassis_mac.append(self.clean_range(item))
+                except ValueError as e:
+                    self.logger.error(
+                        "Invalid MAC range %s - %s: %s",
+                        item["first_chassis_mac"],
+                        item["last_chassis_mac"],
+                        e,
+                    )
+
         DiscoveryID.submit(
             object=self.object,
             chassis_mac=chassis_mac,
@@ -44,3 +55,31 @@ class IDCheck(DiscoveryCheck):
             router_id=result.get("router_id"),
             additional_macs=interface_macs,
         )
+
+    @staticmethod
+    def format_range(r: list[dict[str, str]] | None) -> str:
+        """Format MAC range for logging."""
+
+        def q(r: dict[str, str]) -> str:
+            return f"{r['first_chassis_mac']} - {r['last_chassis_mac']}"
+
+        if not r:
+            return "None"
+        return ", ".join(q(x) for x in r)
+
+    def clean_range(self, r: dict[str, str]) -> MACRange:
+        """
+        Sanitize MAC range.
+        """
+        s = MAC(r["first_chassis_mac"])
+        e = MAC(r["last_chassis_mac"])
+        if s > e:
+            s, e = e, s  # Swap
+        if not MAC.is_same_oui(s, e):
+            raise ValueError("not belongs to same OUI")
+        if config.discovery.max_id_mac_range > 0:
+            d = MAC.distance(s, e)
+            if d > config.discovery.max_id_mac_range:
+                msg = f"too broad range {d} macs (max {config.discovery.max_id_mac_range} allowed)"
+                raise ValueError(msg)
+        return MACRange(first_mac=str(s), last_mac=str(e))

--- a/services/discovery/jobs/box/id.py
+++ b/services/discovery/jobs/box/id.py
@@ -47,6 +47,8 @@ class IDCheck(DiscoveryCheck):
                         item["last_chassis_mac"],
                         e,
                     )
+            if not chassis_mac:
+                self.logger.warning("All MAC ranges failed, check get_discovery_id script")
 
         DiscoveryID.submit(
             object=self.object,

--- a/services/discovery/jobs/box/id.py
+++ b/services/discovery/jobs/box/id.py
@@ -48,7 +48,7 @@ class IDCheck(DiscoveryCheck):
                         e,
                     )
             if not chassis_mac:
-                self.logger.warning("All MAC ranges failed, check get_discovery_id script")
+                self.logger.error("All MAC ranges failed, check get_discovery_id script")
 
         DiscoveryID.submit(
             object=self.object,


### PR DESCRIPTION
During device discovery, scripts like get_discovery_id may return malformed or overly broad MAC ranges (e.g. 00:00:00:00:00:00 → ff:ff:ff:ff:ff:ff), which can expand to 16.7M individual MACs and either explode DB storage for DiscoveryID records or cause memory exhaustion on the discovery service side.
    
No defense was in place.
    
 ## Changes
    
- Add config validation for chassis MAC ranges returned by device scripts (get_discovery_id):

  - First/last swap to normalize reverse ranges (last > first)
   - OUI (vendor) boundary check — chassis MACs must belong to the same vendor block
  - Optional distance limit that rejects ranges exceeding a configured maximum number of MAC addresses
    
- Add config parameter discovery.max_id_mac_range (default 0 = disabled; set to positive integer to enforce).
- When all chassis MAC ranges fail validation, log a WARNING so the operator knows get_discovery_id is returning bad data and can fix the script.