### PR TITLE
Replace fsspec with Gufo Blob

### DIFF
--- a/commands/beef.py
+++ b/commands/beef.py
@@ -562,9 +562,8 @@ class Command(BaseCommand):
             self.print("Configs for tests %s", test_config)
         r = []
         with storage.get_storage() as blob:
-            file_filter = []
             for beef_path in blob.scan(path):
-                if beef_path.endswith(".yml") or not file_filter(beef_path):
+                if beef_path.endswith(".yml"):
                     continue
                 try:
                     beef = self.get_beef(storage, beef_path)

--- a/commands/beef.py
+++ b/commands/beef.py
@@ -116,7 +116,6 @@ class Command(BaseCommand):
         connect()
         from noc.inv.models.resourcegroup import ResourceGroup
         from noc.dev.models.spec import Spec
-        from fs import open_fs
 
         class FakeSpec:
             def __init__(self, name):
@@ -126,8 +125,8 @@ class Command(BaseCommand):
         # Get spec data
         if ":" in spec:
             path, file = smart_text(os.path.dirname(spec)), smart_text(os.path.basename(spec))
-            spec_data = open_fs(path).open(file)
-            sp = Spec.from_json(spec_data.read())
+            with ExtStorage.from_url(path) as blob:
+                sp = Spec.from_json(blob[file])
             sp.quiz = FakeSpec("Ad-Hoc")
             sp.profile = FakeSpec("Generic.Host")
         else:
@@ -285,19 +284,18 @@ class Command(BaseCommand):
         for storage in storages:
             self.print(f"\n{'=' * 20}Storage: {storage.name}{'=' * 20}\n")
             r = ["GUID,Profile,Vendor,Platform,Version,Description,SpecUUID,Changed,Path"]
-            st_fs = storage.open_fs()
-            for step in st_fs.walk("", exclude=["*.yml"]):
-                if not step.files:
-                    continue
-                for file in step.files:
-                    try:
-                        beef = Beef.load(storage, file.make_path(step.path))
-                    except ValueError:
-                        self.print(f"Error when loading beef file {file.make_path(step.path)}")
+            with storage.get_storage() as blob:
+                for file in blob.scan(""):
+                    if file.endswith(".yml"):
                         continue
-                    r += [
+                    try:
+                        beef = Beef.load(storage, file)
+                    except ExtStorage.StorageErrors:
+                        self.print(f"Error when loading beef file {file}")
+                        continue
+                    r.append(
                         ",".join(
-                            [
+                            (
                                 beef.uuid,
                                 beef.box.profile,
                                 beef.box.vendor,
@@ -306,10 +304,10 @@ class Command(BaseCommand):
                                 beef.description,
                                 beef.spec or "",  # For ad-hoc specs
                                 beef.changed,
-                                file.make_path(step.path),
-                            ]
+                                file,
+                            )
                         )
-                    ]
+                    )
             # Dump output
             self.stdout.write("\n".join(r) + "\n")
 
@@ -404,25 +402,23 @@ class Command(BaseCommand):
             cfg = self.get_config(config_storage, config_path)
         # Create test
         test_storage = self.get_storage(test_storage, beef_test=True)
-        with test_storage.open_fs() as fs:
+        with test_storage.get_storage() as blob:
             # Load beef
             for beef, t_config in beefs:
                 # beef, t_config = beefs[(storage, path)]
                 config = cfg or t_config
                 # Create test directory
                 save_path = test_path or beef._path
-                if fs.exists(save_path):
+                if save_path in blob:
                     self.print(f"Path {save_path} already exists. Skipping...")
                     continue
                 self.print(f"Creating {test_storage}:{save_path}")
-                fs.makedirs(smart_text(save_path))
                 # Write config
                 # config = cfg[beef.uuid][0] if beef.uuid in cfg else cfg[""][0]
                 config["beef"] = str(beef.uuid)
                 self.print(f"Writing {test_storage}:{save_path}/test-config.yml")
-                fs.writebytes(
-                    smart_text(os.path.join(save_path, "test-config.yml")),
-                    smart_bytes(yaml.dump(config, default_flow_style=False)),
+                blob[smart_text(os.path.join(save_path, "test-config.yml"))] = smart_bytes(
+                    yaml.dump(config, default_flow_style=False)
                 )
                 # Write beef
                 self.print(f"Writing {test_storage}:{save_path}/beef.json.bz2")
@@ -440,9 +436,8 @@ class Command(BaseCommand):
             test_st = test_storage
         if not cfg:
             # Get config
-            with test_st.open_fs() as fs:
-                data = fs.readbytes(smart_text(os.path.join(test_path, "test-config.yml")))
-                cfg = yaml.safe_load(data)
+            data = test_st.read_bytes(smart_text(os.path.join(test_path, "test-config.yml")))
+            cfg = yaml.safe_load(data)
         # Get beef
         beef_path = os.path.join(test_path, "beef.json.bz2")
         beef = self.get_beef(test_st, beef_path)
@@ -493,8 +488,7 @@ class Command(BaseCommand):
             data = bz2.compress(orjson.dumps(tc))
             rn = os.path.join(test_path, f"{n:04d}.{test['script']}.json.bz2")
             self.print(f"[{n:04d}] Writing {rn}")
-            with test_st.open_fs() as fs:
-                fs.writebytes(smart_text(rn), data)
+            test_st.write_bytes(smart_text(rn), data)
 
     def get_storage(self, name, beef=False, beef_test=False, beef_test_config=False):
         """
@@ -543,9 +537,8 @@ class Command(BaseCommand):
 
     def get_config(self, storage=None, path=None):
         config_st = self.get_storage(storage, beef_test_config=True)
-        with config_st.open_fs() as fs:
-            cfg = fs.readbytes(smart_text(path))
-            return yaml.safe_load(cfg)
+        cfg = config_st.read_bytes(smart_text(path))
+        return yaml.safe_load(cfg)
 
     def beef_filter(self, storage=None, path="/", uuids=None, profile=None, with_tests=False):
         """
@@ -568,35 +561,31 @@ class Command(BaseCommand):
             test_config = self.get_test_configs(storage)
             self.print("Configs for tests %s", test_config)
         r = []
-        st_fs = storage.open_fs()
-        file_filter = []
-        if st_fs.isfile(path):
-            file_filter = [os.path.basename(path)]
-            path = os.path.dirname(path)
-        for beef_path in st_fs.walk.files(
-            path=smart_text(path), exclude=["*.yml"], filter=file_filter
-        ):
-            try:
-                beef = self.get_beef(storage, beef_path)
-            except ValueError:
-                self.print(f"Bad beef on path {beef_path}")
-                continue
-            if uuids and beef.uuid not in uuids:
-                continue
-            if profile and beef.profile != "profile":
-                continue
-            if test_config and beef.uuid in test_config:
-                tc = test_config[beef.uuid]
-            elif test_config and os.path.dirname(beef_path) in test_config:
-                tc = test_config[os.path.dirname(beef_path)]
-            else:
-                tc = None
-            # r[(st_fs, beef_path)] = (beef, tc)
-            beef._path = beef_path
-            r += [(beef, tc)]
+        with storage.get_storage() as blob:
+            file_filter = []
+            for beef_path in blob.scan(path):
+                if beef_path.endswith(".yml") or not file_filter(beef_path):
+                    continue
+                try:
+                    beef = self.get_beef(storage, beef_path)
+                except ValueError:
+                    self.print(f"Bad beef on path {beef_path}")
+                    continue
+                if uuids and beef.uuid not in uuids:
+                    continue
+                if profile and beef.profile != "profile":
+                    continue
+                if test_config and beef.uuid in test_config:
+                    tc = test_config[beef.uuid]
+                elif test_config and os.path.dirname(beef_path) in test_config:
+                    tc = test_config[os.path.dirname(beef_path)]
+                else:
+                    tc = None
+                beef._path = beef_path
+                r.append((beef, tc))
         return r
 
-    def get_test_configs(self, storage):
+    def get_test_configs(self, storage: ExtStorage):
         """
         Getting test config from beef folder
         * base config - first yaml
@@ -604,23 +593,12 @@ class Command(BaseCommand):
 
         """
         r = {}
-        with storage.open_fs() as fs:
-            r["/"] = yaml.safe_load(fs.readbytes("test-config.yml"))
-            for step in fs.walk.walk(filter=["*.yml"]):
-                for f in step.files:
-                    data = yaml.safe_load(fs.readbytes(os.path.join(step.path, f.name)))
-                    r[data.get("beef", step.path)] = data
-                if not step.files:
-                    base_path = list(os.path.split(step.path))
-                    while base_path:
-                        path = os.path.join(*base_path)
-                        if path in r:
-                            r[step.path] = r[path]
-                            break
-                        base_path.pop()
-                    if step.path not in r:
-                        # default
-                        r[step.path] = r["/"]
+        with storage.get_storage() as blob:
+            r["/"] = yaml.safe_load(blob["test-config.yml"])
+            for f in blob.scan(""):
+                if f.endswith(".yml"):
+                    data = yaml.safe_load(blob[f])
+                    r[data.get("beef", f)] = data
         return r
 
     rx_arg = re.compile(r"^(?P<name>[a-zA-Z][a-zA-Z0-9_]*)(?P<op>:?=@?)(?P<value>.*)$")

--- a/commands/script.py
+++ b/commands/script.py
@@ -12,12 +12,13 @@ import pprint
 import datetime
 import re
 from collections import namedtuple
-
-# Third-party modules
-import orjson
 import yaml
 import codecs
 import uuid
+from pathlib import Path
+
+# Third-party modules
+import orjson
 
 # NOC modules
 from noc.core.management.base import BaseCommand
@@ -170,10 +171,7 @@ class Command(BaseCommand):
         if beef_output:
             bdata = self.get_beef(scr, obj)
             beef = Beef.from_json(bdata)
-            storage = StorageStub("osfs:///")
-            sdata = beef.get_data(decode=True)
-            with storage.open_fs() as fs:
-                fs.writebytes(beef_output, smart_bytes(yaml.safe_dump(sdata)))
+            Path(beef_output).write_text(yaml.safe_dump(beef.get_data(decode=True)))
 
     def get_object(self, object_name):
         """
@@ -504,16 +502,3 @@ class JSONObject:
 
     def get_controller_credentials(self):
         return None
-
-
-class StorageStub:
-    def __init__(self, url):
-        self.url = url
-
-    def open_fs(self):
-        from fs import open_fs
-
-        return open_fs(self.url)
-
-    class Error(Exception):
-        pass

--- a/core/script/beef.py
+++ b/core/script/beef.py
@@ -1,12 +1,11 @@
 # ----------------------------------------------------------------------
 # Beef API
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
 # Python modules
-import os
 from collections import namedtuple
 import bisect
 import itertools
@@ -19,6 +18,7 @@ from typing import NamedTuple
 
 # NOC modules
 from noc.core.comp import smart_text, smart_bytes
+from noc.main.models.extstorage import ExtStorage
 
 Box = namedtuple("Box", ["profile", "vendor", "platform", "version"])
 CLIFSM = namedtuple("CLIFSM", ["state", "reply"])
@@ -167,7 +167,7 @@ class Beef:
         }
 
     @staticmethod
-    def compress_gzip(data):
+    def compress_gzip(data: bytes) -> bytes:
         import gzip
 
         f = StringIO()
@@ -176,13 +176,13 @@ class Beef:
         return f.getvalue()
 
     @staticmethod
-    def compress_bz2(data):
+    def compress_bz2(data: bytes) -> bytes:
         import bz2
 
         return bz2.compress(data)
 
     @staticmethod
-    def decompress_gzip(data):
+    def decompress_gzip(data: bytes) -> bytes:
         import gzip
 
         f = StringIO(data)
@@ -190,12 +190,12 @@ class Beef:
             return z.read()
 
     @staticmethod
-    def decompress_bz2(data):
+    def decompress_bz2(data: bytes) -> bytes:
         import bz2
 
         return bz2.decompress(data)
 
-    def save(self, storage, path):
+    def save(self, storage: ExtStorage, path: str) -> tuple[int, int]:
         """
         Write beef to external storage. Compression depends on extension.
         Following extensions are supported:
@@ -209,19 +209,15 @@ class Beef:
         """
         data = orjson.dumps(self.get_data())
         usize = len(data)
-        dir_path = os.path.dirname(path)
         if path.endswith(".gz"):
             data = self.compress_gzip(data)
         elif path.endswith(".bz2"):
             data = self.compress_bz2(data)
         csize = len(data)
         try:
-            with storage.open_fs() as fs:
-                if dir_path and dir_path != "/":
-                    fs.makedirs(dir_path, recreate=True)
-                fs.writebytes(path, data)
-        except storage.Error as e:
-            raise OSError(str(e))
+            storage.write_bytes(path, data)
+        except storage.StorageErrors as e:
+            raise OSError(str(e)) from e
         return csize, usize
 
     @classmethod
@@ -234,21 +230,17 @@ class Beef:
         """
         if isinstance(storage, str):
             # Load from URL
-            from fs import open_fs
-            from fs.errors import FSError
-
             try:
-                with open_fs(storage) as fs:
-                    data = fs.readbytes(smart_text(path))
-            except FSError as e:
-                raise OSError(str(e))
+                with ExtStorage.from_url(storage) as blob:
+                    data = blob[smart_text(path)]
+            except ExtStorage.StorageErrors as e:
+                raise OSError(str(e)) from e
         else:
             # Load from external storage
             try:
-                with storage.open_fs() as fs:
-                    data = fs.readbytes(smart_text(path))
-            except storage.Error as e:
-                raise OSError(str(e))
+                data = storage.read_bytes(path)
+            except ExtStorage.StorageErrors as e:
+                raise OSError(str(e)) from e
         if path.endswith(".gz"):
             data = cls.decompress_gzip(data)
         elif path.endswith(".json.bz2"):

--- a/main/models/extstorage.py
+++ b/main/models/extstorage.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # ExtStorage model
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2025 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -9,10 +9,11 @@
 from threading import Lock
 from typing import Optional
 import operator
+from pathlib import Path
 
 # Third-party modules
 import cachetools
-from fsspec import url_to_fs
+from gufo.blob.sync import BlobBase, open_blob, BlobError
 from mongoengine.document import Document
 from mongoengine.fields import StringField
 from bson import ObjectId
@@ -49,6 +50,8 @@ class ExtStorage(Document):
     _id_cache = cachetools.TTLCache(maxsize=100, ttl=60)
     _name_cache = cachetools.TTLCache(maxsize=100, ttl=60)
 
+    StorageErrors = (BlobError, KeyError)
+
     def __str__(self):
         return self.name
 
@@ -62,9 +65,96 @@ class ExtStorage(Document):
     def get_by_name(cls, name: str) -> Optional["ExtStorage"]:
         return ExtStorage.objects.filter(name=name).first()
 
-    def open_fs(self):
-        fs, _ = url_to_fs(self.url)
-        return fs
+    @classmethod
+    def from_url(cls, url: str) -> BlobBase:
+        """
+        Open blob from url.
+
+        Args:
+            url: Blob URL
+
+        Returns:
+            Blob object
+
+        Raises:
+            StorageErrors: on any error
+        """
+        return open_blob(url)
+
+    def get_storage(self) -> BlobBase:
+        """
+        Get Blob object.
+
+        To be used in context managers like:
+
+        ```python
+        with my_storage.storage as blob:
+            ...
+        ```
+
+        Returns:
+            BlobBase subclass instance
+        """
+        return open_blob(self.url)
+
+    def read_bytes(self, path: str) -> bytes:
+        """
+        Read bytes from path.
+
+        Args:
+            path: File path.
+
+        Returns:
+            Received bytes.
+
+        Raises:
+            StorageErrors: on error.
+        """
+        with self.get_storage() as blob:
+            return blob[path]
+
+    def write_bytes(self, path: str | Path, data: bytes) -> None:
+        """
+        Write data to storage.
+
+        Args:
+            path: File path.
+            data: data to store.
+
+        Raises:
+            StorageErorrs on any error.
+        """
+        with self.get_storage() as blob:
+            blob[str(path)] = data
+
+    @classmethod
+    def read_bytes_from_ref(cls, ref: str) -> bytes:
+        """
+        Read bytes from reference.
+
+        Reference has a form of `<name>:<path>`. Where:
+
+        - `name` - ExtStorage name.
+        - `path` - Resource path inside the storage.
+
+        Args:
+            ref: Reference.
+
+        Returns:
+            Received bytes.
+
+        Raises:
+            StorageErorrs: On any error.
+        """
+        if ":" not in ref:
+            msg = f"Invalid ref format: {ref}"
+            raise BlobError(msg)
+        storage_name, path = ref.split(":", 1)
+        storage = cls.get_by_name(storage_name)
+        if not storage:
+            msg = f"Invalid storage: {storage_name}"
+            raise BlobError(msg)
+        return storage.read_bytes(path)
 
     @property
     def is_config_mirror(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,6 @@ node = [
   "siphash24==1.8",
   "demjson3==3.0.6",
   "dnspython==2.7.0",
-  "fsspec==2026.6.0",
   "geojson==3.2.0",
   "geopy==2.4.1",
   "gufo-http==0.7.0",
@@ -117,6 +116,7 @@ node = [
   "gufo-snmp==0.12.0",
   "gufo_noc_speedup==0.1.0",
   "gufo-loader==2.0.1",
+  "gufo-blob==0.2.0",
 ]
 ping = ["gufo-ping==0.7.0"]
 prod-tools = [

--- a/sa/models/managedobject.py
+++ b/sa/models/managedobject.py
@@ -84,6 +84,7 @@ from noc.aaa.models.group import Group
 from noc.main.models.pool import Pool
 from noc.main.models.timepattern import TimePattern
 from noc.main.models.remotesystem import RemoteSystem
+from noc.main.models.extstorage import ExtStorage
 from noc.vc.models.l2domain import L2Domain
 from noc.main.models.label import Label
 from noc.inv.models.networksegment import NetworkSegment
@@ -140,7 +141,7 @@ from noc.core.change.policy import change_tracker
 from noc.core.resourcegroup.decorator import resourcegroup
 from noc.core.confdb.tokenizer.loader import loader as tokenizer_loader
 from noc.core.confdb.engine.base import Engine
-from noc.core.comp import smart_text, DEFAULT_ENCODING
+from noc.core.comp import smart_text
 from noc.main.models.glyph import Glyph
 from noc.core.topology.types import (
     ShapeOverlayPosition,
@@ -1690,15 +1691,10 @@ class ManagedObject(NOCModel):
             self.object_profile.config_mirror_storage.name,
             path,
         )
-        dir_path = os.path.dirname(path)
         try:
-            with storage.open_fs() as fs:
-                if dir_path and dir_path != "/" and not fs.isdir(dir_path):
-                    logger.debug("[%s] Ensuring directory: %s", self.name, dir_path)
-                    fs.makedirs(dir_path, recreate=True)
-                logger.debug("[%s] Mirroring %d bytes", self.name, len(data))
-                fs.writebytes(path, data.encode(encoding=DEFAULT_ENCODING))
-        except storage.Error as e:
+            logger.debug("[%s] Mirroring %d bytes", self.name, len(data))
+            storage.write_bytes(path, data.encode())
+        except ExtStorage.StorageErrors as e:
             logger.error("[%s] Failed to mirror config: %s", self.name, e)
 
     def to_validate(self, changed):

--- a/services/discovery/jobs/box/config.py
+++ b/services/discovery/jobs/box/config.py
@@ -1,13 +1,14 @@
 # ---------------------------------------------------------------------
 # Config check
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
 # NOC modules
 from noc.core.error import NOCError
 from noc.services.discovery.jobs.base import DiscoveryCheck
+from noc.main.models.extstorage import ExtStorage
 
 
 class ConfigCheck(DiscoveryCheck):
@@ -73,7 +74,7 @@ class ConfigCheck(DiscoveryCheck):
                     diagnostic="CLI" if e.remote_code in self.error_map else None,
                 )
 
-    def get_config_download(self):
+    def get_config_download(self) -> str | None:
         self.logger.info("Downloading config from external storage")
         # Check storage is set
         storage = self.object.object_profile.config_download_storage
@@ -93,9 +94,8 @@ class ConfigCheck(DiscoveryCheck):
         # Download
         self.logger.info("Downloading from %s:%s", storage.name, path)
         try:
-            with storage.open_fs() as fs, fs.open(path) as f:
-                return f.read()
-        except storage.Error as e:
+            return storage.read_bytes(path).decode()
+        except ExtStorage.StorageErrors as e:
             self.logger.info("Failed to download: %s", e)
             return None
 

--- a/services/web/apps/inv/inv/plugins/opm.py
+++ b/services/web/apps/inv/inv/plugins/opm.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # inv.inv opm plugin
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2025 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -245,19 +245,15 @@ class OPMPlugin(InvPlugin):
 
     def get_beef(self, obj: Object) -> dict[str, Any]:
         box = obj.get_box()
-        d = box.get_data("debug", "beef_path", scope="get_params")
-        if not d:
+        ref = box.get_data("debug", "beef_path", scope="get_params")
+        if not ref:
             self.logger.info("beef_path is not configured")
             return {}
-        storage_name, path = d.split(":", 1)
-        self.logger.info("Trying to get beef fron %s", d)
-        storage = ExtStorage.get_by_name(storage_name)
-        if not storage:
-            self.logger.info("Storage %s is not found, skipping", storage_name)
+        try:
+            return orjson.loads(ExtStorage.read_bytes_from_ref(ref))
+        except ExtStorage.StorageErrors as e:
+            self.logger.error("Failed to download: %s", e)
             return {}
-        fs = storage.open_fs()
-        with fs.open(path) as fp:
-            return orjson.loads(fp.read())
 
     @staticmethod
     def _get_card(obj: Object) -> int:

--- a/services/web/apps/inv/inv/plugins/pconf.py
+++ b/services/web/apps/inv/inv/plugins/pconf.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # inv.inv pconf plugin
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2025 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -490,18 +490,14 @@ class PConfPlugin(InvPlugin):
 
     def get_pconf_beef(self, obj: Object) -> None:
         box = obj.get_box()
-        d = box.get_data("debug", "beef_path", scope="get_params")
-        if not d:
+        ref = box.get_data("debug", "beef_path", scope="get_params")
+        if not ref:
             return None
-        storage_name, path = d.split(":", 1)
-        self.logger.info("Trying to get beef fron %s", d)
-        storage = ExtStorage.get_by_name(storage_name)
-        if not storage:
-            self.logger.info("Storage %s is not found, skipping", storage_name)
+        try:
+            return orjson.loads(ExtStorage.read_bytes_from_ref(ref))
+        except ExtStorage.StorageErrors as e:
+            self.logger.error("Failed to download: %s", e)
             return None
-        fs = storage.open_fs()
-        with fs.open(path) as fp:
-            return orjson.loads(fp.read())
 
     @classmethod
     def get_model_name(cls, obj: Object) -> str:

--- a/tests/collections/test_fm_eventclassificationrule.py
+++ b/tests/collections/test_fm_eventclassificationrule.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # EventClassificationRule test
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2025 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -12,7 +12,7 @@ import os
 # Third-party modules
 import pytest
 import orjson
-import fsspec
+from gufo.blob.sync import open_blob
 
 # NOC modules
 from noc.services.classifier.ruleset import RuleSet
@@ -58,18 +58,15 @@ def iter_json_loader(urls):
     if not urls:
         urls = []
     for url in urls:
-        fs, url_path = fsspec.url_to_fs(url)
-        for path, _, files in fs.walk(url_path):
-            for name in files:
-                if not name.endswith(".json"):
+        with open_blob(url) as blob:
+            for key in blob.scan(""):
+                if not key.endswith(".json"):
                     continue
-                path = os.path.join(path, name)
-                with fs.open(os.path.join(path, name), mode="rb") as f:
-                    data = orjson.loads(f.read())
+                data = orjson.loads(blob[key])
                 if not isinstance(data, list):
                     data = [data]
                 for i in data:
-                    yield path, i
+                    yield key, i
 
 
 @pytest.fixture(scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,9 +16,9 @@ import warnings
 
 # Third-party modules
 import pytest
-import fsspec
 import orjson
 from django.db import models
+from gufo.blob.sync.base import open_blob
 
 # NOC modules
 from noc.config import config
@@ -272,13 +272,11 @@ def _load_mibs():
 @with_timing("load_fixtures")
 def _load_fixtures():
     for url in config.tests.fixtures_paths:
-        fs, fs_path = fsspec.url_to_fs(url)
-        for path, _, files in fs.walk(fs_path):
-            for name in files:
-                if not name.endswith(".json"):
+        with open_blob(url) as blob:
+            for key in blob.scan(""):
+                if not key.endswith(".json"):
                     continue
-                with fs.open(os.path.join(path, name), mode="rb") as f:
-                    data = orjson.loads(f.read())
+                data = orjson.loads(blob[key])
                 if not isinstance(data, list):
                     data = [data]
                 for i in data:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ import warnings
 import pytest
 import orjson
 from django.db import models
-from gufo.blob.sync.base import open_blob
+from gufo.blob.sync import open_blob
 
 # NOC modules
 from noc.config import config

--- a/tests/test_beef.py
+++ b/tests/test_beef.py
@@ -1,14 +1,13 @@
 # ----------------------------------------------------------------------
 # Beef test
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2018 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
 # Python modules
 import re
 import bz2
-import os
 
 # Third-party modules
 import pytest

--- a/tests/test_beef.py
+++ b/tests/test_beef.py
@@ -13,7 +13,7 @@ import os
 # Third-party modules
 import pytest
 import orjson
-import fsspec
+from gufo.blob.sync import open_blob
 
 # NOC modules
 from noc.config import config
@@ -34,33 +34,21 @@ class ServiceStub:
         setup_asyncio()
 
 
-def get_beef_tests():
-    r = []
+def get_beef_tests() -> list[tuple[str, str]]:
+    r: list[tuple[str, str]] = []
     paths = config.tests.beef_paths or []
     for url in paths:
-        fs, url_path = fsspec.url_to_fs(url)
-        for path, _, files in fs.walk(url_path):
-            for name in files:
-                path = os.path.join(path, name)
-                if rx_tc.match(path):
-                    r += [(fs, path)]
+        with open_blob(url) as blob:
+            for key in blob.scan(""):
+                if rx_tc.match(key):
+                    r.append((url, key))
     return r
 
 
-def beef_test_name(v):
-    if isinstance(v, tuple):
-        return v[1]
-    return None
-
-
-@pytest.fixture(params=get_beef_tests(), ids=beef_test_name)
-def beef_test(request):
-    return request.param
-
-
-def test_beef(beef_test):
-    fs, path = beef_test
-    test = orjson.loads(bz2.decompress(fs.readbytes(path)))
+@pytest.mark.parametrize(("url", "path"), get_beef_tests())
+def test_beef(url: str, path: str):
+    with open_blob(url) as blob:
+        test = orjson.loads(bz2.decompress(blob[path]))
     service = ServiceStub(pool="default")
     # Load script
     script = test["script"]

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -6,7 +6,6 @@
 # ----------------------------------------------------------------------
 
 # Python modules
-import os.path
 from collections import defaultdict
 
 # Third-party modules

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # Discovery test
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -11,9 +11,9 @@ from collections import defaultdict
 
 # Third-party modules
 import pytest
-import fsspec
 import yaml
 import cachetools
+from gufo.blob.sync import open_blob
 
 # NOC modules
 from noc.config import config
@@ -101,20 +101,16 @@ def get_discovery_configs():
     paths = config.tests.beef_paths or []
     for n, url in enumerate(paths):
         pool_name = "DP%04d" % (n + 1)
-        fs, url_path = fsspec.url_to_fs(url)
-        num = 0
-        for path, _, files in fs.walk(url_path):
-            for name in files:
-                if name != "test-discovery.yml":
+        with open_blob(url) as blob:
+            num = 0
+            for key in blob.scan(""):
+                if key != "test-discovery.yml":
                     continue
-                file_path = os.path.join(path, name)
-                with fs.open(file_path, mode="rb") as f:
-                    data = yaml.safe_load(f.read())
-                    # name = os.path.basename(os.path.dirname(path))
-                    m = num + 1
-                    address = "10.%d.%d.%d" % ((m >> 16) & 0xFF, (m >> 8) & 0xFF, m & 0xFF)
-                    beef_path = os.path.join(os.path.dirname(file_path), "beef.json.bz2")
-                    r += [(name, address, pool_name, url, beef_path, data)]
+                data = yaml.safe_load(blob[key])
+                # name = os.path.basename(os.path.dirname(path))
+                m = num + 1
+                address = "10.%d.%d.%d" % ((m >> 16) & 0xFF, (m >> 8) & 0xFF, m & 0xFF)
+                r += [(key, address, pool_name, url, key, data)]
                 num += 1
     return r
 


### PR DESCRIPTION
Migrate external storage access from `fsspec`/`fs` libraries to the in-house `gufo-blob` library. This removes an external dependency and aligns storage operations across the platform.

### Key Changes
- **main/models/extstorage.py**: Full rewrite of storage access layer — replace `url_to_fs` with `gufo.blob.sync.open_blob`. New methods: `get_storage()`, `read_bytes()`, `write_bytes()`, `read_bytes_from_ref()`. Added `StorageErrors` exception group.
- **commands/beef.py**: Migrate from `storage.open_fs()` context manager to ExtStorage methods. Refactor list/create/build commands to use direct blob API.
- **commands/script.py**: Replace `StorageStub` class with standard library `Path.write_text()`.
- **core/script/beef.py**: Update `Beef.save()` and `Beef.load()` to use ExtStorage directly. Add type hints.
- **sa/models/managedobject.py**: Migrate `mirror_config()` to use `storage.write_bytes()`. Remove `DEFAULT_ENCODING` import (UTF-8 is default).
- **services/discovery/jobs/box/config.py**: Use `storage.read_bytes().decode()` for config downloads.
- **services/web/apps/inv/inv/plugins/opm.py**, **pconf.py**: Simplify beef loading via `ExtStorage.read_bytes_from_ref()`.
- **pyproject.toml**: Drop `fsspec==2026.6.0`, add `gufo-blob==0.2.0`.

### Notable Implementation Details
- Gufo Blob uses dict-like access (`blob[path]`) instead of fs.open().
- Connection lifecycle: `get_storage()` opens blob, used as context manager.
- `read_bytes_from_ref()` class method supports `<storage_name>:<path>` references for convenient cross-storage lookups.
- Directory creation responsibility shifted from explicit `makedirs` to (assumed) automatic in gufo-blob.
