### PR TITLE
Replace ORJSONResponse with JSONResponse

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,8 @@ The codebase follows a modular architecture similar to Django apps — each "app
 
 - **Language:** English only in code artifacts — comments, docstrings, logs, CLI output, configs. Never Russian or any other language.
 
+- **FastAPI Response:** use `JSONResponse(content=data)`, NOT ~~`ORJSONResponse`~~ — it's deprecated and Pydantic-native serialization is faster.
+
 ## Encoding
 
 NOC uses UTF-8 for all text data — no `smart_text()` needed. All strings, HTTP responses, ClickHouse query results, and file I/O are UTF-8. Python `.decode()` with the default UTF-8 encoding is sufficient; never fall back to `smart_text` as a "safe" alternative.

--- a/core/service/jsonrpcapi.py
+++ b/core/service/jsonrpcapi.py
@@ -11,7 +11,7 @@ from collections import namedtuple
 
 # Third-party modules
 from fastapi import APIRouter, Header, Depends
-from fastapi.responses import ORJSONResponse
+from fastapi.responses import JSONResponse
 
 # NOC modules
 from noc.aaa.models.user import User
@@ -76,7 +76,7 @@ class JSONRPCAPI:
 
         self.current_user = remote_user
         if req.method not in self.methods:
-            return ORJSONResponse(
+            return JSONResponse(
                 content={
                     "error": {"message": f"Method not found: '{req.method}'", "code": -32601},
                     "id": req.id,
@@ -111,21 +111,21 @@ class JSONRPCAPI:
                     result = await result
                 if isinstance(result, Redirect):
                     # Redirect protocol extension
-                    return ORJSONResponse(
+                    return JSONResponse(
                         content={"method": result.method, "params": result.params, "id": req.id},
                         status_code=307,
                         headers={"location": result.location},
                     )
-                return ORJSONResponse(content={"result": result, "id": req.id})
+                return JSONResponse(content={"result": result, "id": req.id})
             except NOCError as e:
                 span.set_error_from_exc(e, e.code)
-                return ORJSONResponse(
+                return JSONResponse(
                     content={"error": {"message": f"Failed: {e}", "code": e.code}, "id": req.id}
                 )
             except Exception as e:
                 error_report()
                 span.set_error_from_exc(e)
-                return ORJSONResponse(
+                return JSONResponse(
                     content={"error": {"message": f"Failed: {e}", "code": -32000}, "id": req.id}
                 )
 

--- a/services/card/base.py
+++ b/services/card/base.py
@@ -11,7 +11,7 @@ import hashlib
 
 # Third-party modules
 from fastapi import APIRouter, Request
-from fastapi.responses import ORJSONResponse, HTMLResponse
+from fastapi.responses import JSONResponse, HTMLResponse
 from fastapi.templating import Jinja2Templates
 
 # NOC modules
@@ -56,7 +56,7 @@ class BaseAPI:
                 path=route["path"],
                 methods=[route["method"]],  # ["POST"]
                 endpoint=route["endpoint"],
-                response_class=route.get("response_class", ORJSONResponse),
+                response_class=route.get("response_class", JSONResponse),
                 response_model=route["response_model"],
                 name=route["name"],
                 description=route["description"],

--- a/services/card/paths/card.py
+++ b/services/card/paths/card.py
@@ -15,7 +15,7 @@ from urllib.parse import unquote
 # Third-party modules
 import cachetools
 from fastapi import APIRouter, Header, HTTPException, Request, Response
-from fastapi.responses import HTMLResponse, RedirectResponse, ORJSONResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from jinja2 import Template
 import orjson
 
@@ -143,7 +143,7 @@ class CardAPI(BaseAPI):
             "path": "/api/card/search/",
             "method": "GET",
             "endpoint": self.handler_card_search,
-            "response_class": ORJSONResponse,
+            "response_class": JSONResponse,
             "response_model": None,
             "name": "card-search",
             "description": "",
@@ -155,7 +155,7 @@ class CardAPI(BaseAPI):
                     "path": f"/api/card/resourcepool/{a}/",
                     "method": "POST",
                     "endpoint": endpoint,
-                    "response_class": ORJSONResponse,
+                    "response_class": JSONResponse,
                     "response_model": None,
                     "name": f"card-{a}",
                     "description": "",

--- a/services/login/paths/auth.py
+++ b/services/login/paths/auth.py
@@ -12,7 +12,7 @@ from urllib.parse import quote
 
 # Third-party modules
 from fastapi import APIRouter, Request, Cookie, Header, Depends
-from fastapi.responses import ORJSONResponse
+from fastapi.responses import JSONResponse
 import cachetools
 
 # NOC modules
@@ -76,7 +76,7 @@ async def auth(
     """
     if original_uri and is_pinhole(original_uri):
         # Pinholes to endpoints without authorization
-        return ORJSONResponse({"status": True}, status_code=200)
+        return JSONResponse({"status": True}, status_code=200)
     if remote_cert_subj:
         cert_user = get_user_from_cert_subject(remote_cert_subj)
         logger.info("Remote party certificate subject: %s", remote_cert_subj)
@@ -94,12 +94,12 @@ async def auth(
             request=request, authorization=authorization, svc=svc, pinned_user=cert_user
         )
     logger.error("[%s] Denied: Unsupported authentication method", request.client.host)
-    return ORJSONResponse({"status": False}, status_code=401)
+    return JSONResponse({"status": False}, status_code=401)
 
 
 async def auth_cookie(
     request: Request, jwt_cookie: str, *, pinned_user: str | None = None
-) -> ORJSONResponse:
+) -> JSONResponse:
     """
     Authorize against JWT token contained in cookie
     """
@@ -107,17 +107,17 @@ async def auth_cookie(
         user = get_user_from_jwt(jwt_cookie, audience="auth")
         if pinned_user and user != pinned_user:
             raise ValueError("User doesn't match certificate")
-        return ORJSONResponse(
+        return JSONResponse(
             {"status": True}, status_code=200, headers={"Remote-User": encode_user(user)}
         )
     except ValueError as e:
         logger.error("[Cookie][%s] Denied: %s", request.client.host, str(e) or "Unspecified reason")
-        return ORJSONResponse({"status": False}, status_code=401)
+        return JSONResponse({"status": False}, status_code=401)
 
 
 async def auth_private_token(
     request: Request, private_token: str, *, pinned_user: str | None = None
-) -> ORJSONResponse:
+) -> JSONResponse:
     """
     Authenticate against Private-Token header
     """
@@ -125,7 +125,7 @@ async def auth_private_token(
     remote_ip = request.client.host
     user, access = get_api_access(private_token, remote_ip)
     if user and access and (not pinned_user or user == pinned_user):
-        return ORJSONResponse(
+        return JSONResponse(
             {"status": True},
             status_code=200,
             headers={"Remote-User": encode_user(user), "X-NOC-API-Access": access},
@@ -142,7 +142,7 @@ async def auth_private_token(
         remote_ip,
         reason or "Unspecified reason",
     )
-    return ORJSONResponse({"status": False}, status_code=401)
+    return JSONResponse({"status": False}, status_code=401)
 
 
 api_key_cache = cachetools.TTLCache(100, ttl=3)
@@ -162,7 +162,7 @@ def get_api_access(key: str, ip: str) -> tuple[str, str]:
 
 async def auth_authorization(
     request: Request, authorization: str, svc: LoginService, *, pinned_user: str | None = None
-) -> ORJSONResponse:
+) -> JSONResponse:
     """
     Authenticate against Authorization header
     """
@@ -190,12 +190,12 @@ async def auth_authorization(
             "[Authorization][%s] Denied: Unsupported authorization header",
             request.client.host,
         )
-    return ORJSONResponse({"status": False}, status_code=401)
+    return JSONResponse({"status": False}, status_code=401)
 
 
 async def auth_authorization_basic(
     request: Request, data: str, *, pinned_user: str | None = None
-) -> ORJSONResponse:
+) -> JSONResponse:
     """
     HTTP Basic authorization handler
     """
@@ -203,33 +203,33 @@ async def auth_authorization_basic(
     auth_data = smart_text(codecs.decode(smart_bytes(data), "base64"))
     if ":" not in auth_data:
         logger.error("[Authorization|Basic][%s] Denied: Malformed data", remote_ip)
-        return ORJSONResponse({"status": False}, status_code=401)
+        return JSONResponse({"status": False}, status_code=401)
     user, password = auth_data.split(":", 1)
     credentials = {"user": user, "password": password, "ip": remote_ip}
     user = authenticate(credentials)
     if user:
         if pinned_user and user != pinned_user:
             logger.error("[Authorization|Basic][%s] user doesn't match certificate", user)
-            return ORJSONResponse({"status": False}, status_code=401)
+            return JSONResponse({"status": False}, status_code=401)
         register_last_login(user)
-        response = ORJSONResponse(
+        response = JSONResponse(
             {"status": True}, status_code=200, headers={"Remote-User": encode_user(user)}
         )
         set_jwt_cookie(response, user)
         return response
     logger.error("[Authorization|Basic][%s|%s] Denied: Authentication failed", user, remote_ip)
-    return ORJSONResponse({"status": False}, status_code=401)
+    return JSONResponse({"status": False}, status_code=401)
 
 
 async def auth_authorization_bearer(
     request: Request, data: str, svc: LoginService, pinned_user: str | None = None
-) -> ORJSONResponse:
+) -> JSONResponse:
     """
     HTTP Bearer autorization handler
     :return:
     """
     if svc.is_revoked(data):
-        return ORJSONResponse({"status": False}, status_code=401)
+        return JSONResponse({"status": False}, status_code=401)
     try:
         user = get_user_from_jwt(data, audience="auth")
         if pinned_user and user != pinned_user:
@@ -238,8 +238,8 @@ async def auth_authorization_bearer(
         logger.error(
             "[Authorization|Bearer][%s] Denied: Authentication failed", request.client.host
         )
-        return ORJSONResponse({"status": False}, status_code=401)
-    return ORJSONResponse(
+        return JSONResponse({"status": False}, status_code=401)
+    return JSONResponse(
         {"status": True}, status_code=200, headers={"Remote-User": encode_user(user)}
     )
 

--- a/services/login/paths/change_credentials.py
+++ b/services/login/paths/change_credentials.py
@@ -7,7 +7,7 @@
 
 # Third-party modules
 from fastapi import APIRouter
-from fastapi.responses import ORJSONResponse
+from fastapi.responses import JSONResponse
 
 
 # NOC modules
@@ -33,6 +33,6 @@ async def change_credentials(req: ChangeCredentialsRequest) -> StatusResponse:
     except ChangeCredentialsError as e:
         return StatusResponse(status=False, message=str(e))
     # Update login cookie
-    response = ORJSONResponse({"status": True})
+    response = JSONResponse({"status": True})
     set_jwt_cookie(response, req.user, expire=config.login.session_ttl)
     return response

--- a/services/login/paths/login.py
+++ b/services/login/paths/login.py
@@ -11,7 +11,7 @@ import logging
 
 # Third-party modules
 from fastapi import APIRouter, Request
-from fastapi.responses import ORJSONResponse
+from fastapi.responses import JSONResponse
 
 # NOC modules
 from noc.aaa.models.user import User
@@ -80,10 +80,10 @@ async def login(request: Request, creds: LoginRequest):
         now = datetime.datetime.now()
         ttl = int((user.change_at - now).total_seconds())
         if ttl < EXPIRATION_GUARD_TIME:
-            return ORJSONResponse({"status": True, "must_change": True})
+            return JSONResponse({"status": True, "must_change": True})
     else:
         ttl = config.login.session_ttl
     # Generate JWT cookie
-    response = ORJSONResponse({"status": True, "must_change": False})
+    response = JSONResponse({"status": True, "must_change": False})
     set_jwt_cookie(response, user_name, expire=ttl)
     return response

--- a/services/metricscollector/paths/vmagent.py
+++ b/services/metricscollector/paths/vmagent.py
@@ -16,7 +16,7 @@ import snappy
 import zstd
 from google.protobuf.message import DecodeError
 from fastapi import APIRouter, Header, HTTPException, Body, Request
-from fastapi.responses import ORJSONResponse
+from fastapi.responses import JSONResponse
 
 # NOC modules
 from noc.core.service.loader import get_service
@@ -87,7 +87,7 @@ class VMAgentAPI:
         remote_write_version: str | None = Header(
             None, alias="x-victoriametrics-remote-write-version"
         ),
-    ) -> ORJSONResponse:
+    ) -> JSONResponse:
         if not authorization:
             raise HTTPException(status_code=HTTPStatus.FORBIDDEN)
         _, key = authorization.split(" ")
@@ -98,14 +98,14 @@ class VMAgentAPI:
                 "error", ("type", "unknown_remote_system"), ("collector", VMAGENT_COLLECTOR)
             ] += 1
             # IP Address
-            return ORJSONResponse(
+            return JSONResponse(
                 {
                     "error": f"Unknown Remote System {remote_system_code}",
                 },
                 status_code=HTTPStatus.NOT_FOUND,
             )
         if rs_cfg.api_key != key:
-            return ORJSONResponse(
+            return JSONResponse(
                 {
                     "error": f"Remote System API Key not Authorization {remote_system_code}",
                 },
@@ -122,7 +122,7 @@ class VMAgentAPI:
         )
         if not channel or channel.is_banned:
             # IP Address
-            return ORJSONResponse(
+            return JSONResponse(
                 {
                     "error": f"Not Found Remote System by key {remote_system_code}",
                 },
@@ -138,7 +138,7 @@ class VMAgentAPI:
             parser.ParseFromString(req)
         except DecodeError as e:
             logger.error("Error when parsed: %s", str(e))
-            return ORJSONResponse({}, status_code=200)
+            return JSONResponse({}, status_code=200)
         logger.debug("VMAgent, Parsed %s", parser)
         for ts in parser.timeseries:
             metric_name, instance, host, labels = self.parse_labels(ts.labels)
@@ -157,7 +157,7 @@ class VMAgentAPI:
             logger.info(
                 "[%s|%s] Received series: %s", self.api_name, channel.remote_system.name, received
             )
-        return ORJSONResponse({}, status_code=200)
+        return JSONResponse({}, status_code=200)
 
     def setup_endpoints(self):
         self.router.add_api_route(

--- a/services/metricscollector/paths/zabbix.py
+++ b/services/metricscollector/paths/zabbix.py
@@ -14,7 +14,7 @@ from http import HTTPStatus
 # Third-party modules
 import orjson
 from fastapi import APIRouter, Header, HTTPException, Body
-from fastapi.responses import ORJSONResponse
+from fastapi.responses import JSONResponse
 
 # NOC modules
 from noc.core.perf import metrics
@@ -56,7 +56,7 @@ class ZabbixAPI:
         req: bytes = Body(...),
         remote_system_code: str | None = None,
         authorization: str | None = Header(None, alias="Authorization"),
-    ) -> ORJSONResponse:
+    ) -> JSONResponse:
         if not authorization:
             raise HTTPException(status_code=HTTPStatus.FORBIDDEN)
         _, key = authorization.split(" ")
@@ -64,14 +64,14 @@ class ZabbixAPI:
         rs_cfg = self.service.get_remote_system_by_key(key.strip())
         if not rs_cfg:
             # IP Address
-            return ORJSONResponse(
+            return JSONResponse(
                 {
                     "error": f"Unknown Remote System {remote_system_code}",
                 },
                 status_code=HTTPStatus.NOT_FOUND,
             )
         if rs_cfg.api_key != key:
-            return ORJSONResponse(
+            return JSONResponse(
                 {
                     "error": f"Remote System API Key not Authorization {remote_system_code}",
                 },
@@ -84,7 +84,7 @@ class ZabbixAPI:
         channel = self.service.get_channel(rs_cfg, ZABBIX_COLLECTOR)
         if not channel or channel.is_banned:
             # IP Address
-            return ORJSONResponse(
+            return JSONResponse(
                 {
                     "error": f"Not Found Remote System by key {remote_system_code}",
                 },
@@ -116,14 +116,14 @@ class ZabbixAPI:
         if sensors:
             logger.debug("Received sensors: %s", len(sensors))
             self.service.send_sensors(sensors)
-        return ORJSONResponse({}, status_code=200)
+        return JSONResponse({}, status_code=200)
 
     async def events(
         self,
         req: bytes = Body(...),
         remote_system_code: str | None = None,
         authorization: str | None = Header(None, alias="Authorization"),
-    ) -> ORJSONResponse:
+    ) -> JSONResponse:
         if not authorization:
             raise HTTPException(status_code=HTTPStatus.FORBIDDEN)
         logger.debug("REQUEST: %r", req)
@@ -132,14 +132,14 @@ class ZabbixAPI:
         rs_cfg = self.service.get_remote_system_by_key(key.strip())
         if not rs_cfg or rs_cfg.is_banned:
             # IP Address
-            return ORJSONResponse(
+            return JSONResponse(
                 {
                     "error": f"Unknown Remote System {remote_system_code}",
                 },
                 status_code=HTTPStatus.NOT_FOUND,
             )
         if rs_cfg.api_key != key.strip():
-            return ORJSONResponse(
+            return JSONResponse(
                 {
                     "error": f"Remote System API Key not Authorization {remote_system_code}",
                 },
@@ -175,7 +175,7 @@ class ZabbixAPI:
             )
             logger.info("Received %s event", fm_event)
             await channel.feed_etl(fm_event)
-        return ORJSONResponse({}, status_code=200)
+        return JSONResponse({}, status_code=200)
 
     def setup_endpoints(self):
         # Items

--- a/services/nbi/base.py
+++ b/services/nbi/base.py
@@ -9,7 +9,7 @@
 
 # Third-party modules
 from fastapi import APIRouter
-from fastapi.responses import ORJSONResponse
+from fastapi.responses import JSONResponse
 
 # NOC modules
 from noc.core.service.loader import get_service
@@ -63,7 +63,7 @@ class NBIAPI:
                 path=route["path"],
                 methods=[route["method"]],  # ["POST"]
                 endpoint=route["endpoint"],
-                response_class=route.get("response_class", ORJSONResponse),
+                response_class=route.get("response_class", JSONResponse),
                 response_model=route["response_model"],
                 name=route["name"],
                 description=route["description"],


### PR DESCRIPTION
Replace deprecated ORJSONResponse with JSONResponse across all files
    
ORJSONResponse has been removed from FastAPI (see feast-dev/feast#6139). Pydantic 2 native JSON serialization is faster than orjson + custom response class, and eliminates the extra dependency.
    
This PR:
- Replaces ORJSONResponse → JSONResponse in all 9 files matching grep ORJSONResponse *.py
- Updates function return type annotations (e.g. -> ORJSONResponse → -> JSONResponse)
- Updates default response_class fallbacks in base classes (nbi/base.py, card/base.py)
- Preserves standalone import orjson where used for request parsing (orjson.loads())

No semantic changes — the JSONResponse(content=...) and JSONResponse({...}) call pattern is identical to ORJSONResponse.