### PR TITLE
Route Ext stores through NOC.api and drop grid load masks

### DIFF
--- a/ui/web/core/label/LabelField.js
+++ b/ui/web/core/label/LabelField.js
@@ -440,7 +440,6 @@ Ext.define("NOC.core.label.LabelField", {
 
     Ext.destroy(
       me.componentLayout,
-      me.loadMask,
       me.floatingDescendants,
     );
   },

--- a/ui/web/js/override.js
+++ b/ui/web/js/override.js
@@ -231,6 +231,74 @@ Ext.define("EXTJS-15862.tab.Bar", {
 //   },
 // });
 
+//
+// Disable the per-grid/tree load mask globally. Store traffic now flows
+// through NOC.api and is indicated by the shared #noc-api-bar spinner,
+// so the local overlay is redundant.
+//
+Ext.override(Ext.panel.Table, {
+  loadMask: false,
+});
+
+//
+// Route Ext.data.Connection.request (and therefore Ext.Ajax and all
+// Ext.data.proxy.Ajax / Rest proxies used by stores and combos) through
+// NOC.api.requestLegacy — a fetch-based transport. This eliminates the
+// last XHR path in the app and unifies store/proxy traffic with the
+// #noc-api-bar in-flight indicator.
+//
+Ext.override(Ext.data.Connection, {
+  request: function(options){
+    options = options || {};
+    var scope = options.scope,
+      origSuccess = options.success,
+      origFailure = options.failure,
+      origCallback = options.callback,
+      url = options.url,
+      hasBody = options.jsonData !== undefined
+                || options.rawData !== undefined
+                || options.params !== undefined,
+      method = (options.method || (hasBody ? "POST" : "GET")).toUpperCase(),
+      params = options.params;
+
+    // GET requests carry params in the query string, not the body
+    if(method === "GET" && params !== undefined){
+      var qs = typeof params === "string" ? params : Ext.Object.toQueryString(params);
+      if(qs){
+        url = url + (url.indexOf("?") === -1 ? "?" : "&") + qs;
+      }
+      params = undefined;
+    }
+
+    NOC.api.requestLegacy({
+      url: url,
+      method: method,
+      jsonData: options.jsonData,
+      params: params,
+      defaultPostHeader: options.defaultPostHeader,
+      success: function(response){
+        if(typeof origSuccess === "function"){
+          origSuccess.call(scope, response, options);
+        }
+        if(typeof origCallback === "function"){
+          origCallback.call(scope, options, true, response);
+        }
+      },
+      failure: function(response){
+        if(typeof origFailure === "function"){
+          origFailure.call(scope, response, options);
+        }
+        if(typeof origCallback === "function"){
+          origCallback.call(scope, options, false, response);
+        }
+      },
+    });
+
+    // Stub handle: current fetch-based transport does not expose abort()
+    return {abort: Ext.emptyFn, isLoading: function(){ return false; }};
+  },
+});
+
 Ext.define("Override.grid.header.Container", {
   override: "Ext.grid.header.Container",
     

--- a/ui/web/maintenance/maintenance/ObjectsPanel.js
+++ b/ui/web/maintenance/maintenance/ObjectsPanel.js
@@ -21,7 +21,6 @@ Ext.define("NOC.maintenance.maintenance.ObjectsPanel", {
   stateful: true,
   autoDestroy: true,
   stateId: "sa.managedobjectselector-objects",
-  loadMask: true,
   defaultListenerScope: true,
   store: {
     type: "maintenance.objects",


### PR DESCRIPTION
## Summary

Eliminate the last XHR path in the application — all AJAX requests from stores, combo boxes, and forms now route through `NOC.api.requestLegacy` (fetch-based transport with the global `#noc-api-bar` in-flight indicator).

Per-grid/tree load masks are disabled globally since visual feedback is now provided by the central spinner.

## Changes

### `ui/web/js/override.js` (+68)
- **Global `loadMask: false`.** One-liner override on `Ext.panel.Table` that disables local overlay masks for every grid, tree grid, and panel in the application.
- **Route `Ext.data.Connection.request` through `NOC.api`.** Override intercepts all requests from `Ext.Ajax`, `Ext.data.proxy.Ajax`, and `Ext.data.proxy.Rest`. Serializes GET params into the query string (handles existing `?`), forwards request body (`jsonData`, `params`, `defaultPostHeader`), and maps success/failure/callback callbacks back to ExtJS convention.
- Returns a stub `{ abort: Ext.emptyFn, isLoading: () => false }` — current fetch-based transport does not expose per-request abort; note for future AbortController integration.

### `ui/web/core/label/LabelField.js` (−1)

Remove `me.loadMask` from the destroy chain — redundant after global override.

### `ui/web/maintenance/maintenance/ObjectsPanel.js` (−1)

Drop explicit `loadMask: true` config — overridden globally anyway.

## Regression Checklist

- [x] Grid data loads (open any tree-grid, expand nodes)
- [x] Form submissions with POST/PUT bodies (config edit, login credential change)
- [x] Combo box dynamic lookups (store-backed combos)
- [x] `#noc-api-bar` spinner appears/disappears during request lifecycle

## Notes

- `Ext.Ajax.request({ rawData: "..." })` — body may be lost if any caller uses this pattern. Grep of the codebase shows no such callers, but worth verifying before merge.
- Per-request `abort()` is stubbed — cannot cancel individual requests. AbortController integration is a follow-up.
