### PR TITLE
python-multipart 0.0.32

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ node = [
   "starlette>=1.3.1", # Used by FastAPI, restricted by security reasons
   "uvicorn==0.40.0",
   'yappi==1.7.3',
-  "python-multipart==0.0.31", # Used by FastAPI to process form data
+  "python-multipart==0.0.32", # Used by FastAPI to process form data
   "gufo-liftbridge==0.2.0",
   "gufo-snmp==0.12.0",
   "gufo_noc_speedup==0.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ node = [
   "starlette>=1.3.1", # Used by FastAPI, restricted by security reasons
   "uvicorn==0.40.0",
   'yappi==1.7.3',
-  "python-multipart==0.0.28", # Used by FastAPI to process form data
+  "python-multipart==0.0.31", # Used by FastAPI to process form data
   "gufo-liftbridge==0.2.0",
   "gufo-snmp==0.12.0",
   "gufo_noc_speedup==0.1.0",


### PR DESCRIPTION
Update python-multipart to latest version (fix critical CVE)

Security update: bump python-multipart from 0.0.28 to 0.0.32 — latest stable release.

CVEs fixed in this migration

The following vulnerabilities are present in our current version (0.0.28):

1. GHSA-v9pg-7xvm-68hf (fixed in 0.0.31)
   Negative Content-Length in parse_form buffers the entire body in memory → DoS via OOM.

2. GHSA-5rvq-cxj2-64vf (fixed in 0.0.30)
   Quadratic-time querystring parsing with semicolon separators → CPU DoS (O(n²) complexity on crafted input).

3. GHSA-6jv3-5f52-599m (fixed in 0.0.30)
   Semicolon treated as querystring field separator → parameter smuggling and potential cache/ACL bypass in downstream logic.
    
    
    Why this matters
    python-multipart is a transitive dependency of FastAPI, used internally to process multipart form data (UploadFile, File fields). Our codebase uses it indirectly via services/ui/paths/avatar.py, where users can upload image files as avatars — exactly the vector these DoS and smuggling flaws target.
