### PR TITLE
run-dev script

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.202.3/containers/docker-existing-dockerfile
 {
 	"name": "NOC",
+	"containerName": "noc-dev",
 	"runArgs": [
 		"--init"
 	],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,6 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.202.3/containers/docker-existing-dockerfile
 {
 	"name": "NOC",
-	"containerName": "noc-dev",
 	"runArgs": [
 		"--init"
 	],

--- a/scripts/run-dev
+++ b/scripts/run-dev
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Find the devcontainer associated with the current working tree.
+CID=$(
+    docker ps -q \
+        --filter "label=devcontainer.local_folder=$(pwd)"
+)
+# Container must be running
+if [ -z "$CID" ]; then
+    echo "No running devcontainer found for $(pwd)" >&2
+    exit 7
+fi
+# Run command inside the container
+exec docker exec "$CID" "$@"


### PR DESCRIPTION
## Purpose
Introduces `scripts/run-dev` — a shell wrapper to run commands inside the active NOC devcontainer without manually finding the container ID.

## Usage
```bash
# Run any command in the running devcontainer
./scripts/run-dev python -c "print(42)"

# Start backend services
./scripts/run-dev ./manage.py migrate
\ # Or via alias — recommended:
alias run-dev="/path/to/noc/scripts/run-dev"
```