### PR TITLE
Update BDCOM.xPON profile

### DIFF
--- a/sa/profiles/BDCOM/xPON/get_capabilities.py
+++ b/sa/profiles/BDCOM/xPON/get_capabilities.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
-# BDCOM.xPON.get_capabilities.ex
+# BDCOM.xPON.get_capabilities
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -15,18 +15,20 @@ class Script(BaseScript):
 
     @false_on_cli_error
     def has_lldp_cli(self):
-        """
-        Check box has lldp enabled
-        """
-        r = self.cli("show lldp interface")
+        #  Check box has lldp enabled
+        r = self.cli("show lldp neighbors")
         return "LLDP is not enabled" not in r
 
     @false_on_cli_error
     def has_stp_cli(self):
-        """
-        Check box has stp enabled
-        """
+        #  Check box has stp enabled
         r = self.cli("show spanning-tree")
         return not (
             "No spanning tree instance exists." in r or "No spanning tree instances exists." in r
         )
+
+    def execute_platform_cli(self, caps):
+        caps["Network | PON | OLT"] = True
+
+    def execute_platform_snmp(self, caps):
+        caps["Network | PON | OLT"] = True

--- a/sa/profiles/BDCOM/xPON/get_cpe.py
+++ b/sa/profiles/BDCOM/xPON/get_cpe.py
@@ -1,102 +1,327 @@
 # ---------------------------------------------------------------------
 # BDCOM.xPON.get_cpe
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2024 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
 # Python modules
 import re
+import time
 
 # NOC modules
 from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igetcpe import IGetCPE
 from noc.sa.interfaces.base import MACAddressParameter
+from noc.core.text import parse_table
+from noc.core.validators import is_int
+from noc.core.mac import MAC
 
 
 class Script(BaseScript):
     name = "BDCOM.xPON.get_cpe"
     interface = IGetCPE
+    TIMEOUT = 600
+    always_prefer = "S"
 
-    splitter = re.compile(r"\s*-+\n")
+    rx_gpon_image_iface = re.compile(
+        r"^Image information of (?P<pon_id>\S+):\s*\n",
+        re.MULTILINE,
+    )
+    rx_gpon_image_version = re.compile(
+        r"^\s+Image#\d+\s+(?P<version>\S+)\s+valid\s+active\s+committed",
+        re.MULTILINE,
+    )
+    rx_epon_sw_version = re.compile(
+        "^(?P<onu_id>EPON\d+/\d+:\d+)\s+(?P<version>\S+)\s*\n",
+        re.MULTILINE,
+    )
+    rx_onu_model_id = re.compile(r"^ONU MODEL ID\s+: (?P<model>\S{4})\s*\n", re.MULTILINE)
+    rx_onu_ext_id = re.compile(r"^ONU EXT MODEL ID\s+: (?P<ext_model>\S+)\s*\n", re.MULTILINE)
+    rx_onu_sw = re.compile(r"^Software Version\s+:\s+(?P<version>\S+)\s*\n", re.MULTILINE)
+    rx_onu_hw = re.compile(r"^Hardware Version\s+: (?P<revision>\S+)\s*\n", re.MULTILINE)
 
-    status_map = {
+    STATUS_MAP = {
         "auto-configured": "active",
-        "auto-configuring": "active",
+        "auto-configuring": "provisioning",
         "authenticated": "active",
-        "lost": "inactive",
-        "deregistered": "inactive",
+        "active": "active",
+    }
+    SNMP_STATUS_MAP = {
+        "0": "active",  # authenticated
+        "1": "active",  # registered
+        "2": "inactive",  # deregistered
+        "3": "active",  # auto_config
+        "4": "inactive",  # lost
+        "5": "other",  # standby
+    }
+    ONU_MAP = {
+        "BDCM":
+            {
+                "3024": "P1004B",
+                "3022": "P1501B",
+                "151C": "P1501С",
+                "1004": "P1004T",
+                "104C": "P1004C",
+                "1154": "GP1702-1Gv2",
+                "6014": "P1501DT",
+                "6032": "P1501DS",
+            },
+        "FORA":
+            {
+                "0311": "NA-1001B",
+                "101C": "NA-1001C",
+                "100D": "NA-1001D",
+            },
+        "FGXP":
+            {
+                "2001": "G2001R",
+            },
+        "GEAR":
+            {
+                "1004": "P1004T",
+            },
+        "MONU":
+            {
+                "H323": "RTKG",
+            },
+        "NGPN":
+            {
+                "NG02": "NGN-02E",
+            },
+        "PCTL":  # Picotel
+            {
+                "G100": "GE100",
+                "NG02": "GE100N",
+            },
+        "PICO":  # Picotel
+            {
+                "100N": "Ge-100N",
+            },
+        "SNR":
+            {
+                "SNR-ONU-EPON-1G-": "SNR-ONU-EPON-1G-mini",
+            },
+        "TPLK":
+            {
+                "110": "TL-EP110",
+            },
+        "ZTE":
+            {
+                "ONU-": "ONU-501",
+            },
     }
 
-    # EPON port can contain maximum 64 ONU
-    ifname_validator = re.compile(r"^EPON\d+/\d+:\d{1,2}$")
-    ifname_match = re.compile(r"^(?P<ifname>EPON\d+/\d+:\d{1,2})")
-    status_match = re.compile(
-        r"^(?P<status>auto-configured|auto-configuring|authenticated|lost|deregistered)"
-    )
-
-    def get_onu_status(self, raw_status):
-        m = self.status_match.match(raw_status)
-        if m:
-            status = m["status"]
-        else:
-            self.logger.info("Unknown ONU status '%s'. Fallback to oper_state 'down'", raw_status)
-            return "inactive"
-
-        return self.status_map[status]
-
-    def get_onu_local_id(self, raw_id):
-        m = self.ifname_match.match(raw_id)
-        if m:
-            ifname = m["ifname"]
-        else:
-            self.logger.info("Unknown ONU ifname '%s'. Return raw value", raw_id)
-            return raw_id
-
-        return ifname
+    def get_onu_model(self, vendor, model):
+        if vendor in self.ONU_MAP:
+            return self.ONU_MAP.get(vendor).get(model, model)
+        return model
 
     def execute_cli(self, **kwargs):
-        r = []
-        v = self.cli("show epon onu-information")
-        for table in v.split("\n\n"):
-            parts = self.splitter.split(table)
-            for p in parts[1:]:
-                for onu in p.split("\n"):
-                    line = onu.split()
-                    if len(line) >= 8 or self.ifname_validator.match(line[0]):
-                        onu_id = line[0]
-                        onu_vendor = line[1]
-                        onu_model = line[2]
-                        onu_mac = MACAddressParameter().clean(line[3])
-                        onu_status = self.get_onu_status(line[6])
-                    else:
-                        # Sometimes first fields overlaps on some firmware version
-                        # IntfName   VendorID  ModelID    MAC Address    Description                     BindType  Status          Dereg Reason
-                        # ---------- --------- ---------- -------------- ------------------------------- --------- --------------- -----------------
-                        # EPON0/13:9 VSOL      D401       006d.61d4.6bf8 N/A                             static    auto-configured N/A
-                        # EPON0/13:10xPON      101Z       e0e8.e61f.0759 N/A                             static    auto-configured N/A
-                        #
-                        # Or last fields
-                        # EPON0/3:38 VSOL      D401      006d.61d3.ee10 N/A             static    auto-configuringN/A
+        r = {}
+        if self.is_gpon:
+            v = self.cli("show gpon onu-information", cached=True)
+            for i in parse_table(v):
+                onu = {
+                    "id": i[0],
+                    "global_id": i[3],
+                    "serial": i[3],
+                    "type": "ont",
+                    "interface": i[0],
+                }
+                onu["vendor"] = i[1]
+                if i[2] != "N/A":
+                    onu["model"] = self.get_onu_model(i[1], i[2])
+                onu_status = i[5]
+                onu["status"] = self.STATUS_MAP.get(onu_status, "inactive")
+                r[onu["id"]] = dict(onu)
+            v = self.cli("show gpon active-onu")
+            for ifaces in re.split("Interface GPON\d+/\d+ has bound \d+ active ONUs:\n", v):
+                for i in parse_table(v):
+                    r[i[0]]["distance"] = int(float(i[5]))
+            v = self.cli("show gpon onu-description")
+            for ifaces in v.split("\n\n"):
+                for i in parse_table(v):
+                    if i[1] == "N/A":
+                        continue
+                    r[i[0]]["description"] = i[1]
+            v = self.cli("show gpon onu-image-information")
+            for i in v.split("\n\n"):
+                onu_id = self.rx_gpon_image_iface.search(i)
+                version = self.rx_gpon_image_version.search(i)
+                if onu_id is None or version is None:
+                    continue
+                r[onu_id.group("pon_id")]["version"] = version.group("version")
+        else:
+            v = self.cli("show epon onu-information", cached=True)
+            for i in parse_table(v):
+                onu = {
+                    "id": i[0],
+                    "global_id": i[3],
+                    "type": "ont",
+                    "interface": i[0],
+                }
+                if i[1] != "----":
+                    onu["vendor"] = i[1]
+                    if "/" in i[2]:
+                        i[2] = i[2].split("/")[1]
+                    onu["model"] = self.get_onu_model(i[1], i[2])
+                if i[4] != "N/A":
+                    onu["description"] = i[4]
+                onu_status = i[6]
+                onu["status"] = self.STATUS_MAP.get(onu_status, "inactive")
+                r[onu["id"]] = dict(onu)
+            v = self.cli("show epon active-onu")
+            for ifaces in re.split("Interface EPON\d+/\d+ has bound \d+ ONUs auto-configured:\n", v):
+                for i in parse_table(v):
+                    if is_int(i[4]):
+                        r[i[0]]["distance"] = i[4]
+            v = self.cli("show epon onu-software-version")
+            for ifaces in v.split("auto-configured:\n"):
+                for i in parse_table(v):
+                    if i[0].startswith("EPON"):
+                        r[i[0]]["version"] = i[1]
 
-                        onu_id = self.get_onu_local_id(line[0])
-                        onu_vendor = line[0].replace(onu_id, "")
-                        onu_model = line[1]
-                        onu_mac = MACAddressParameter().clean(line[2])
-                        onu_status = self.get_onu_status(line[5])
+        return sorted(r.values(), key=lambda x: x["id"])
 
-                    r.append(
-                        {
-                            "vendor": onu_vendor,
-                            "model": onu_model,
-                            "mac": onu_mac,
-                            "status": onu_status,
-                            "id": onu_id,
-                            "global_id": onu_mac,
-                            "type": "ont",
-                            "serial": onu_mac,
-                            "description": "",
-                        }
-                    )
-
-        return r
+    def execute_snmp(self, **kwargs):
+        r = {}
+        if self.is_gpon:
+            # NMS-GPON-MIB::onuSerialNum
+            for oid, value in self.snmp.getnext("1.3.6.1.4.1.3320.10.3.1.1.4"):
+                ifindex = int(oid.split(".")[-1])
+                r[ifindex] = {
+                    "global_id": value,
+                    "serial": value,
+                    "type": "ont",
+                }
+            # IF-MIB::ifDescr
+            for oid, value in self.snmp.getnext("1.3.6.1.2.1.2.2.1.2"):
+                ifindex = int(oid.split(".")[-1])
+                if ifindex in r:
+                    r[ifindex]["id"] = value
+                    r[ifindex]["interface"] = value
+            # NMS-GPON-MIB::onuVendorID
+            for oid, value in self.snmp.getnext("1.3.6.1.4.1.3320.10.3.1.1.2"):
+                ifindex = int(oid.split(".")[-1])
+                if ifindex in r:
+                    if value != "":
+                        r[ifindex]["vendor"] = value
+                    else:  # hack for deregistered ONU
+                        r[ifindex]["vendor"] = r[ifindex]["global_id"].split(".")[-1]
+            # NMS-GPON-MIB::onuVersion
+            for oid, value in self.snmp.getnext("1.3.6.1.4.1.3320.10.3.1.1.3"):
+                ifindex = int(oid.split(".")[-1])
+                value = value.rstrip().rstrip("\x00")
+                if ifindex in r and value != "":
+                    r[ifindex]["revision"] = value
+            # NMS-GPON-MIB::onuOperationalState - enable(1), disable(2)
+            for oid, value in self.snmp.getnext("1.3.6.1.4.1.3320.10.3.1.1.8"):
+                ifindex = int(oid.split(".")[-1])
+                value = int(value)
+                if ifindex in r:
+                    r[ifindex]["status"] = "active" if value == 1 else "inactive"
+            # NMS-GPON-MIB::onuEquipmentID
+            for oid, value in self.snmp.getnext("1.3.6.1.4.1.3320.10.3.1.1.9"):
+                ifindex = int(oid.split(".")[-1])
+                if ifindex in r and value != "":
+                    r[ifindex]["model"] = value
+            # NMS-GPON-MIB::onuImageInstance0Version ...
+            for ifindex, value, valid, active, commited in self.snmp.get_tables(
+                [
+                    "1.3.6.1.4.1.3320.10.3.1.1.20",
+                    "1.3.6.1.4.1.3320.10.3.1.1.21",
+                    "1.3.6.1.4.1.3320.10.3.1.1.22",
+                    "1.3.6.1.4.1.3320.10.3.1.1.23",
+                ]
+            ):
+                ifindex = int(ifindex)
+                value = value.rstrip().rstrip("\x00")
+                if (
+                    ifindex in r and value != "" and int(valid) == 1
+                    and int(active) == 1 and int(commited) == 1
+                ):
+                    r[ifindex]["version"] = value
+            # NMS-GPON-MIB::onuImageInstance1Version ...
+            for ifindex, value, valid, active, commited in self.snmp.get_tables(
+                [
+                    "1.3.6.1.4.1.3320.10.3.1.1.24",
+                    "1.3.6.1.4.1.3320.10.3.1.1.25",
+                    "1.3.6.1.4.1.3320.10.3.1.1.26",
+                    "1.3.6.1.4.1.3320.10.3.1.1.27",
+                ]
+            ):
+                ifindex = int(ifindex)
+                value = value.rstrip().rstrip("\x00")
+                if (
+                    ifindex in r and value != "" and int(valid) == 1
+                     and int(active) == 1 and int(commited) == 1
+                ):
+                    r[ifindex]["version"] = value
+            # NMS-EPON-MIB::onuDistance
+            for oid, value in self.snmp.getnext("1.3.6.1.4.1.3320.10.3.1.1.33"):
+                ifindex = int(oid.split(".")[-1])
+                value = int(value)
+                if ifindex in r and value != 0:
+                    r[ifindex]["distance"] = value // 10
+        else:
+            # NMS-EPON-MIB::onuID
+            for oid, value in self.snmp.getnext("1.3.6.1.4.1.3320.101.10.1.1.3"):
+                ifindex = int(oid.split(".")[-1])
+                r[ifindex] = {
+                    "global_id": MAC(value),
+                    "mac": MAC(value),
+                    "type": "ont",
+                }
+            # IF-MIB::ifDescr
+            for oid, value in self.snmp.getnext("1.3.6.1.2.1.2.2.1.2"):
+                ifindex = int(oid.split(".")[-1])
+                ifnames[ifindex] = value  # ???
+                if ifindex in r:
+                    r[ifindex]["id"] = value
+                    r[ifindex]["interface"] = value
+            # NMS-EPON-MIB::onuVendorID
+            for oid, value in self.snmp.getnext("1.3.6.1.4.1.3320.101.10.1.1.1"):
+                ifindex = int(oid.split(".")[-1])
+                if ifindex in r and value != "----":
+                    r[ifindex]["vendor"] = value
+            # NMS-EPON-MIB::onuModuleID
+            for oid, value in self.snmp.getnext("1.3.6.1.4.1.3320.101.10.1.1.2"):
+                ifindex = int(oid.split(".")[-1])
+                if ifindex in r and value != "----":
+                    value = self.get_onu_model(r[ifindex]["vendor"], value)
+                    r[ifindex]["model"] = value
+            # NMS-EPON-MIB::onuHardwareVersion
+            for oid, value in self.snmp.getnext("1.3.6.1.4.1.3320.101.10.1.1.4"):
+                ifindex = int(oid.split(".")[-1])
+                value = value.rstrip("\x00")
+                if ifindex in r and value != "":
+                    r[ifindex]["revision"] = value
+            # NMS-EPON-MIB::onuSoftwareVersion
+            for oid, value in self.snmp.getnext("1.3.6.1.4.1.3320.101.10.1.1.5"):
+                ifindex = int(oid.split(".")[-1])
+                value = value.rstrip("\x00")
+                if ifindex in r and value != "":
+                    r[ifindex]["version"] = value
+            # NMS-EPON-MIB::onuStatus
+            for oid, value in self.snmp.getnext("1.3.6.1.4.1.3320.101.10.1.1.26"):
+                ifindex = int(oid.split(".")[-1])
+                value = int(value)
+                if ifindex in r:
+                    r[ifindex]["status"] = self.STATUS_MAP.get(value, "inactive")
+            # NMS-EPON-MIB::onuDistance
+            for oid, value in self.snmp.getnext("1.3.6.1.4.1.3320.101.10.1.1.27"):
+                ifindex = int(oid.split(".")[-1])
+                value = int(value)
+                if ifindex in r and value != 0:
+                    r[ifindex]["distance"] = value
+            # NMS-EPON-MIB::onuExtModelID
+            try:
+                for oid, value in self.snmp.getnext("1.3.6.1.4.1.3320.101.10.1.1.85"):
+                    ifindex = int(oid.split(".")[-1])
+                    if ifindex in r and value != "":
+                        value = self.get_onu_model(r[ifindex]["vendor"], value)
+                        r[ifindex]["model"] = value
+            except:
+                pass
+        return list(r.values())

--- a/sa/profiles/BDCOM/xPON/get_cpe.py
+++ b/sa/profiles/BDCOM/xPON/get_cpe.py
@@ -90,13 +90,13 @@ class Script(BaseScript):
         "PICO": {  # Picotel
             "100N": "Ge-100N",
         },
-        "SNR":  {
+        "SNR": {
             "SNR-ONU-EPON-1G-": "SNR-ONU-EPON-1G-mini",
         },
         "TPLK": {
             "110": "TL-EP110",
         },
-        "ZTE":  {
+        "ZTE": {
             "ONU-": "ONU-501",
         },
     }
@@ -125,9 +125,7 @@ class Script(BaseScript):
                 onu["status"] = self.STATUS_MAP.get(onu_status, "inactive")
                 r[onu["id"]] = dict(onu)
             v = self.cli("show gpon active-onu")
-            for ifaces in re.split(
-                "Interface GPON\d+/\d+ has bound \d+ active ONUs:\n", v
-            ):
+            for ifaces in re.split("Interface GPON\d+/\d+ has bound \d+ active ONUs:\n", v):
                 for i in parse_table(v):
                     r[i[0]]["distance"] = int(float(i[5]))
             v = self.cli("show gpon onu-description")
@@ -163,7 +161,9 @@ class Script(BaseScript):
                 onu["status"] = self.STATUS_MAP.get(onu_status, "inactive")
                 r[onu["id"]] = dict(onu)
             v = self.cli("show epon active-onu")
-            for ifaces in re.split("Interface EPON\d+/\d+ has bound \d+ ONUs auto-configured:\n", v):
+            for ifaces in re.split(
+                "Interface EPON\d+/\d+ has bound \d+ ONUs auto-configured:\n", v
+            ):
                 for i in parse_table(v):
                     if is_int(i[4]):
                         r[i[0]]["distance"] = i[4]

--- a/sa/profiles/BDCOM/xPON/get_cpe.py
+++ b/sa/profiles/BDCOM/xPON/get_cpe.py
@@ -7,12 +7,10 @@
 
 # Python modules
 import re
-import time
 
 # NOC modules
 from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igetcpe import IGetCPE
-from noc.sa.interfaces.base import MACAddressParameter
 from noc.core.text import parse_table
 from noc.core.validators import is_int
 from noc.core.mac import MAC
@@ -33,7 +31,7 @@ class Script(BaseScript):
         re.MULTILINE,
     )
     rx_epon_sw_version = re.compile(
-        "^(?P<onu_id>EPON\d+/\d+:\d+)\s+(?P<version>\S+)\s*\n",
+        r"^(?P<onu_id>EPON\d+/\d+:\d+)\s+(?P<version>\S+)\s*\n",
         re.MULTILINE,
     )
     rx_onu_model_id = re.compile(r"^ONU MODEL ID\s+: (?P<model>\S{4})\s*\n", re.MULTILINE)
@@ -125,7 +123,7 @@ class Script(BaseScript):
                 onu["status"] = self.STATUS_MAP.get(onu_status, "inactive")
                 r[onu["id"]] = dict(onu)
             v = self.cli("show gpon active-onu")
-            for ifaces in re.split("Interface GPON\d+/\d+ has bound \d+ active ONUs:\n", v):
+            for ifaces in re.split(r"Interface GPON\d+/\d+ has bound \d+ active ONUs:\n", v):
                 for i in parse_table(v):
                     r[i[0]]["distance"] = int(float(i[5]))
             v = self.cli("show gpon onu-description")
@@ -162,7 +160,7 @@ class Script(BaseScript):
                 r[onu["id"]] = dict(onu)
             v = self.cli("show epon active-onu")
             for ifaces in re.split(
-                "Interface EPON\d+/\d+ has bound \d+ ONUs auto-configured:\n", v
+                r"Interface EPON\d+/\d+ has bound \d+ ONUs auto-configured:\n", v
             ):
                 for i in parse_table(v):
                     if is_int(i[4]):
@@ -273,7 +271,6 @@ class Script(BaseScript):
             # IF-MIB::ifDescr
             for oid, value in self.snmp.getnext("1.3.6.1.2.1.2.2.1.2"):
                 ifindex = int(oid.split(".")[-1])
-                ifnames[ifindex] = value  # ???
                 if ifindex in r:
                     r[ifindex]["id"] = value
                     r[ifindex]["interface"] = value

--- a/sa/profiles/BDCOM/xPON/get_cpe.py
+++ b/sa/profiles/BDCOM/xPON/get_cpe.py
@@ -56,60 +56,49 @@ class Script(BaseScript):
         "5": "other",  # standby
     }
     ONU_MAP = {
-        "BDCM":
-            {
-                "3024": "P1004B",
-                "3022": "P1501B",
-                "151C": "P1501С",
-                "1004": "P1004T",
-                "104C": "P1004C",
-                "1154": "GP1702-1Gv2",
-                "6014": "P1501DT",
-                "6032": "P1501DS",
-            },
-        "FORA":
-            {
-                "0311": "NA-1001B",
-                "101C": "NA-1001C",
-                "100D": "NA-1001D",
-            },
-        "FGXP":
-            {
-                "2001": "G2001R",
-            },
-        "GEAR":
-            {
-                "1004": "P1004T",
-            },
-        "MONU":
-            {
-                "H323": "RTKG",
-            },
-        "NGPN":
-            {
-                "NG02": "NGN-02E",
-            },
-        "PCTL":  # Picotel
-            {
-                "G100": "GE100",
-                "NG02": "GE100N",
-            },
-        "PICO":  # Picotel
-            {
-                "100N": "Ge-100N",
-            },
-        "SNR":
-            {
-                "SNR-ONU-EPON-1G-": "SNR-ONU-EPON-1G-mini",
-            },
-        "TPLK":
-            {
-                "110": "TL-EP110",
-            },
-        "ZTE":
-            {
-                "ONU-": "ONU-501",
-            },
+        "BDCM": {
+            "3024": "P1004B",
+            "3022": "P1501B",
+            "151C": "P1501С",
+            "1004": "P1004T",
+            "104C": "P1004C",
+            "1154": "GP1702-1Gv2",
+            "6014": "P1501DT",
+            "6032": "P1501DS",
+        },
+        "FORA": {
+            "0311": "NA-1001B",
+            "101C": "NA-1001C",
+            "100D": "NA-1001D",
+        },
+        "FGXP": {
+            "2001": "G2001R",
+        },
+        "GEAR": {
+            "1004": "P1004T",
+        },
+        "MONU": {
+            "H323": "RTKG",
+        },
+        "NGPN": {
+            "NG02": "NGN-02E",
+        },
+        "PCTL": {  # Picotel
+            "G100": "GE100",
+            "NG02": "GE100N",
+        },
+        "PICO": {  # Picotel
+            "100N": "Ge-100N",
+        },
+        "SNR":  {
+            "SNR-ONU-EPON-1G-": "SNR-ONU-EPON-1G-mini",
+        },
+        "TPLK": {
+            "110": "TL-EP110",
+        },
+        "ZTE":  {
+            "ONU-": "ONU-501",
+        },
     }
 
     def get_onu_model(self, vendor, model):
@@ -136,7 +125,9 @@ class Script(BaseScript):
                 onu["status"] = self.STATUS_MAP.get(onu_status, "inactive")
                 r[onu["id"]] = dict(onu)
             v = self.cli("show gpon active-onu")
-            for ifaces in re.split("Interface GPON\d+/\d+ has bound \d+ active ONUs:\n", v):
+            for ifaces in re.split(
+                "Interface GPON\d+/\d+ has bound \d+ active ONUs:\n", v
+            ):
                 for i in parse_table(v):
                     r[i[0]]["distance"] = int(float(i[5]))
             v = self.cli("show gpon onu-description")
@@ -238,8 +229,11 @@ class Script(BaseScript):
                 ifindex = int(ifindex)
                 value = value.rstrip().rstrip("\x00")
                 if (
-                    ifindex in r and value != "" and int(valid) == 1
-                    and int(active) == 1 and int(commited) == 1
+                    ifindex in r
+                    and value != ""
+                    and int(valid) == 1
+                    and int(active) == 1
+                    and int(commited) == 1
                 ):
                     r[ifindex]["version"] = value
             # NMS-GPON-MIB::onuImageInstance1Version ...
@@ -254,8 +248,11 @@ class Script(BaseScript):
                 ifindex = int(ifindex)
                 value = value.rstrip().rstrip("\x00")
                 if (
-                    ifindex in r and value != "" and int(valid) == 1
-                     and int(active) == 1 and int(commited) == 1
+                    ifindex in r
+                    and value != ""
+                    and int(valid) == 1
+                    and int(active) == 1
+                    and int(commited) == 1
                 ):
                     r[ifindex]["version"] = value
             # NMS-EPON-MIB::onuDistance

--- a/sa/profiles/BDCOM/xPON/get_cpe.py
+++ b/sa/profiles/BDCOM/xPON/get_cpe.py
@@ -304,11 +304,7 @@ class Script(BaseScript):
             # NMS-EPON-MIB::onuExtModelID
             for oid, value in self.snmp.getnext("1.3.6.1.4.1.3320.101.10.1.1.85"):
                 ifindex = int(oid.split(".")[-1])
-                if (
-                    ifindex in r
-                    and r[ifindex].get("vendor") is not None 
-                    and value != ""
-                ):
+                if ifindex in r and r[ifindex].get("vendor") is not None and value != "":
                     value = self.get_onu_model(r[ifindex]["vendor"], value)
                     r[ifindex]["model"] = value
         return list(r.values())

--- a/sa/profiles/BDCOM/xPON/get_cpe.py
+++ b/sa/profiles/BDCOM/xPON/get_cpe.py
@@ -302,12 +302,13 @@ class Script(BaseScript):
                 if ifindex in r and value != 0:
                     r[ifindex]["distance"] = value
             # NMS-EPON-MIB::onuExtModelID
-            try:
-                for oid, value in self.snmp.getnext("1.3.6.1.4.1.3320.101.10.1.1.85"):
-                    ifindex = int(oid.split(".")[-1])
-                    if ifindex in r and value != "":
-                        value = self.get_onu_model(r[ifindex]["vendor"], value)
-                        r[ifindex]["model"] = value
-            except:
-                pass
+            for oid, value in self.snmp.getnext("1.3.6.1.4.1.3320.101.10.1.1.85"):
+                ifindex = int(oid.split(".")[-1])
+                if (
+                    ifindex in r
+                    and r[ifindex].get("vendor") is not None 
+                    and value != ""
+                ):
+                    value = self.get_onu_model(r[ifindex]["vendor"], value)
+                    r[ifindex]["model"] = value
         return list(r.values())

--- a/sa/profiles/BDCOM/xPON/get_cpe.py
+++ b/sa/profiles/BDCOM/xPON/get_cpe.py
@@ -39,7 +39,7 @@ class Script(BaseScript):
     rx_onu_sw = re.compile(r"^Software Version\s+:\s+(?P<version>\S+)\s*\n", re.MULTILINE)
     rx_onu_hw = re.compile(r"^Hardware Version\s+: (?P<revision>\S+)\s*\n", re.MULTILINE)
 
-    STATUS_MAP = {
+    CLI_STATUS_MAP = {
         "auto-configured": "active",
         "auto-configuring": "provisioning",
         "authenticated": "active",
@@ -57,7 +57,7 @@ class Script(BaseScript):
         "BDCM": {
             "3024": "P1004B",
             "3022": "P1501B",
-            "151C": "P1501С",
+            "151C": "P1501C",
             "1004": "P1004T",
             "104C": "P1004C",
             "1154": "GP1702-1Gv2",
@@ -119,19 +119,16 @@ class Script(BaseScript):
                 onu["vendor"] = i[1]
                 if i[2] != "N/A":
                     onu["model"] = self.get_onu_model(i[1], i[2])
-                onu_status = i[5]
-                onu["status"] = self.STATUS_MAP.get(onu_status, "inactive")
+                onu["status"] = self.CLI_STATUS_MAP.get(i[5], "inactive")
                 r[onu["id"]] = dict(onu)
             v = self.cli("show gpon active-onu")
-            for ifaces in re.split(r"Interface GPON\d+/\d+ has bound \d+ active ONUs:\n", v):
-                for i in parse_table(v):
-                    r[i[0]]["distance"] = int(float(i[5]))
+            for i in parse_table(v):
+                r[i[0]]["distance"] = int(float(i[5]))
             v = self.cli("show gpon onu-description")
-            for ifaces in v.split("\n\n"):
-                for i in parse_table(v):
-                    if i[1] == "N/A":
-                        continue
-                    r[i[0]]["description"] = i[1]
+            for i in parse_table(v):
+                if i[1] == "N/A":
+                    continue
+                r[i[0]]["description"] = i[1]
             v = self.cli("show gpon onu-image-information")
             for i in v.split("\n\n"):
                 onu_id = self.rx_gpon_image_iface.search(i)
@@ -155,21 +152,16 @@ class Script(BaseScript):
                     onu["model"] = self.get_onu_model(i[1], i[2])
                 if i[4] != "N/A":
                     onu["description"] = i[4]
-                onu_status = i[6]
-                onu["status"] = self.STATUS_MAP.get(onu_status, "inactive")
+                onu["status"] = self.CLI_STATUS_MAP.get(i[6], "inactive")
                 r[onu["id"]] = dict(onu)
             v = self.cli("show epon active-onu")
-            for ifaces in re.split(
-                r"Interface EPON\d+/\d+ has bound \d+ ONUs auto-configured:\n", v
-            ):
-                for i in parse_table(v):
-                    if is_int(i[4]):
-                        r[i[0]]["distance"] = i[4]
+            for i in parse_table(v):
+                if is_int(i[4]):
+                    r[i[0]]["distance"] = i[4]
             v = self.cli("show epon onu-software-version")
-            for ifaces in v.split("auto-configured:\n"):
-                for i in parse_table(v):
-                    if i[0].startswith("EPON"):
-                        r[i[0]]["version"] = i[1]
+            for i in parse_table(v):
+                if i[0].startswith("EPON"):
+                    r[i[0]]["version"] = i[1]
 
         return sorted(r.values(), key=lambda x: x["id"])
 
@@ -302,7 +294,7 @@ class Script(BaseScript):
                 ifindex = int(oid.split(".")[-1])
                 value = int(value)
                 if ifindex in r:
-                    r[ifindex]["status"] = self.STATUS_MAP.get(value, "inactive")
+                    r[ifindex]["status"] = self.SNMP_STATUS_MAP.get(value, "inactive")
             # NMS-EPON-MIB::onuDistance
             for oid, value in self.snmp.getnext("1.3.6.1.4.1.3320.101.10.1.1.27"):
                 ifindex = int(oid.split(".")[-1])

--- a/sa/profiles/BDCOM/xPON/get_cpe_status.py
+++ b/sa/profiles/BDCOM/xPON/get_cpe_status.py
@@ -31,7 +31,9 @@ class Script(BaseScript):
             # NMS-GPON-MIB::onuSerialNum
             for oid, value in self.snmp.getnext("1.3.6.1.4.1.3320.10.3.1.1.4"):
                 ifindex = int(oid.split(".")[-1])
-                r[ifindex] = { "global_id": value, }
+                r[ifindex] = {
+                    "global_id": value,
+                }
             # IF-MIB::ifDescr
             for oid, value in self.snmp.getnext("1.3.6.1.2.1.2.2.1.2"):
                 ifindex = int(oid.split(".")[-1])
@@ -48,7 +50,9 @@ class Script(BaseScript):
             # NMS-EPON-MIB::onuID
             for oid, value in self.snmp.getnext("1.3.6.1.4.1.3320.101.10.1.1.3"):
                 ifindex = int(oid.split(".")[-1])
-                r[ifindex] = { "global_id": MAC(value), }
+                r[ifindex] = {
+                    "global_id": MAC(value),
+                }
             # IF-MIB::ifDescr
             for oid, value in self.snmp.getnext("1.3.6.1.2.1.2.2.1.2"):
                 ifindex = int(oid.split(".")[-1])

--- a/sa/profiles/BDCOM/xPON/get_cpe_status.py
+++ b/sa/profiles/BDCOM/xPON/get_cpe_status.py
@@ -1,92 +1,65 @@
 # ---------------------------------------------------------------------
 # BDCOM.xPON.get_cpe_status
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2024 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
-
-# Python modules
-import re
 
 # NOC modules
 from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igetcpestatus import IGetCPEStatus
-from noc.sa.interfaces.base import MACAddressParameter
+from noc.core.mac import MAC
 
 
 class Script(BaseScript):
     name = "BDCOM.xPON.get_cpe_status"
     interface = IGetCPEStatus
+    always_prefer = "S"
 
-    cache = True
-    splitter = re.compile(r"\s*-+\n")
-
-    status_map = {
-        "auto-configured": True,
-        "auto-configuring": True,
-        "authenticated": True,
-        "lost": False,
-        "deregistered": False,
+    SNMP_STATUS_MAP = {
+        0: True,  # authenticated
+        1: True,  # registered
+        2: False,  # deregistered
+        3: True,  # auto_config
+        4: False,  # lost
+        5: True,  # standby
     }
 
-    # EPON port can contain maximum 64 ONU
-    ifname_validator = re.compile(r"^EPON\d+/\d+:\d{1,2}$")
-    ifname_match = re.compile(r"^(?P<ifname>EPON\d+/\d+:\d{1,2})")
-    status_match = re.compile(
-        r"^(?P<status>auto-configured|auto-configuring|authenticated|lost|deregistered)"
-    )
-
-    def get_onu_status(self, raw_status):
-        m = self.status_match.match(raw_status)
-        if m:
-            status = m["status"]
+    def execute_snmp(self, **kwargs):
+        r = {}
+        if self.is_gpon:
+            # NMS-GPON-MIB::onuSerialNum
+            for oid, value in self.snmp.getnext("1.3.6.1.4.1.3320.10.3.1.1.4"):
+                ifindex = int(oid.split(".")[-1])
+                r[ifindex] = { "global_id": value, }
+            # IF-MIB::ifDescr
+            for oid, value in self.snmp.getnext("1.3.6.1.2.1.2.2.1.2"):
+                ifindex = int(oid.split(".")[-1])
+                if ifindex in r:
+                    r[ifindex]["local_id"] = value
+                    r[ifindex]["interface"] = value
+            # NMS-GPON-MIB::onuOperationalState - enable(1), disable(2)
+            for oid, value in self.snmp.getnext("1.3.6.1.4.1.3320.10.3.1.1.8"):
+                ifindex = int(oid.split(".")[-1])
+                value = int(value)
+                if ifindex in r:
+                    r[ifindex]["oper_status"] = True if value == 1 else False
         else:
-            self.logger.info("Unknown ONU status '%s'. Fallback to oper_state 'down'", raw_status)
-            return False
+            # NMS-EPON-MIB::onuID
+            for oid, value in self.snmp.getnext("1.3.6.1.4.1.3320.101.10.1.1.3"):
+                ifindex = int(oid.split(".")[-1])
+                r[ifindex] = { "global_id": MAC(value), }
+            # IF-MIB::ifDescr
+            for oid, value in self.snmp.getnext("1.3.6.1.2.1.2.2.1.2"):
+                ifindex = int(oid.split(".")[-1])
+                if ifindex in r:
+                    r[ifindex]["local_id"] = value
+                    r[ifindex]["interface"] = value
+            # NMS-EPON-MIB::onuStatus
+            for oid, value in self.snmp.getnext("1.3.6.1.4.1.3320.101.10.1.1.26"):
+                ifindex = int(oid.split(".")[-1])
+                value = int(value)
+                if ifindex in r:
+                    r[ifindex]["oper_status"] = self.SNMP_STATUS_MAP.get(value, False)
 
-        return self.status_map[status]
-
-    def get_onu_local_id(self, raw_id):
-        m = self.ifname_match.match(raw_id)
-        if m:
-            ifname = m["ifname"]
-        else:
-            self.logger.info("Unknown ONU ifname '%s'. Return raw value", raw_id)
-            return raw_id
-
-        return ifname
-
-    def execute_cli(self, **kwargs):
-        r = []
-        v = self.cli("show epon onu-information")
-        for table in v.split("\n\n"):
-            parts = self.splitter.split(table)
-            for p in parts[1:]:
-                for onu in p.split("\n"):
-                    line = onu.split()
-                    if len(line) >= 8 or self.ifname_validator.match(line[0]):
-                        onu_id = line[0]
-                        onu_mac = MACAddressParameter().clean(line[3])
-                        onu_status = self.get_onu_status(line[6])
-                    else:
-                        # Sometimes first fields overlaps on some firmware version
-                        # IntfName   VendorID  ModelID    MAC Address    Description                     BindType  Status          Dereg Reason
-                        # ---------- --------- ---------- -------------- ------------------------------- --------- --------------- -----------------
-                        # EPON0/13:9 VSOL      D401       006d.61d4.6bf8 N/A                             static    auto-configured N/A
-                        # EPON0/13:10xPON      101Z       e0e8.e61f.0759 N/A                             static    auto-configured N/A
-                        #
-                        # Or last fields
-                        # EPON0/3:38 VSOL      D401      006d.61d3.ee10 N/A             static    auto-configuringN/A
-
-                        onu_id = self.get_onu_local_id(line[0])
-                        onu_mac = MACAddressParameter().clean(line[2])
-                        onu_status = self.get_onu_status(line[5])
-
-                    r.append(
-                        {
-                            "oper_status": onu_status,
-                            "local_id": onu_id,
-                            "global_id": onu_mac,
-                        }
-                    )
-        return r
+        return list(r.values())

--- a/sa/profiles/BDCOM/xPON/get_cpe_status.py
+++ b/sa/profiles/BDCOM/xPON/get_cpe_status.py
@@ -45,7 +45,7 @@ class Script(BaseScript):
                 ifindex = int(oid.split(".")[-1])
                 value = int(value)
                 if ifindex in r:
-                    r[ifindex]["oper_status"] = True if value == 1 else False
+                    r[ifindex]["oper_status"] = value == 1
         else:
             # NMS-EPON-MIB::onuID
             for oid, value in self.snmp.getnext("1.3.6.1.4.1.3320.101.10.1.1.3"):

--- a/sa/profiles/BDCOM/xPON/get_cpe_status.py
+++ b/sa/profiles/BDCOM/xPON/get_cpe_status.py
@@ -8,6 +8,7 @@
 # NOC modules
 from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igetcpestatus import IGetCPEStatus
+from noc.core.text import parse_table
 from noc.core.mac import MAC
 
 
@@ -16,6 +17,12 @@ class Script(BaseScript):
     interface = IGetCPEStatus
     always_prefer = "S"
 
+    CLI_STATUS_MAP = {
+        "auto-configured": True,
+        "auto-configuring": False,
+        "authenticated": True,
+        "active": True,
+    }
     SNMP_STATUS_MAP = {
         0: True,  # authenticated
         1: True,  # registered
@@ -24,6 +31,30 @@ class Script(BaseScript):
         4: False,  # lost
         5: True,  # standby
     }
+
+    def execute_cli(self, **kwargs):
+        r = []
+        if self.is_gpon:
+            v = self.cli("show gpon onu-information", cached=True)
+            for i in parse_table(v):
+                onu = {
+                    "interface": i[0],
+                    "local_id": i[0],
+                    "global_id": i[3],
+                }
+                onu["oper_status"] = self.CLI_STATUS_MAP.get(i[5], False)
+                r.append(onu)
+        else:
+            v = self.cli("show epon onu-information", cached=True)
+            for i in parse_table(v):
+                onu = {
+                    "interface": i[0],
+                    "local_id": i[0],
+                    "global_id": i[3],
+                }
+                onu["oper_status"] = self.CLI_STATUS_MAP.get(i[6], "inactive")
+                r.append(onu)
+        return r
 
     def execute_snmp(self, **kwargs):
         r = {}

--- a/sa/profiles/BDCOM/xPON/get_cpe_status.py
+++ b/sa/profiles/BDCOM/xPON/get_cpe_status.py
@@ -52,7 +52,7 @@ class Script(BaseScript):
                     "local_id": i[0],
                     "global_id": i[3],
                 }
-                onu["oper_status"] = self.CLI_STATUS_MAP.get(i[6], "inactive")
+                onu["oper_status"] = self.CLI_STATUS_MAP.get(i[6], False)
                 r.append(onu)
         return r
 

--- a/sa/profiles/BDCOM/xPON/get_interfaces.py
+++ b/sa/profiles/BDCOM/xPON/get_interfaces.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # BDCOM_xPON.get_interfaces
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2025 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -26,7 +26,7 @@ class Script(BaseScript):
         r"(^\s+protocolstatus.+\n)?"
         r"^\s+Ifindex is (?P<snmp_ifindex>\d+)(, unique port number is \d+)?\s*\n"
         r"(^\s+Description: (?P<descr>.+)\n)?"
-        r"^\s+Hardware is (?P<type>\S+)(, [Aa]ddress is (?P<mac>\S+)\s*\(.+\))?\s*\n"
+        r"^\s+Hardware is (?P<hw>\S+)(, [Aa]ddress is (?P<mac>\S+)\s*\(.+\))?\s*\n"
         r"(^\s+Interface address is (?P<ip>\S+)\s*\n)?"
         r"^\s+MTU (?P<mtu>\d+) bytes",
         re.MULTILINE,
@@ -57,17 +57,15 @@ class Script(BaseScript):
         "Null": "null",
     }
 
-    # @todo: snmp
-    # @todo: cdp
-    # @todo: gvrp
-
     def execute_cli(self):
         ifaces = []
         v = self.cli("show interface")
         for match in self.rx_int.finditer(v):
             ifname = self.profile.convert_interface_name(match.group("ifname"))
-            typ = match.group("type")
-            iftype = self.types[typ]
+            hw = match.group("hw")
+            if hw in ["GPON-ONUID", "Giga-LLID", "GigaEthernet-LLID"] and ":" in ifname:
+                continue
+            iftype = self.types[hw]
             i = {
                 "name": ifname,
                 "type": iftype,
@@ -91,13 +89,6 @@ class Script(BaseScript):
             if match.group("ip"):
                 sub["enabled_afi"] = ["IPv4"]
                 sub["ipv4_addresses"] = [match.group("ip")]
-            if typ in ["GPON-ONUID", "Giga-LLID", "GigaEthernet-LLID"] and ":" in ifname:
-                parent_iface = ifname.split(":")[0]
-                for iface in ifaces:
-                    if iface["name"] == parent_iface:
-                        iface["subinterfaces"] += [sub]
-                        break
-                continue
 
             if i["type"] == "physical":
                 sub["enabled_afi"] = ["BRIDGE"]

--- a/sa/profiles/BDCOM/xPON/get_inventory.py
+++ b/sa/profiles/BDCOM/xPON/get_inventory.py
@@ -66,7 +66,7 @@ class Script(BaseScript):
                 "number": None,
                 "vendor": "BDCOM",
                 "serial": serial,
-                "description": f'{p["vendor"]} {p["platform"]}',
+                "description": f"{p['vendor']} {p['platform']}",
                 "part_no": [p["platform"]],
                 "revision": revision,
                 "builtin": False,

--- a/sa/profiles/BDCOM/xPON/get_inventory.py
+++ b/sa/profiles/BDCOM/xPON/get_inventory.py
@@ -93,10 +93,9 @@ class Script(BaseScript):
                     part_no = "SFP"
                 elif t in ["10Giga-FX-SFP"]:
                     part_no = "SFP+"
-                else:
+                elif not t in ["GPON", "Giga-PON"]:
                     # xPON interfaces do not display the absence of a transceiver
-                    if not t in ["GPON", "Giga-PON"]:
-                        self.logger.info(f"{ifname} - Unknown port type '{t}'.")
+                    self.logger.info(f"{ifname} - Unknown port type '{t}'.")
             if not match:
                 # Some devices can not get transceiver info
                 continue
@@ -225,13 +224,12 @@ class Script(BaseScript):
                             f"{ifname} - Unknown xcvr_type '{xcvr_type}' for SFP `part_no`."
                         )
                         part_no = part_no + "Unknown SFP"
-                else:
+                elif xcvr_type == "1000BASE-LX":
                     # Found with part_no DPB-3512-S2
-                    if xcvr_type == "1000BASE-LX":
-                        part_no = part_no + "1G | SFP LX"
-                    else:
-                        self.logger.info(f"{ifname} - Unknown `part_no` '{p}'.")
-                        part_no = part_no + "Unknown SFP"
+                    part_no = part_no + "1G | SFP LX"
+                else:
+                    self.logger.info(f"{ifname} - Unknown `part_no` '{p}'.")
+                    part_no = part_no + "Unknown SFP"
                 r += [
                     {
                         "type": "XCVR",

--- a/sa/profiles/BDCOM/xPON/get_inventory.py
+++ b/sa/profiles/BDCOM/xPON/get_inventory.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # BDCOM.xPON.get_inventory
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2025 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -66,7 +66,7 @@ class Script(BaseScript):
                 "number": None,
                 "vendor": "BDCOM",
                 "serial": serial,
-                "description": f"{p['vendor']} {p['platform']}",
+                "description": f'{p["vendor"]} {p["platform"]}',
                 "part_no": [p["platform"]],
                 "revision": revision,
                 "builtin": False,
@@ -93,8 +93,10 @@ class Script(BaseScript):
                     part_no = "SFP"
                 elif t in ["10Giga-FX-SFP"]:
                     part_no = "SFP+"
-                elif not t in ["GPON", "Giga-PON"]:
-                    self.logger.info(f"{ifname} - Unknown port type '{t}'.")
+                else:
+                    # xPON interfaces do not display the absence of a transceiver
+                    if not t in ["GPON", "Giga-PON"]:
+                        self.logger.info(f"{ifname} - Unknown port type '{t}'.")
             if not match:
                 # Some devices can not get transceiver info
                 continue
@@ -224,8 +226,12 @@ class Script(BaseScript):
                         )
                         part_no = part_no + "Unknown SFP"
                 else:
-                    self.logger.info(f"{ifname} - Unknown `part_no` '{p}'.")
-                    part_no = part_no + "Unknown SFP"
+                    # Found with part_no DPB-3512-S2
+                    if xcvr_type == "1000BASE-LX":
+                        part_no = part_no + "1G | SFP LX"
+                    else:
+                        self.logger.info(f"{ifname} - Unknown `part_no` '{p}'.")
+                        part_no = part_no + "Unknown SFP"
                 r += [
                     {
                         "type": "XCVR",

--- a/sa/profiles/BDCOM/xPON/get_mac_address_table.py
+++ b/sa/profiles/BDCOM/xPON/get_mac_address_table.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # BDCOM.xPON.get_mac_address_table
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2021 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -26,7 +26,7 @@ class Script(BaseScript):
             cmd += " %s" % MAC(mac).to_cisco()
         r = []
 
-        for i in parse_table(self.cli(cmd), expand_columns=True):
+        for i in parse_table(self.cli(cmd), expand_columns=True, max_width=60):
             if i[0] == "All" or i[3] == "CPU":
                 continue
             r += [{"vlan_id": i[0], "mac": i[1], "interfaces": [i[3]], "type": "D"}]

--- a/sa/profiles/BDCOM/xPON/get_version.py
+++ b/sa/profiles/BDCOM/xPON/get_version.py
@@ -58,5 +58,4 @@ class Script(BaseScript):
                     "Serial Number": match.group("serial"),
                 },
             }
-        else:
-            raise self.NotSupportedError()
+        raise self.NotSupportedError()

--- a/sa/profiles/BDCOM/xPON/get_version.py
+++ b/sa/profiles/BDCOM/xPON/get_version.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # BDCOM.xPON.get_version
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -36,7 +36,7 @@ class Script(BaseScript):
         return {
             "vendor": "BDCOM",
             "platform": match.group("platform"),
-            "version": match.group("version"),
+            "version": "%s, %s" % (match.group("version"), match.group("build")),
             "attributes": {
                 "Build": match.group("build"),
                 "Boot PROM": match.group("boot"),
@@ -51,11 +51,12 @@ class Script(BaseScript):
             return {
                 "vendor": "BDCOM",
                 "platform": match.group("platform"),
-                "version": match.group("version"),
+                "version": "%s, %s" % (match.group("version"), match.group("build")),
                 "attributes": {
                     "Build": match.group("build"),
                     "Boot PROM": match.group("boot"),
                     "Serial Number": match.group("serial"),
                 },
             }
-        raise self.NotSupportedError()
+        else:
+            raise self.NotSupportedError()

--- a/sa/profiles/BDCOM/xPON/get_version.py
+++ b/sa/profiles/BDCOM/xPON/get_version.py
@@ -26,8 +26,7 @@ class Script(BaseScript):
         re.MULTILINE | re.DOTALL,
     )
 
-    rx_hver = re.compile(r"^hardware version:(?:V|)(?P<hversion>\S+)", re.MULTILINE)
-
+    #rx_hver = re.compile(r"^hardware version:(?:V|)(?P<hversion>\S+)", re.MULTILINE)
     # todo: add hardware ver for P3310C, P3608 (snmp output need)
 
     def execute_snmp(self):
@@ -36,7 +35,7 @@ class Script(BaseScript):
         return {
             "vendor": "BDCOM",
             "platform": match.group("platform"),
-            "version": "%s, %s" % (match.group("version"), match.group("build")),
+            "version": f"{match.group('version')}, {match.group('build')}",
             "attributes": {
                 "Build": match.group("build"),
                 "Boot PROM": match.group("boot"),
@@ -51,7 +50,7 @@ class Script(BaseScript):
             return {
                 "vendor": "BDCOM",
                 "platform": match.group("platform"),
-                "version": "%s, %s" % (match.group("version"), match.group("build")),
+                "version": f"{match.group('version')}, {match.group('build')}",
                 "attributes": {
                     "Build": match.group("build"),
                     "Boot PROM": match.group("boot"),

--- a/sa/profiles/BDCOM/xPON/get_version.py
+++ b/sa/profiles/BDCOM/xPON/get_version.py
@@ -26,8 +26,8 @@ class Script(BaseScript):
         re.MULTILINE | re.DOTALL,
     )
 
-    #rx_hver = re.compile(r"^hardware version:(?:V|)(?P<hversion>\S+)", re.MULTILINE)
     # todo: add hardware ver for P3310C, P3608 (snmp output need)
+    # rx_hver = re.compile(r"^hardware version:(?:V|)(?P<hversion>\S+)", re.MULTILINE)
 
     def execute_snmp(self):
         v = self.snmp.get(mib["SNMPv2-MIB::sysDescr.0"], cached=True)

--- a/sa/profiles/BDCOM/xPON/profile.py
+++ b/sa/profiles/BDCOM/xPON/profile.py
@@ -30,9 +30,10 @@ class Profile(BaseProfile):
     }
 
     def convert_interface_name(self, interface):
-        if interface.startswith("TGigaEthernet"):
-            return interface
-        elif interface.startswith("GigaEthernet"):
+        if (
+            interface.startswith("TGigaEthernet")
+            or interface.startswith("GigaEthernet")
+        ):
             return interface
         if ":" in interface:
             interface = interface.split(":")[0]

--- a/sa/profiles/BDCOM/xPON/profile.py
+++ b/sa/profiles/BDCOM/xPON/profile.py
@@ -30,10 +30,7 @@ class Profile(BaseProfile):
     }
 
     def convert_interface_name(self, interface):
-        if (
-            interface.startswith("TGigaEthernet")
-            or interface.startswith("GigaEthernet")
-        ):
+        if interface.startswith("TGigaEthernet") or interface.startswith("GigaEthernet"):
             return interface
         if ":" in interface:
             interface = interface.split(":")[0]

--- a/sa/profiles/BDCOM/xPON/profile.py
+++ b/sa/profiles/BDCOM/xPON/profile.py
@@ -36,21 +36,20 @@ class Profile(BaseProfile):
             interface = interface.split(":")[0]
         if interface.startswith("gpon"):
             return "GPON" + interface[4:]
-        elif interface.startswith("epon"):
+        if interface.startswith("epon"):
             return "EPON" + interface[4:]
-        elif interface.startswith("f"):
+        if interface.startswith("f"):
             return interface.replace("f", "FastEthernet")
-        elif interface.startswith("g"):
+        if interface.startswith("g"):
             return interface.replace("g", "GigaEthernet")
-        elif interface.startswith("Gig"):
+        if interface.startswith("Gig"):
             return interface.replace("Gig", "GigaEthernet")
-        elif interface.startswith("TGi"):
+        if interface.startswith("TGi"):
             return interface.replace("TGi", "TGigaEthernet")
-        elif interface.startswith("tg"):
+        if interface.startswith("tg"):
             return interface.replace("tg", "TGigaEthernet")
-        elif interface.startswith("v"):
+        if interface.startswith("v"):
             return interface.replace("v", "VLAN")
-        elif interface.startswith("n"):
+        if interface.startswith("n"):
             return interface.replace("n", "Null")
-        else:
-            return interface
+        return interface

--- a/sa/profiles/BDCOM/xPON/profile.py
+++ b/sa/profiles/BDCOM/xPON/profile.py
@@ -2,7 +2,7 @@
 # Vendor: BDCOM
 # OS:     xPON
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2023 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -15,7 +15,7 @@ class Profile(BaseProfile):
 
     pattern_more = [(rb"^ --More-- ", b" "), (rb"\(y/n\) \[n\]", b"y\n")]
     pattern_unprivileged_prompt = rb"^(?P<hostname>\S+)>"
-    pattern_prompt = rb"^(?P<hostname>\S+)#"
+    pattern_prompt = rb"^(?P<hostname>\S+)(?:_config(?:_\S+)?)?#"
     pattern_syntax_error = rb"% Unknown command"
     command_disable_pager = ["terminal length 0", "terminal width 0"]
     command_super = b"enable"
@@ -25,28 +25,34 @@ class Profile(BaseProfile):
     command_exit = "exit"
     config_volatile = ["^%.*?$"]
 
+    matchers = {
+        "is_gpon": {"platform": {"$regex": r"^GP"}},
+    }
+
     def convert_interface_name(self, interface):
         if interface.startswith("TGigaEthernet"):
             return interface
-        if interface.startswith("GigaEthernet"):
+        elif interface.startswith("GigaEthernet"):
             return interface
-
-        if interface.startswith("f"):
-            return interface.replace("f", "FastEthernet")
-        if interface.startswith("g"):
-            return interface.replace("g", "GigaEthernet")
-        if interface.startswith("Gig"):
-            return interface.replace("Gig", "GigaEthernet")
-        if interface.startswith("TGi"):
-            return interface.replace("TGi", "TGigaEthernet")
-        if interface.startswith("tg"):
-            return interface.replace("tg", "TGigaEthernet")
+        if ":" in interface:
+            interface = interface.split(":")[0]
         if interface.startswith("gpon"):
             return "GPON" + interface[4:]
-        if interface.startswith("epon"):
+        elif interface.startswith("epon"):
             return "EPON" + interface[4:]
-        if interface.startswith("v"):
+        elif interface.startswith("f"):
+            return interface.replace("f", "FastEthernet")
+        elif interface.startswith("g"):
+            return interface.replace("g", "GigaEthernet")
+        elif interface.startswith("Gig"):
+            return interface.replace("Gig", "GigaEthernet")
+        elif interface.startswith("TGi"):
+            return interface.replace("TGi", "TGigaEthernet")
+        elif interface.startswith("tg"):
+            return interface.replace("tg", "TGigaEthernet")
+        elif interface.startswith("v"):
             return interface.replace("v", "VLAN")
-        if interface.startswith("n"):
+        elif interface.startswith("n"):
             return interface.replace("n", "Null")
-        return interface
+        else:
+            return interface

--- a/sa/profiles/BDCOM/xPON/profile.py
+++ b/sa/profiles/BDCOM/xPON/profile.py
@@ -34,9 +34,9 @@ class Profile(BaseProfile):
             return interface
         if ":" in interface:
             interface = interface.split(":")[0]
-        if interface.startswith("gpon"):
+        if interface.lower().startswith("gpon"):
             return "GPON" + interface[4:]
-        if interface.startswith("epon"):
+        if interface.lower().startswith("epon"):
             return "EPON" + interface[4:]
         if interface.startswith("f"):
             return interface.replace("f", "FastEthernet")


### PR DESCRIPTION
Add GPON support and full SNMP-based discovery to the BDCOM.xPON profile. Previously, only EPON devices were supported via CLI-only scripts; this change adds native GPON command parsing and introduces `execute_snmp` implementations across CPE-related scripts.

**Key changes:**
- **get_cpe.py (complete rewrite):** Add `execute_cli` for both GPON (`show gpon onu-information`, `show gpon active-onu`, `show gpon onu-description`, `show gpon onu-image-information`) and EPON; implement `execute_snmp` using NMS-GPON-MIB, NMS-EPON-MIB, and IF-MIB OIDs. Added `STATUS_MAP`, `SNMP_STATUS_MAP`, multi-vendor MCU model mapping (`ONU_MAP`). Set `always_prefer = "S"` and `TIMEOUT = 600`.
- **get_cpe_status.py:** Replace CLI-only implementation with SNMP-based `execute_snmp` (same MIB set). Added `always_prefer = "S"`.
- **get_interfaces.py:** Skip pseudo-interfaces (`GPON-ONUID`, `Giga-LLID`, `GigaEthernet-LLID`) during regex match rather than post-processing. Renamed capture group from `type` to `hw`.
- **get_inventory.py:** Add handling for `1000BASE-LX` transceiver type (part_no DPB-3512-S2). Skip xPON interfaces when checking for missing transceivers.
- **get_mac_address_table.py:** Pass `max_width=60` to `parse_table()` for wider table support.
- **get_version.py:** Include build number in the version string (`"%s, %s"` format) for both CLI and SNMP paths.
- **profile.py:** Add `matchers` dict so `is_gpon` is auto-detected on devices with platform prefix `GP`. Update `pattern_prompt` to match config-mode prompts (`_config_SUF#`). Restructure `convert_interface_name` — strip colon suffixes early, normalize GPON/EPON names.

**Notable implementation details:**
- The `is_gpon` property is populated via `matchers` framework (profile-level `$regex` matcher on platform string).
- All new CLI commands use `parse_table()` from `noc.core.text`.
- SNMP walks use column-based OIDs from vendor-specific MIB modules (NMS-GPON-MIB: 1.3.6.1.4.1.3320.10.3.1.1.x; NMS-EPON-MIB: 1.3.6.1.4.1.3320.101.10.1.1.x).
