### PR TITLE
Implement smartrefresh feature in Polling mixin

### DIFF
--- a/ui/web/core/mixins/Polling.js
+++ b/ui/web/core/mixins/Polling.js
@@ -61,7 +61,6 @@ Ext.define("NOC.core.mixins.Polling", {
     };
     this._handleWindowBlur = () => {
       if(this.destroyed) return;
-      if(this.isFullScreen()) return;
       this._windowFocused = false;
       this.disableHandler(true);
     };
@@ -100,10 +99,6 @@ Ext.define("NOC.core.mixins.Polling", {
     } else{
       this.pollingTask();
     }
-  },
-
-  isFullScreen: function(){
-    return window.outerWidth === screen.width || window.outerHeight === screen.height;
   },
 
   stopPolling: function(){

--- a/ui/web/core/mixins/Polling.js
+++ b/ui/web/core/mixins/Polling.js
@@ -18,6 +18,11 @@ Ext.define("NOC.core.mixins.Polling", {
   observer: null,
 
   startPolling: function(){
+    if(!NOC.settings.features.includes("smartrefresh")){
+      this.runPollingTask();
+      return;
+    }
+
     if(this.observer){
       this.stopPolling();
     }
@@ -55,6 +60,10 @@ Ext.define("NOC.core.mixins.Polling", {
     window.addEventListener("blur", this._handleWindowBlur);
     document.addEventListener("visibilitychange", this._handleVisibilityChange);
 
+    this.runPollingTask();
+  },
+
+  runPollingTask: function(){
     if(Ext.isEmpty(this.pollingTaskId)){
       var jitter = this.pollingInterval * 0.1 * (2 * Math.random() - 1);
       this.pollingTaskId = Ext.TaskManager.start({

--- a/ui/web/core/mixins/Polling.js
+++ b/ui/web/core/mixins/Polling.js
@@ -19,6 +19,10 @@ Ext.define("NOC.core.mixins.Polling", {
 
   startPolling: function(){
     if(!NOC.settings.features.includes("smartrefresh")){
+      // Without smartrefresh there is no IntersectionObserver/focus tracking,
+      // so force the "visible & focused" state the pollingTask guard relies on.
+      this.isIntersecting = true;
+      this._windowFocused = true;
       this.runPollingTask();
       return;
     }

--- a/ui/web/core/mixins/Polling.js
+++ b/ui/web/core/mixins/Polling.js
@@ -39,8 +39,17 @@ Ext.define("NOC.core.mixins.Polling", {
       threshold: 0.1,
     });
 
-    if(this.getEl() && this.getEl().dom){
-      this.observer.observe(this.getEl().dom);
+    if(!this.observeTarget()){
+      // Element is not rendered yet — defer observe() until the host
+      // component fires afterrender, otherwise isIntersecting would stay
+      // false forever and polling would never fetch.
+      var cmp = Ext.isFunction(this.getView) ? this.getView() : this;
+      if(cmp && Ext.isFunction(cmp.on)){
+        cmp.on("afterrender", function(){
+          if(this.destroyed || !this.observer) return;
+          this.observeTarget();
+        }, this, {single: true});
+      }
     }
 
     this._windowFocused = document.hasFocus();
@@ -65,6 +74,19 @@ Ext.define("NOC.core.mixins.Polling", {
     document.addEventListener("visibilitychange", this._handleVisibilityChange);
 
     this.runPollingTask();
+  },
+
+  isPolling: function(){
+    return !!this.observer || !Ext.isEmpty(this.pollingTaskId);
+  },
+
+  observeTarget: function(){
+    var el = this.getEl();
+    if(el && el.dom){
+      this.observer.observe(el.dom);
+      return true;
+    }
+    return false;
   },
 
   runPollingTask: function(){

--- a/ui/web/fm/alarm/view/grids/ContainerController.js
+++ b/ui/web/fm/alarm/view/grids/ContainerController.js
@@ -86,6 +86,14 @@ Ext.define("NOC.fm.alarm.view.grids.ContainerController", {
   getEl: function(){
     return this.getView().getEl();
   },
+  // Override the mixin's generateIcon to keep the 4px left padding the inline
+  // "{alarmsTotal}{icon}" toolbar text relies on (matches the default icon).
+  generateIcon: function(isUpdatable, icon, color, msg){
+    if(isUpdatable){
+      return `<i class='fa fa-${icon}' style='padding-left:4px;color:${color};width:16px;' data-qtip='${msg}'></i>`;
+    }
+    return "<i class='fa fa-fw' style='padding-left:4px;width:16px;'></i>";
+  },
   pollingTask: function(){
     if(this.destroyed) return;
     if(!document.hidden && this.isFocused() && this.isIntersecting){

--- a/ui/web/inv/map/Application.js
+++ b/ui/web/inv/map/Application.js
@@ -326,8 +326,8 @@ Ext.define("NOC.inv.map.Application", {
     });
 
     me.statusIndicator = Ext.create("Ext.toolbar.TextItem", {
-      padding: "3 4 0 4",
-      html: "<i class='fa fa-fw' style='width:16px;'></i>",
+      padding: "3 4 0 0",
+      html: "<i class='fa fa-fw' style='padding-left:4px;width:16px;'></i>",
     });
 
     me.miniMapButton = Ext.create("Ext.button.Button", {

--- a/ui/web/inv/map/MapPanel.js
+++ b/ui/web/inv/map/MapPanel.js
@@ -354,6 +354,15 @@ Ext.define("NOC.inv.map.MapPanel", {
       ));
   },
 
+  // Override the mixin's generateIcon to carry the 4px left padding on the icon
+  // itself (statusIndicator container no longer adds it), matching other panels.
+  generateIcon: function(isUpdatable, icon, color, msg){
+    if(isUpdatable){
+      return `<i class='fa fa-${icon}' style='padding-left:4px;color:${color};width:16px;' data-qtip='${msg}'></i>`;
+    }
+    return "<i class='fa fa-fw' style='padding-left:4px;width:16px;'></i>";
+  },
+
   overlayPollingTask: function(){
     if(this.destroyed) return;
     if(!document.hidden && this.isFocused() && this.isIntersecting){

--- a/ui/web/inv/map/MapRenderer.js
+++ b/ui/web/inv/map/MapRenderer.js
@@ -157,8 +157,14 @@ Ext.define("NOC.inv.map.MapRenderer", {
     let document = this.topoMap.convertMapData(data);
     this.topoMap.loadDocument(document);
     this.panel.app.viewStpButton.setDisabled(!data.caps.includes("Network | STP"));
-    // Run status polling
-    this.panel.startPolling();
+    // Run status polling. On segment change the panel is reused, so avoid
+    // tearing down and recreating the observer/listeners on every render —
+    // just trigger an immediate refresh if polling is already active.
+    if(this.panel.isPolling()){
+      this.panel.runPollingTask();
+    } else{
+      this.panel.startPolling();
+    }
     this.panel.fireEvent("renderdone");
   },
 

--- a/ui/web/sa/monitor/Application.js
+++ b/ui/web/sa/monitor/Application.js
@@ -24,7 +24,7 @@ Ext.define("NOC.sa.monitor.Application", {
   stateId: "monitor.appPanel",
 
   defaults: {
-    resizable: true,
+    // resizable: true,
     animCollapse: false,
     collapseMode: "mini",
     hideCollapseTool: true,

--- a/ui/web/sa/monitor/Controller.js
+++ b/ui/web/sa/monitor/Controller.js
@@ -7,11 +7,11 @@ console.debug("Defining NOC.sa.monitor.Controller");
 Ext.define("NOC.sa.monitor.Controller", {
   extend: "Ext.app.ViewController",
   alias: "controller.monitor",
-  pollingTaskId: null,
   pollingInterval: 300000, // msec
 
   mixins: [
     "NOC.core.mixins.Export",
+    "NOC.core.mixins.Polling",
   ],
 
   onShowFilter: function(){
@@ -62,12 +62,37 @@ Ext.define("NOC.sa.monitor.Controller", {
   onReload: function(btn){
     if(btn.pressed){
       this.startPolling();
+      this.getViewModel().set("icon",
+                              this.generateIcon(true, "circle", NOC.colors.yes, __("online")));
     } else{
       this.stopPolling();
+      this.getViewModel().set("icon", this.generateIcon(false));
     }
   },
 
+  getEl: function(){
+    return this.getView().getEl();
+  },
+
+  setContainerDisabled: function(state){
+    if(this.destroyed) return;
+    var grid = this.lookupReference("grid");
+    if(grid){
+      grid.getView().setDisabled(state);
+    }
+    this.getViewModel().set("icon", state ?
+      this.generateIcon(true, "stop-circle-o", "grey", __("suspend")) :
+      this.generateIcon(true, "circle", NOC.colors.yes, __("online")));
+  },
+
   pollingTask: function(){
+    if(this.destroyed) return;
+    if(!document.hidden && this.isFocused() && this.isIntersecting){
+      this.objectsReload();
+    }
+  },
+
+  objectsReload: function(){
     var logPanel = this.getView().lookupReference("logPanel"),
       grid = this.getView().lookupReference("grid");
     grid.mask(__("Loading..."));
@@ -78,25 +103,6 @@ Ext.define("NOC.sa.monitor.Controller", {
     );
     if(!logPanel.collapsed){
       logPanel.load();
-    }
-  },
-
-  startPolling: function(){
-    if(this.pollingTaskId){
-      this.pollingTask();
-    } else{
-      this.pollingTaskId = Ext.TaskManager.start({
-        run: this.pollingTask,
-        interval: this.pollingInterval,
-        scope: this,
-      });
-    }
-  },
-
-  stopPolling: function(){
-    if(this.pollingTaskId){
-      Ext.TaskManager.stop(this.pollingTaskId);
-      this.pollingTaskId = null;
     }
   },
 });

--- a/ui/web/sa/monitor/SelectionGrid.js
+++ b/ui/web/sa/monitor/SelectionGrid.js
@@ -187,6 +187,12 @@ Ext.define("NOC.sa.monitor.SelectionGrid", {
         html: __("Selected") + ": {total.selection}",
       },
     },
+    {
+      xtype: "tbtext",
+      bind: {
+        html: "{icon}",
+      },
+    },
   ],
   listeners: {
     selectionchange: "onSelectionChange",

--- a/ui/web/sa/monitor/ViewModel.js
+++ b/ui/web/sa/monitor/ViewModel.js
@@ -16,6 +16,7 @@ Ext.define("NOC.sa.monitor.ViewModel", {
     total: {
       selection: 0,
     },
+    icon: "<i class='fa fa-fw' style='width:16px;'></i>",
     polling: {
       devices: [],
       leave: 0,


### PR DESCRIPTION
The previous Polling mixin relied on IntersectionObserver + focus/visibility events to pause updates when a panel is not visible. This approach works unreliably across different monitor configurations and screen resolutions — some setups (multi-monitor, fractional scaling, nested containers) cause the observer to never fire or fire with unexpected results, effectively breaking polling for those users.

## Changes

- Add smartrefresh feature gate (NOC.settings.features). When present → new behavior with IntersectionObserver + visibility guard. Absent → legacy constant polling (default/fallback).
- Migrate sa/monitor/Controller.js from manual polling implementation to use the shared Polling mixin.
- Add isPolling() and observeTarget() helpers for better lifecycle management.
- Fix deferred observe: when element rendering is async, defer observer.observe() until afterrender instead of failing silently.
- Add icon status indicator to monitor (SelectionGrid toolbar) showing online/suspend state.
- Add generateIcon() overrides with proper 4px left padding in MapPanel and alarm grid containers.

## Behavior

| Feature gate                            | Polling mode                                                        |
|-----------------------------------------|---------------------------------------------------------------------|
| NOT set (default)                       | Constant polling — legacy behavior, no visibility/guard logic       |
| smartrefresh included in features array | Intelligent polling — pause when hidden, resume on visiblity change |