### PR TITLE
Models: Refine typing

### DIFF
--- a/models.py
+++ b/models.py
@@ -21,7 +21,7 @@ DB_MODEL_INSTANCE = DjangoModel | Document
 DB_MODEL_TYPE = type[DjangoModel] | type[Document]
 
 
-def is_document(obj: DB_MODEL_INSTANCE) -> bool:
+def is_document(obj: DB_MODEL_INSTANCE | DB_MODEL_TYPE) -> bool:
     """
     Check object is mongoengine document.
 
@@ -34,7 +34,7 @@ def is_document(obj: DB_MODEL_INSTANCE) -> bool:
     return getattr(obj, "_is_document", False)
 
 
-def get_model_id(obj: DB_MODEL_INSTANCE) -> str:
+def get_model_id(obj: DB_MODEL_INSTANCE | DB_MODEL_TYPE) -> str:
     """
     Returns model id for instance object.
 


### PR DESCRIPTION
This PR refines typing in noc/models.py by widening the accepted type of two public helpers that inspect or identify DB models.

## Changes:

- `is_document():` Now accepts both an instance (DB_MODEL_INSTANCE) and a class (DB_MODEL_TYPE) as argument, instead of only an instance.
- `get_model_id()`: Same change — accepts DB_MODEL_INSTANCE | DB_MODEL_TYPE.
- 
This allows callers that hold a model class (rather than an instance) to reuse these helpers without type errors, reducing the need to instantiate or cast before calling. No logic changes — only the signature widened using union typing.