### PR TITLE
run-dev: git worktree support

### DIFF
--- a/scripts/run-dev
+++ b/scripts/run-dev
@@ -1,14 +1,60 @@
 #!/bin/sh
 
-# Find the devcontainer associated with the current working tree.
+set -eu
+
+# Must be inside a git working tree.
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "Current directory is not inside a git working tree" >&2
+    exit 6
+fi
+
+# Current worktree root.
+WT_ROOT=$(git rev-parse --show-toplevel)
+
+# Main repository root.
+COMMON_DIR=$(git rev-parse --git-common-dir)
+REPO_ROOT=$(cd "$COMMON_DIR/.." && pwd)
+
+# Find devcontainer attached to the main repository.
 CID=$(
     docker ps -q \
-        --filter "label=devcontainer.local_folder=$(pwd)"
+        --filter "label=devcontainer.local_folder=$REPO_ROOT"
 )
-# Container must be running
+
 if [ -z "$CID" ]; then
-    echo "No running devcontainer found for $(pwd)" >&2
+    echo "No running devcontainer found for $REPO_ROOT" >&2
     exit 7
 fi
-# Run command inside the container
-exec docker exec "$CID" "$@"
+
+# Find repository mount inside the container.
+CONTAINER_ROOT=$(
+    docker inspect \
+        --format '{{range .Mounts}}{{if eq .Source "'"$REPO_ROOT"'"}}{{println .Destination}}{{end}}{{end}}' \
+        "$CID"
+)
+
+if [ -z "$CONTAINER_ROOT" ]; then
+    echo "Repository is not mounted inside the devcontainer" >&2
+    exit 8
+fi
+
+# Worktree relative to repository.
+if [ "$WT_ROOT" = "$REPO_ROOT" ]; then
+    REL_WT=""
+else
+    REL_WT=${WT_ROOT#"$REPO_ROOT"/}
+fi
+
+# Current directory relative to worktree.
+if [ "$PWD" = "$WT_ROOT" ]; then
+    REL_PWD=""
+else
+    REL_PWD=${PWD#"$WT_ROOT"/}
+fi
+
+WORKDIR=$CONTAINER_ROOT
+
+[ -n "$REL_WT" ] && WORKDIR="$WORKDIR/$REL_WT"
+[ -n "$REL_PWD" ] && WORKDIR="$WORKDIR/$REL_PWD"
+
+exec docker exec -w "$WORKDIR" "$CID" "$@"

--- a/scripts/run-dev
+++ b/scripts/run-dev
@@ -27,15 +27,18 @@ if [ -z "$CID" ]; then
 fi
 
 # Find repository mount inside the container.
-CONTAINER_ROOT=$(
+if ! CONTAINER_ROOT=$(
     docker inspect \
         --format '{{range .Mounts}}{{if eq .Source "'"$REPO_ROOT"'"}}{{println .Destination}}{{end}}{{end}}' \
         "$CID"
-)
+); then
+    echo "Failed to inspect devcontainer $CID" >&2
+    exit 8
+fi
 
 if [ -z "$CONTAINER_ROOT" ]; then
     echo "Repository is not mounted inside the devcontainer" >&2
-    exit 8
+    exit 9
 fi
 
 # Worktree relative to repository.
@@ -54,7 +57,12 @@ fi
 
 WORKDIR=$CONTAINER_ROOT
 
-[ -n "$REL_WT" ] && WORKDIR="$WORKDIR/$REL_WT"
-[ -n "$REL_PWD" ] && WORKDIR="$WORKDIR/$REL_PWD"
+if [ -n "$REL_WT" ]; then
+    WORKDIR="$WORKDIR/$REL_WT"
+fi
+
+if [ -n "$REL_PWD" ]; then
+    WORKDIR="$WORKDIR/$REL_PWD"
+fi
 
 exec docker exec -w "$WORKDIR" "$CID" "$@"


### PR DESCRIPTION
Enable `scripts/run-dev` to work correctly from git worktrees, not just the main repository root. This is essential for developers using worktrees for isolated feature branches or parallel development.

**Key changes:**
- Resolve the main repository root via `git rev-parse --git-common-dir` instead of assuming `$(pwd)` points to the repo root
- Detect devcontainers by labeling them with the main repository path (all worktrees share the same container)
- Use `docker inspect` to determine where the repository is actually mounted inside the container
- Calculate the correct working directory by combining: container mount point → relative worktree subpath → relative current directory

**Notable implementation details:**
- `--is-inside-work-tree` guard catches running outside any git tree (exit code 6)
- `docker inspect --format '{{range .Mounts}}...'` extracts the actual mount destination
- POSIX-compliant parameter expansion `${WT_ROOT#"$REPO_ROOT"/}` for relative path calculation
- Proper error handling for missing devcontainer (exit 7), unmounted repo (exit 8)