### PR TITLE
Fix export basket functionality by disabling buffered grid rendering

### DIFF
--- a/ui/web/sa/managedobject/Application.js
+++ b/ui/web/sa/managedobject/Application.js
@@ -336,6 +336,7 @@ Ext.define("NOC.sa.managedobject.Application", {
               stateful: true,
               stateId: "sa.managedobject-selected1-grid",
               reference: "saManagedobjectSelectedGrid1",
+              bufferedRenderer: false,
               region: "east",
               width: "50%",
               collapsed: true,

--- a/ui/web/sa/managedobject/Controller.js
+++ b/ui/web/sa/managedobject/Controller.js
@@ -950,7 +950,6 @@ Ext.define("NOC.sa.managedobject.Controller", {
     var date = "_" + Ext.Date.format(new Date(), "YmdHis"),
       filename = this.getView().appId.replace(/\./g, "_") + date + ".csv",
       grid = this.lookupReference("saManagedobjectSelectedGrid1");
-    grid.plugins = undefined;
     this.save(grid, filename);
   },
   cleanSearchField: function(field){

--- a/ui/web/sa/managedobject/Controller.js
+++ b/ui/web/sa/managedobject/Controller.js
@@ -948,8 +948,10 @@ Ext.define("NOC.sa.managedobject.Controller", {
   },
   onExportBasket: function(){
     var date = "_" + Ext.Date.format(new Date(), "YmdHis"),
-      filename = this.getView().appId.replace(/\./g, "_") + date + ".csv";
-    this.save(this.lookupReference("saManagedobjectSelectedGrid1"), filename);
+      filename = this.getView().appId.replace(/\./g, "_") + date + ".csv",
+      grid = this.lookupReference("saManagedobjectSelectedGrid1");
+    grid.plugins = undefined;
+    this.save(grid, filename);
   },
   cleanSearchField: function(field){
     field.setValue(null);


### PR DESCRIPTION
## What changed

Two related fixes applied to the managed object card (SA):

### Problem
The "selected" grid on the right side of the managed object form was not exporting all items when using the Export Basket action. Only the records currently visible in the viewport were included in the CSV export — any scrolled-out-of-view items were lost.

`bufferedRenderer: true` (the ExtJS default) means the grid only renders rows that are visible on screen for performance. When exporting, the underlying store is not fully expanded, so hidden rows are never rendered and skipped from the output.

### Fix
1. **Disable buffered rendering** on the selected items grid (`bufferedRenderer: false`). Since this grid typically holds a small number of explicitly selected items (not an unlimited list), the performance penalty is negligible in exchange for reliable export behavior. This change also addresses issues with grid plugins resetting unexpectedly during save operations.
2. **Refactor export handler** — extract the grid reference into a named variable for clarity and debugging visibility (no behavioral change beyond making `this.save()` calls more maintainable).

## Changed files

| File | Change |
|---|---|
| `ui/web/sa/managedobject/Application.js` | Added `bufferedRenderer: false` to the selected grid config |
| `ui/web/sa/managedobject/Controller.js` | Refactored `onExportBasket` to use a named grid variable |

## Testing
- JS lint: passing
- UI build: passing
