### PR TITLE
Dockerfile: install pnpm into build-ui target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ RUN\
     bzip2 \
     curl \
     ca-certificates \
+    && corepack enable \
+    && corepack prepare pnpm@10.33.0 --activate \
+    && (cd ui/ && pnpm install --frozen-lockfile) \    
     && ./scripts/build/build-ui
 
 # Base layer containing system packages and requirements


### PR DESCRIPTION
Install pnpm via corepack in the build-ui Docker image instead of relying on a globally installed npm or missing package manager.

## Changes:
- Enable corepack and install pinned pnpm@10.33.0
- Run pnpm install --frozen-lockfile under ui/ to resolve Frontend dependencies during build

## Rationale:
- Ensures reproducible UI builds across environments
- Freezes dependency versions via the lockfile
- No global npm required in the builder stage