### PR TITLE
Show DeprecationWarning summary in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,22 +33,7 @@ _stats = None
 _durations: defaultdict[str, int] = defaultdict(int)
 _counts: defaultdict[str, int] = defaultdict(int)
 _start_times: dict[str, int] = {}
-_original_showwarning: (
-    Callable[[Warning, type[Warning], str, int, TextIO | None, str | None], None] | None
-) = None
-_deprecations: defaultdict[type[DeprecationWarning], int] = defaultdict(int)
-
-
-def pytest_sessionstart(session: pytest.Session) -> None:
-    global _original_showwarning
-    _original_showwarning = warnings.showwarning
-    # Show all deprecation warnings
-    warnings.simplefilter("always", DeprecationWarning)
-    warnings.showwarning = _show_warning
-
-
-def pytest_sessionfinish(session: pytest.Session, exitstatus: pytest.ExitCode) -> None:
-    warnings.showwarning = _original_showwarning
+_deprecations: defaultdict[str, int] = defaultdict(int)
 
 
 def _setup_config() -> None:
@@ -89,6 +74,13 @@ def pytest_runtest_teardown(item: pytest.Item, nextitem: pytest.Item):
     func_name: str = item.originalname or item.name.split("[")[0]
     _durations[func_name] += duration
     _counts[func_name] += 1
+
+
+def pytest_warning_recorded(
+    warning_message: warnings.WarningMessage, when: str, nodeid: str, location: Any
+) -> None:
+    msg = f"{warning_message.category.__name__}[{warning_message.message}]"
+    _deprecations[msg] += 1
 
 
 def with_timing(name: str):
@@ -146,8 +138,8 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     terminalreporter.write_line(f"Total: {total:.3f}s")
     if _deprecations:
         terminalreporter.write_sep("=", "Deprecations summary")
-        for dep_type, count in sorted(_deprecations.items(key=lambda x: x[1], reverse=True)):
-            terminalreporter.write_line(f"{dep_type:<20}: {count}")
+        for dep_msg, count in sorted(_deprecations.items(), key=lambda x: x[1], reverse=True):
+            terminalreporter.write_line(f"{dep_msg:<40}: {count}")
     _stats = terminalreporter.stats
 
 
@@ -340,18 +332,3 @@ def _load_data(data: list[dict[str, Any]]) -> None:
     for k in m2m:
         for r in m2m[k]:
             getattr(d, k).add(r)
-
-
-def _show_warning(
-    message: Warning,
-    category: type[Warning],
-    filename: str,
-    lineno: int,
-    file: TextIO | None = None,
-    line: str | None = None,
-) -> None:
-    """Collect deprecation warnings"""
-    global _deprecations
-    if issubclass(category, DeprecationWarning):
-        _deprecations[type(message)] += 1
-    return _original_showwarning(message, category, filename, lineno, file=file, line=line)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,11 +7,12 @@
 
 # Python modules
 from collections import defaultdict
-from typing import Any
+from typing import Any, TextIO
 from time import perf_counter_ns
 import functools
 import os
 import sys
+import warnings
 
 # Third-party modules
 import pytest
@@ -32,6 +33,20 @@ _stats = None
 _durations: defaultdict[str, int] = defaultdict(int)
 _counts: defaultdict[str, int] = defaultdict(int)
 _start_times: dict[str, int] = {}
+_original_showwarning = None
+_deprecations: defaultdict[type[DeprecationWarning], int] = defaultdict(int)
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    global _original_showwarning
+    _original_showwarning = warnings.showwarning
+    # Show all deprecation warnings
+    warnings.simplefilter("always", DeprecationWarning)
+    warnings.showwarning = _show_warning
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: pytest.ExitCode) -> None:
+    warnings.showwarning = _original_showwarning
 
 
 def _setup_config() -> None:
@@ -127,6 +142,10 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
             label = f"{label} (x{other_count})"
         terminalreporter.write_line(f"{label:<40} {other_time:.3f}s ({percent:.3f}%)")
     terminalreporter.write_line(f"Total: {total:.3f}s")
+    if _deprecations:
+        terminalreporter.write_sep("=", "Deprecations summary")
+        for dep_type, count in sorted(_deprecations.items(key=lambda x: x[1], reverse=True)):
+            terminalreporter.write_line(f"{dep_type:<20}: {count}")
     _stats = terminalreporter.stats
 
 
@@ -319,3 +338,18 @@ def _load_data(data: list[dict[str, Any]]) -> None:
     for k in m2m:
         for r in m2m[k]:
             getattr(d, k).add(r)
+
+
+def _show_warning(
+    message: Warning,
+    category: type[Warning],
+    filename: str,
+    lineno: int,
+    file: TextIO | None = None,
+    line: str | None = None,
+):
+    """Collect deprecation warnings"""
+    global _deprecations
+    if issubclass(category, DeprecationWarning):
+        _deprecations[type(message)] += 1
+    return _original_showwarning(message, category, filename, lineno, file=file, line=line)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,7 +141,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
         total = sum(_deprecations.values())
         for dep_msg, count in sorted(_deprecations.items(), key=lambda x: x[1], reverse=True):
             terminalreporter.write_line(f"{dep_msg:<40}: {count}")
-        terminalreporter.write_line(f"Total: {total:.5d}")
+        terminalreporter.write_line(f"Total: {total}")
     _stats = terminalreporter.stats
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,7 +140,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
         terminalreporter.write_sep("=", "Deprecations summary")
         total = sum(_deprecations.values())
         for dep_msg, count in sorted(_deprecations.items(), key=lambda x: x[1], reverse=True):
-            terminalreporter.write_line(f"{dep_msg:<40}: {count}")            
+            terminalreporter.write_line(f"{dep_msg:<40}: {count}")
         terminalreporter.write_line(f"Total: {total:.5d}")
     _stats = terminalreporter.stats
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,8 +138,10 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     terminalreporter.write_line(f"Total: {total:.3f}s")
     if _deprecations:
         terminalreporter.write_sep("=", "Deprecations summary")
+        total = sum(_deprecations.values())
         for dep_msg, count in sorted(_deprecations.items(), key=lambda x: x[1], reverse=True):
-            terminalreporter.write_line(f"{dep_msg:<40}: {count}")
+            terminalreporter.write_line(f"{dep_msg:<40}: {count}")            
+        terminalreporter.write_line(f"Total: {total:.5d}")
     _stats = terminalreporter.stats
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@
 
 # Python modules
 from collections import defaultdict
-from typing import Any, TextIO
+from typing import Any, TextIO, Callable
 from time import perf_counter_ns
 import functools
 import os
@@ -33,7 +33,9 @@ _stats = None
 _durations: defaultdict[str, int] = defaultdict(int)
 _counts: defaultdict[str, int] = defaultdict(int)
 _start_times: dict[str, int] = {}
-_original_showwarning = None
+_original_showwarning: (
+    Callable[[Warning, type[Warning], str, int, TextIO | None, str | None], None] | None
+) = None
 _deprecations: defaultdict[type[DeprecationWarning], int] = defaultdict(int)
 
 
@@ -347,7 +349,7 @@ def _show_warning(
     lineno: int,
     file: TextIO | None = None,
     line: str | None = None,
-):
+) -> None:
     """Collect deprecation warnings"""
     global _deprecations
     if issubclass(category, DeprecationWarning):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@
 
 # Python modules
 from collections import defaultdict
-from typing import Any, TextIO, Callable
+from typing import Any
 from time import perf_counter_ns
 import functools
 import os


### PR DESCRIPTION
## Purpose

Tests in NOC often emit deprecation warnings that get buried in CI logs, making them invisible to the team. This PR adds a summary table at the end of every test run so all deprecations are visible at a glance.

## What changed

- : hook `pytest_warning_recorded` collects warning category + message into `_deprecations` dict
- `pytest_terminal_summary` now prints a sorted table (by count, descending): `Deprecations summary` section

## How it looks

On every `pytest` run the tail of output now includes:

```
========================================
Deprecations summary
PendingDeprecationWarning[...]: 12
UserWarning[...]: 5
DeprecationWarning[...]: 3
========================================
```

## Notes

- Currently accumulates **all** warning categories — not just `DeprecationWarning`. This is intentional: it shows the full picture of noisy test output and lets us prioritise fixes. Can be narrowed later if needed.
- Summary is printed after timing stats so it doesn't interfere with existing reporting.