### PR TITLE
Application: BoundView wrapper for add_view method

### DIFF
--- a/services/web/base/application.py
+++ b/services/web/base/application.py
@@ -81,6 +81,34 @@ def view(url, access, url_name=None, menu=None, method=None, validate=None, api=
     return decorate
 
 
+class BoundView:
+    """
+    Callable wrapper for a bound method that prevents descriptor binding.
+
+    Views are stored as attributes on application classes. A regular function
+    assigned to a class becomes a descriptor and receives the application
+    instance as the first argument when called. This is not desired for views
+    backed by already bound methods, because the method instance is already
+    captured by the bound method itself.
+
+    This wrapper keeps the callable object semantics of ``functools.partial``
+    used previously: calls are forwarded directly to the original bound method
+    without adding an extra ``self`` argument.
+
+    Attributes:
+        func: Original bound method.
+        __self__: Instance the original method is bound to.
+    """
+
+    def __init__(self, func):
+        self.func = func
+        self.__self__ = func.__self__
+        functools.update_wrapper(self, func)
+
+    def __call__(self, *args, **kwargs):
+        return self.func(*args, **kwargs)
+
+
 class ApplicationBase(type):
     """
     Application metaclass. Registers application class to site
@@ -164,11 +192,8 @@ class Application(metaclass=ApplicationBase):
         validate=None,
         api=False,
     ):
-        # Create function wrapper to avoid binding as method
-        def f(*args, **kwargs):
-            return func(*args, **kwargs)
-
-        functools.update_wrapper(f, func)
+        # wrap view
+        f = BoundView(func)
         # Add to class
         cls.add_to_class(
             name,

--- a/services/web/base/application.py
+++ b/services/web/base/application.py
@@ -164,10 +164,11 @@ class Application(metaclass=ApplicationBase):
         validate=None,
         api=False,
     ):
-        # Decorate function to clear attributes
-        f = functools.partial(func)
-        f.__self__ = func.__self__
-        f.__name__ = func.__name__
+        # Create function wrapper to avoid binding as method
+        def f(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        functools.update_wrapper(f, func)
         # Add to class
         cls.add_to_class(
             name,


### PR DESCRIPTION
Replace functools.partial with an explicit BoundView class wrapper in services/web/base/application.py.
    
## Why?

This change addresses a FutureWarning that appears on Python 3.13+:

```
[py.warnings] /opt/noc/services/web/base/application.py:490: FutureWarning:
functools.partial will be a method descriptor in future Python versions;
wrap it in staticmethod() if you want to preserve the old behavior
```

In upcoming Python versions, functools.partial objects will become data descriptors — meaning assigning one to a class attribute triggers automatic binding (Jython already does this). The previous code relied on functools.partial(func) preserving callable-object semantics when stored as a class attribute, which is about to break.

## How?

A new BoundView class replaces the partial-based pattern:

- Wraps the bound method and forwards calls directly via call
- Sets self so the router can still resolve the application instance
- Uses functools.update_wrapper for proper introspection attributes (name, doc, etc.)

The change is purely internal — semantically equivalent to the previous behavior, just without depending on undefined partial-as-descriptor semantics.

## Changes

- services/web/base/application.py: +30 / -4
- Added BoundView class
- Replaced functools.partial(func) + manual attribute copy with BoundView(func) in add_view()
 