### PR TITLE
Fix 'Profile check detail' report

### DIFF
--- a/collections/main.reports/Profile_Check_Detail.json
+++ b/collections/main.reports/Profile_Check_Detail.json
@@ -79,6 +79,30 @@
                 {
                     "name": "trouble_detail",
                     "title": "Error Detail"
+                },
+                {
+                    "name": "status",
+                    "title": "Status"
+                },
+                {
+                    "name": "enable_ping",
+                    "title": "Ping enable"
+                },
+                {
+                    "name": "enable_box",
+                    "title": "Box enable"
+                },
+                {
+                    "name": "trouble_snmp",
+                    "title": "SNMP Trouble"
+                },
+                {
+                    "name": "trouble_profile",
+                    "title": "Profile Trouble"
+                },
+                {
+                    "name": "trouble_cli",
+                    "title": "CLI Trouble"
                 }
             ],
             "title_template": "Not Availability"
@@ -117,6 +141,30 @@
                 {
                     "name": "trouble_detail",
                     "title": "Error Detail"
+                },
+                {
+                    "name": "status",
+                    "title": "Status"
+                },
+                {
+                    "name": "enable_ping",
+                    "title": "Ping enable"
+                },
+                {
+                    "name": "enable_box",
+                    "title": "Box enable"
+                },
+                {
+                    "name": "trouble_snmp",
+                    "title": "SNMP Trouble"
+                },
+                {
+                    "name": "trouble_profile",
+                    "title": "Profile Trouble"
+                },
+                {
+                    "name": "trouble_cli",
+                    "title": "CLI Trouble"
                 }
             ],
             "title_template": "CLI Errors"
@@ -155,6 +203,30 @@
                 {
                     "name": "trouble_detail",
                     "title": "Error Detail"
+                },
+                {
+                    "name": "status",
+                    "title": "Status"
+                },
+                {
+                    "name": "enable_ping",
+                    "title": "Ping enable"
+                },
+                {
+                    "name": "enable_box",
+                    "title": "Box enable"
+                },
+                {
+                    "name": "trouble_snmp",
+                    "title": "SNMP Trouble"
+                },
+                {
+                    "name": "trouble_profile",
+                    "title": "Profile Trouble"
+                },
+                {
+                    "name": "trouble_cli",
+                    "title": "CLI Trouble"
                 }
             ],
             "title_template": "SNMP Errors"


### PR DESCRIPTION
Exception raised:
unable to find column "status"; valid columns: ["managed_object_id", "name", "profile", "hostname", "address", "administrativedomain", "auth_profile", "avail", "trouble_detail"] Resolved plan until failure: ---> FAILED HERE RESOLVING 'select' <--- DF ["managed_object_id", "name", "profile", "hostname", ...]; PROJECT */9 COLUMNS
It is happenings because some fields ("status" and some others) used in queries, but not declared in bands.
The problem of internal fields.