### PR TITLE
Adopt Gufo Loader

### DIFF
--- a/commands/discovery.py
+++ b/commands/discovery.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # discovery commands
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -14,7 +14,6 @@ from functools import partial
 # NOC modules
 from noc.core.management.base import BaseCommand
 from noc.core.mongo.connection import connect
-from noc.core.handler import get_handler
 from noc.inv.models.resourcegroup import ResourceGroup
 from noc.inv.models.networksegment import NetworkSegment
 from noc.core.scheduler.scheduler import Scheduler
@@ -23,6 +22,7 @@ from noc.core.cache.base import cache
 from noc.core.span import Span, get_spans
 from noc.core.service.pub import publish
 from noc.core.comp import smart_bytes
+from noc.services.discovery.jobs.base import get_discovery_job
 
 
 class Command(BaseCommand):
@@ -138,7 +138,7 @@ class Command(BaseCommand):
         else:
             job_args = {Job.ATTR_ID: "fakeid", Job.ATTR_KEY: mo.id}
         job_args["_checks"] = checks
-        job = get_handler(jcls)(scheduler, job_args)
+        job = get_discovery_job(jcls)(scheduler, job_args)
         if job.context_version:
             ctx_key = job.get_context_cache_key()
             self.print("Loading job context from %s" % ctx_key)

--- a/core/handler.py
+++ b/core/handler.py
@@ -1,38 +1,16 @@
 # ----------------------------------------------------------------------
 #  Handler management utilities
 # ----------------------------------------------------------------------
-#  Copyright (C) 2007-2020 The NOC Project
+#  Copyright (C) 2007-2026 The NOC Project
 #  See LICENSE for details
 # ----------------------------------------------------------------------
 
+# Python modules
+from typing import Any
+
 # Third-party modules
-import cachetools
+from gufo.loader import ImportPathResolver
 
-_CCACHE = {}  # handler -> object cache
-
-
-@cachetools.cached(_CCACHE)
-def get_handler(path):
-    """
-    Converts full path (i.e. "module.name" to python object)
-    performing all necessary imports
-    :param path:
-    :returns: Python object referenced by path
-    """
-    if callable(path):
-        return path
-    try:
-        mod_name, obj_name = path.rsplit(".", 1)
-    except ValueError:
-        raise ImportError("%s isn't valid handler name" % path)
-    # Load module
-    try:
-        m = __import__(str(mod_name), {}, {}, [str(obj_name)])  # if unicode - TypeError
-    except ImportError as e:
-        raise ImportError("Cannot load handler '%s': %s" % (path, e))
-    # Get attribute
-    try:
-        c = getattr(m, obj_name)
-    except AttributeError as e:
-        raise ImportError("Cannot get handler attribute '%s': %s" % (path, e))
-    return c
+# Fallback get_handler. Should be eventually replaced with
+# properly-typed handlers.
+get_handler = ImportPathResolver[Any]()

--- a/core/scheduler/scheduler.py
+++ b/core/scheduler/scheduler.py
@@ -21,7 +21,6 @@ from gufo.loader import ImportPathResolver
 
 # NOC modules
 from noc.core.mongo.connection import get_db
-from noc.core.handler import get_handler
 from noc.core.threadpool import ThreadPoolExecutor
 from noc.core.perf import metrics
 from noc.config import config

--- a/core/scheduler/scheduler.py
+++ b/core/scheduler/scheduler.py
@@ -17,6 +17,7 @@ from time import perf_counter
 # Third-party modules
 import pymongo.errors
 from pymongo import DeleteOne, UpdateOne
+from gufo.loader import ImportPathResolver
 
 # NOC modules
 from noc.core.mongo.connection import get_db
@@ -25,6 +26,8 @@ from noc.core.threadpool import ThreadPoolExecutor
 from noc.core.perf import metrics
 from noc.config import config
 from .job import Job
+
+get_job_handler = ImportPathResolver[type[Job]]()
 
 
 class Scheduler:
@@ -269,7 +272,7 @@ class Scheduler:
             for job in qs:
                 job[Job.ATTR_SAMPLE] = self.sample
                 try:
-                    jcls = get_handler(job[Job.ATTR_CLASS])
+                    jcls = get_job_handler(job[Job.ATTR_CLASS])
                     yield jcls(self, job)
                 except ImportError as e:
                     self.logger.error("Invalid job class %s", job[Job.ATTR_CLASS])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ node = [
   "gufo-liftbridge==0.2.0",
   "gufo-snmp==0.12.0",
   "gufo_noc_speedup==0.1.0",
+  "gufo-loader==2.0.0",
 ]
 ping = ["gufo-ping==0.7.0"]
 prod-tools = [

--- a/services/discovery/jobs/base.py
+++ b/services/discovery/jobs/base.py
@@ -15,13 +15,14 @@ import types
 import operator
 from io import StringIO
 from time import perf_counter
+from typing import Any
 
 # Third-party modules
 import bson
 import cachetools
 import orjson
 from pymongo import UpdateOne
-from typing import Any
+from gufo.loader import ImportPathResolver
 
 # NOC modules
 from noc.core.scheduler.periodicjob import PeriodicJob
@@ -1637,3 +1638,6 @@ class PolicyDiscoveryCheck(DiscoveryCheck):
 
     def has_required_script(self):
         return super().has_required_script() or self.get_policy() != ["script"]
+
+
+get_discovery_job = ImportPathResolver[type[MODiscoveryJob]]()

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -9,7 +9,7 @@
 import pytest
 
 # NOC modules
-from noc.core.handler import get_handler, _CCACHE
+from noc.core.handler import get_handler
 
 
 def my_simple_handler():
@@ -42,19 +42,9 @@ def test_callable():
     assert h == my_simple_handler
 
 
-def test_cache():
-    name = "noc.tests.test_handler.my_cached_handler"
-    assert (name,) not in _CCACHE
-    h = get_handler(name)
-    assert h
-    assert (name,) in _CCACHE
-    hh = get_handler(name)
-    assert h == hh
-
-
 def test_invalid_format():
     # Invalid format
-    with pytest.raises(ImportError):
+    with pytest.raises(ValueError):
         get_handler("xxx")
 
 


### PR DESCRIPTION
Adopt Gufo Loader — type-safe plugin imports

Replace the legacy noc.core.handler.get_handler() with ImportPathResolver from gufo-loader.

## Changes

- core/handler.py — remove get_handler() stub (cachetools cached function, ~30 lines) and export get_handler = ImportPathResolverAny instead
- core/scheduler/scheduler.py — import ImportPathResolver[type[Job]](), use it for job class resolution on demand
- pyproject.toml — add gufo-loader>=2.0 to the dependency list

## Motivation

Previously handler resolution was a hand-rolled wrapper around import() + getattr() with no type hints: callers got Any and had no IDE support for resolving what class would be returned at runtime. ImportPathResolver[T] gives us that for free — parameterised over the expected return type, so call sites like get_job_handlerJob resolve to type[Job] in static analysis.

This PR is the first slice of a broader migration: we will replace all remaining manual _import_path_resolver call-sites with typed ImportPathResolver... instances and add per-handler type generics over time, so each usage gets full inference instead of bare Any.