### PR TITLE
Fix fm.dispositionrules mistype

### DIFF
--- a/collections/fm.dispositionrules/NOC/SA/Join_Activator_Pool_NOC/SA/Activator_Pool_Degraded_clear_.json
+++ b/collections/fm.dispositionrules/NOC/SA/Join_Activator_Pool_NOC/SA/Activator_Pool_Degraded_clear_.json
@@ -10,7 +10,7 @@
     }],
     "default_action": "C",
     "stop_processing": true,
-    "vars": [
+    "vars_op": [
         {
             "name": "pool_sessions",
             "condition": "eq",

--- a/collections/fm.dispositionrules/NOC/SA/Join_Activator_Pool_NOC/SA/Activator_Pool_Degraded_raise_.json
+++ b/collections/fm.dispositionrules/NOC/SA/Join_Activator_Pool_NOC/SA/Activator_Pool_Degraded_raise_.json
@@ -10,7 +10,7 @@
     }],
     "default_action": "R",
     "stop_processing": true,
-    "vars": [
+    "vars_op": [
         {
             "name": "pool_sessions",
             "condition": "eq",

--- a/collections/fm.dispositionrules/Network/BGP/Peer_State_Changed_Network/BGP/Peer_Down_clear_peer_down_.json
+++ b/collections/fm.dispositionrules/Network/BGP/Peer_State_Changed_Network/BGP/Peer_Down_clear_peer_down_.json
@@ -10,7 +10,7 @@
     }],
     "default_action": "C",
     "stop_processing": false,
-    "vars": [
+    "vars_op": [
         {
             "name": "to_state",
             "condition": "ne",

--- a/collections/fm.dispositionrules/Network/BGP/Peer_State_Changed_Network/BGP/Peer_Down_raise_.json
+++ b/collections/fm.dispositionrules/Network/BGP/Peer_State_Changed_Network/BGP/Peer_Down_raise_.json
@@ -10,7 +10,7 @@
     }],
     "default_action": "R",
     "stop_processing": true,
-    "vars": [
+    "vars_op": [
         {
             "name": "to_state",
             "condition": "ne",

--- a/collections/fm.dispositionrules/Network/BGP/Peer_State_Changed_Network/BGP/Prefix_Limit_Exceeded_clear_maxprefix_.json
+++ b/collections/fm.dispositionrules/Network/BGP/Peer_State_Changed_Network/BGP/Prefix_Limit_Exceeded_clear_maxprefix_.json
@@ -10,7 +10,7 @@
     }],
     "default_action": "C",
     "stop_processing": false,
-    "vars": [
+    "vars_op": [
         {
             "name": "to_state",
             "condition": "eq",

--- a/collections/fm.dispositionrules/Network/EIGRP/Neighbor_Up_Network/EIGRP/Neighbor_Down_dispose_.json
+++ b/collections/fm.dispositionrules/Network/EIGRP/Neighbor_Up_Network/EIGRP/Neighbor_Down_dispose_.json
@@ -10,7 +10,7 @@
     }],
     "default_action": "C",
     "stop_processing": false,
-    "vars": [
+    "vars_op": [
         {
             "name": "vars",
             "condition": "exists",

--- a/collections/fm.dispositionrules/Network/Link/Link_Down_Network/Link/Link_Down_dispose_.json
+++ b/collections/fm.dispositionrules/Network/Link/Link_Down_Network/Link/Link_Down_dispose_.json
@@ -10,7 +10,7 @@
     }],
     "default_action": "R",
     "stop_processing": false,
-    "vars": [
+    "vars_op": [
         {
             "name": "interface",
             "affected_model": "inv.Interface",

--- a/collections/fm.dispositionrules/Network/Link/Link_Up_Network/Link/Link_Down_Clear_Link_Down_.json
+++ b/collections/fm.dispositionrules/Network/Link/Link_Up_Network/Link/Link_Down_Clear_Link_Down_.json
@@ -10,7 +10,7 @@
     }],
     "default_action": "C",
     "stop_processing": false,
-    "vars": [
+    "vars_op": [
         {
             "name": "interface",
             "affected_model": "inv.Interface",

--- a/collections/fm.dispositionrules/Network/OSPF/Neighbor_Up_Network/OSPF/Neighbor_Down_dispose_.json
+++ b/collections/fm.dispositionrules/Network/OSPF/Neighbor_Up_Network/OSPF/Neighbor_Down_dispose_.json
@@ -10,7 +10,7 @@
     }],
     "default_action": "C",
     "stop_processing": false,
-    "vars": [
+    "vars_op": [
         {
             "name": "vars",
             "condition": "exists",

--- a/fm/models/dispositionrule.py
+++ b/fm/models/dispositionrule.py
@@ -436,7 +436,7 @@ class DispositionRule(Document):
         if self.conditions:
             r["conditions"] = [m.json_data for m in self.conditions]
         if self.vars_op:
-            r["vars"] = [m.json_data for m in self.vars_op]
+            r["vars_op"] = [m.json_data for m in self.vars_op]
             r["vars_conditions_op"] = self.vars_conditions_op
         if self.replace_rule:
             r |= {


### PR DESCRIPTION
Fixes mismatch between DispositionRuleData.json_data() serialization and collection files for vars → vars_op field rename. The model was still writing "vars" key while all reference data uses "vars_op", causing broken disposition rule evaluation.

## Changes

- fm/models/dispositionrule.py: fix json_data() to output "vars_op" instead of "vars"
- collections/fm.dispositionrules: update 9 collection rules to use "vars_op" key