### PR TITLE
Clear alarms

### DIFF
--- a/collections/fm.dispositionrules/Network/DHCP/DHCP_Flood/DHCP/DHCP_Flood_clear_.json
+++ b/collections/fm.dispositionrules/Network/DHCP/DHCP_Flood/DHCP/DHCP_Flood_clear_.json
@@ -1,0 +1,13 @@
+{
+    "name": "Network | DHCP | DHCP Flood (Network | DHCP | DHCP Flood,clear)",
+    "$collection": "fm.dispositionrules",
+    "uuid": "60c0547b-4942-402c-b4fc-7a464bd027d8",
+    "description": null,
+    "preference": 1000,
+    "alarm_disposition__name": "Network | DHCP | DHCP Flood",
+    "conditions": [{
+        "event_class_re": "Network | DHCP | DHCP Flood Cleared"
+    }],
+    "default_action": "C",
+    "stop_processing": false
+}

--- a/collections/fm.dispositionrules/Network/IP/ARP_Flood/IP/ARP_Flood_clear_.json
+++ b/collections/fm.dispositionrules/Network/IP/ARP_Flood/IP/ARP_Flood_clear_.json
@@ -1,0 +1,13 @@
+{
+    "name": "Network | IP | ARP Flood (Network | IP | ARP Flood,clear)",
+    "$collection": "fm.dispositionrules",
+    "uuid": "92b54fe5-1f82-45ee-9549-02e2d33b4b0b",
+    "description": null,
+    "preference": 1000,
+    "alarm_disposition__name": "Network | IP | ARP Flood",
+    "conditions": [{
+        "event_class_re": "Network | IP | ARP Flood Cleared"
+    }],
+    "default_action": "C",
+    "stop_processing": false
+}

--- a/collections/fm.dispositionrules/Network/xPON/ONU/Power_Failed_ONU/xPON/ONU/Power_Failed_clear_.json
+++ b/collections/fm.dispositionrules/Network/xPON/ONU/Power_Failed_ONU/xPON/ONU/Power_Failed_clear_.json
@@ -1,0 +1,15 @@
+{
+    "name": "Network | xPON | ONU | Power Failed (Network | xPON | ONU | Power Failed,clear)",
+    "$collection": "fm.dispositionrules",
+    "uuid": "60fd2bb0-8356-4912-96f0-b2bce922ae50",
+    "description": null,
+    "preference": 1000,
+    "alarm_disposition__name": "Network | xPON | ONU | Power Failed",
+    "conditions": [
+        {
+            "event_class_re": "Network | xPON | ONU | Discovered"
+        }
+    ],
+    "default_action": "C",
+    "stop_processing": false
+}


### PR DESCRIPTION
Добавлены disposition rules для авто-расформирования алармов при наступлении условий снятия события:

• DHCP Flood → расформирование по событию *DHCP_Flood Cleared*
• ARP Flood → расформирование по событию *ARP_Flood Cleared*
• ONU Power Failed → расформирование по событию *ONU Discovered* (возобновление работа оборудования)

Каждое правило:
- preference: 1000 (стандартный приоритет)
- stop_processing: false (продолжить обработку следующих правил)
