### PR TITLE
Add utf-8 usage in agents instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,10 @@ The codebase follows a modular architecture similar to Django apps — each "app
 
 - **Language:** English only in code artifacts — comments, docstrings, logs, CLI output, configs. Never Russian or any other language.
 
+## Encoding
+
+NOC uses UTF-8 for all text data — no `smart_text()` needed. All strings, HTTP responses, ClickHouse query results, and file I/O are UTF-8. Python `.decode()` with the default UTF-8 encoding is sufficient; never fall back to `smart_text` as a "safe" alternative.
+
 ## Architecture
 
 ### Applications (Django-style)


### PR DESCRIPTION
 ClickHouseClient typing and code quality improvements
    
## Changes
    
### core/clickhouse/connect.py
- Add full typing annotations to ClickhouseClient class — init, execute(), ensure_db(), has_table(), rename_table()
- Split execute() into overloaded signatures via `@overload `+ `Literal[True/False]` for discriminated return type (`list[list[str]]` vs `bytes`)
- Remove unused import of `smart_text` (already deprecated, not needed in this context)
- Replace %s string formatting with f-strings throughout
- Rename unused headers variable to _headers per PEP8 convention
    
### core/clickhouse/ensure.py
  - Add type hints to ensure_bi_models(), ensure_dictionary_models(), ensure_pm_scopes(), ensure_all_pm_scopes(), ensure_report_ds_scopes()
  - Import and use explicit ClickHouseClient type instead of None | Any
  
 ### commands/migrate-ch.py
  - Add typing annotations to CLI handler arguments
  - Rename connect() → _ch_connect() to avoid name collision with instance attribute self.connect (latent crash in original code)
    
## Notes
- No functional changes — strictly typing and internal cleanup
- All new execute() return types correctly documented via overload