### PR TITLE
line tokenizer: don't yield empty lines

### DIFF
--- a/core/confdb/tokenizer/line.py
+++ b/core/confdb/tokenizer/line.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # line tokenizer
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -75,7 +75,7 @@ class LineTokenizer(BaseTokenizer):
         for line in iter:
             yield line.replace("\t", tr)
 
-    def iter_rewrite(self, iter: Iterable) -> Iterator[tuple[str]]:
+    def iter_rewrite(self, iter: Iterable[str]) -> Iterator[tuple[str]]:
         """
         Apply `rewrite`
         :param iter:
@@ -88,11 +88,15 @@ class LineTokenizer(BaseTokenizer):
                     break
             yield line
 
-    def iter_line_tokens(self, line) -> Iterator[tuple[str]]:
+    def iter_line_tokens(self, line: str) -> Iterator[tuple[str]]:
         """
-        Iterate line tokens
-        :param line:
-        :return:
+        Iterate line tokens.
+
+        Args:
+            line: Input line.
+
+        Returns:
+            Yields tuples of tokens.
         """
         if self.keep_indent:
             match = self.rx_indent.match(line)
@@ -101,11 +105,15 @@ class LineTokenizer(BaseTokenizer):
                 line = line[match.end() :]
         yield from line.split()
 
-    def iter_line_quoted_tokens(self, line) -> Iterator[tuple[str]]:
+    def iter_line_quoted_tokens(self, line: str) -> Iterator[tuple[str]]:
         """
-        Iterate line tokens considering strings
-        :param line:
-        :return:
+        Iterate line tokens considering strings.
+
+        Args:
+            line: Input line.
+
+        Returns:
+            Yields tuples of tokens.
         """
         if self.keep_indent:
             match = self.rx_indent.match(line)
@@ -148,4 +156,5 @@ class LineTokenizer(BaseTokenizer):
         else:
             g_tokens = self.iter_line_tokens
         for line in g:
-            yield tuple(g_tokens(line))
+            if tokens := tuple(g_tokens(line)):
+                yield tokens

--- a/tests/confdb/tokenizer/test_line.py
+++ b/tests/confdb/tokenizer/test_line.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # Test line tokenizer
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -96,6 +96,24 @@ TOKENS6 = [
 ]
 
 
+CFG7 = """
+!
+interface gigabitethernet 0/1
+  description "##XXXXXXXXXX 222222222##
+"
+  no lldp transmit
+  no lldp receive
+!
+"""
+
+TOKENS7 = [
+    ("interface", "gigabitethernet", "0/1"),
+    ("description", "##XXXXXXXXXX 222222222##"),
+    ("no", "lldp", "transmit"),
+    ("no", "lldp", "receive"),
+]
+
+
 @pytest.mark.parametrize(
     ("input", "config", "expected"),
     [
@@ -116,6 +134,11 @@ TOKENS6 = [
                 "rewrite": [(re.compile(r"^queue mode"), "  queue mode")],
             },
             TOKENS6,
+        ),
+        (
+            CFG7,
+            {"line_comment": "!", "string_quote": '"'},
+            TOKENS7,
         ),
     ],
 )


### PR DESCRIPTION
line tokenizer: skip empty tokens for comment/blank lines
    
Previously, the line tokenizer yielded empty tuples for lines containing 
only comments (e.g., ! in Cisco-style configs) or whitespace. This update 
filters those out so downstream consumers don't process spurious zero-length entries.
    
- core/confdb/tokenizer/line.py: filter empty token lists before yielding
- tests/confdb/tokenizer/test_line.py: add test case for config with comment-only lines
- Minor: added type hints and standard docstrings to tokenizer methods