### PR TITLE
Rename RemovedInNOC2601Warning to RemovedInNOC26Warning

### DIFF
--- a/config.py
+++ b/config.py
@@ -30,7 +30,7 @@ from noc.core.config.base import (
     ValueRewrite,
     DeprecatedValue,
 )
-from noc.core.deprecations import RemovedInNOC2601Warning
+from noc.core.deprecations import RemovedInNOC26Warning
 from noc.core.config.params import (
     StringParameter,
     MapParameter,
@@ -1291,17 +1291,17 @@ class Config(BaseConfig):
 
 config = Config(
     rewrites=[
-        PrefixRewrite("redpanda", "kafka", deprecation=RemovedInNOC2601Warning),
+        PrefixRewrite("redpanda", "kafka", deprecation=RemovedInNOC26Warning),
         ValueRewrite(
             "msgstream.client_class",
             "noc.core.msgstream.redpanda.RedPandaClient",
             "noc.core.msgstream.kafka.KafkaClient",
-            deprecation=RemovedInNOC2601Warning,
+            deprecation=RemovedInNOC26Warning,
         ),
         DeprecatedValue(
             "msgstream.client_class",
             "noc.core.msgstream.liftbridge.LiftBridgeClient",
-            deprecation=RemovedInNOC2601Warning,
+            deprecation=RemovedInNOC26Warning,
         ),
     ]
 )

--- a/core/deprecations.py
+++ b/core/deprecations.py
@@ -31,4 +31,4 @@ class RemovedInNOC2501Warning(DeprecationWarning):
 
 
 class RemovedInNOC26Warning(PendingDeprecationWarning):
-    """Features to be removed in NOC 26.1."""
+    """Features to be removed in NOC 26."""

--- a/core/deprecations.py
+++ b/core/deprecations.py
@@ -30,5 +30,5 @@ class RemovedInNOC2501Warning(DeprecationWarning):
     """Features to be removed in NOC 25.1."""
 
 
-class RemovedInNOC2601Warning(PendingDeprecationWarning):
+class RemovedInNOC26Warning(PendingDeprecationWarning):
     """Features to be removed in NOC 26.1."""


### PR DESCRIPTION
Rename `RemovedInNOC2601Warning` → `RemovedInNOC26Warning`.

Starting from NOC 26, generations are no longer split within a single year (had 24.1 / 24.2 — different releases of the same calendar year, which was confusing). New versioning uses flat numbering: NOC 26, NOC 27, etc. This PR renames the deprecation warning to match.