### PR TITLE
Remove smart_text("\x00") usage

### DIFF
--- a/sa/profiles/DLink/DxS/get_lldp_neighbors.py
+++ b/sa/profiles/DLink/DxS/get_lldp_neighbors.py
@@ -164,7 +164,7 @@ class Script(BaseScript):
                 neigh["remote_port"] = smart_text(neigh["remote_port"]).rstrip("\x00")
             for i in neigh:
                 if isinstance(neigh[i], str):
-                    neigh[i] = neigh[i].rstrip(smart_text("\x00"))
+                    neigh[i] = neigh[i].rstrip("\x00")
             if neigh["remote_capabilities"]:
                 neigh["remote_capabilities"] = int(
                     "".join(

--- a/sa/profiles/DLink/DxS_Smart/get_lldp_neighbors.py
+++ b/sa/profiles/DLink/DxS_Smart/get_lldp_neighbors.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # DLink.DxS_Smart.get_lldp_neighbors
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2021 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -13,7 +13,6 @@ from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igetlldpneighbors import IGetLLDPNeighbors
 from noc.core.mac import MAC
 from noc.core.lldp import LLDP_CHASSIS_SUBTYPE_MAC, LLDP_PORT_SUBTYPE_MAC
-from noc.core.comp import smart_text
 from noc.core.snmp.render import render_bin
 
 
@@ -91,7 +90,7 @@ class Script(BaseScript):
                 neigh["remote_port"] = neigh["remote_port"].decode("utf8")
             for i in neigh:
                 if isinstance(neigh[i], str):
-                    neigh[i] = neigh[i].rstrip(smart_text("\x00"))
+                    neigh[i] = neigh[i].rstrip("\x00")
             if neigh["remote_capabilities"]:
                 neigh["remote_capabilities"] = int(
                     "".join(

--- a/sa/profiles/ECI/HiFOCuS/get_inventory.py
+++ b/sa/profiles/ECI/HiFOCuS/get_inventory.py
@@ -64,7 +64,7 @@ class Script(BaseScript):
                     "number": "0",
                     "vendor": "ECI",
                     "part_no": [hw_descr, catalog_num],
-                    "serial": serial.split(smart_text("\x00"))[0],
+                    "serial": serial.split("\x00")[0],
                     "revision": rev,
                     "description": "",
                 }

--- a/sa/profiles/EdgeCore/ES/get_lldp_neighbors.py
+++ b/sa/profiles/EdgeCore/ES/get_lldp_neighbors.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # EdgeCore.ES.get_lldp_neighbors
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -30,7 +30,6 @@ from noc.core.lldp import (
     LLDP_CAP_STATION_ONLY,
     lldp_caps_to_bits,
 )
-from noc.core.comp import smart_text
 
 
 class Script(BaseScript):
@@ -139,7 +138,7 @@ class Script(BaseScript):
                         remote_port = binascii.unhexlify("".join(match.group("p_id").split("-")))
                     except TypeError:
                         remote_port = str(match.group("p_id"))
-                    remote_port = remote_port.rstrip(smart_text("\x00"))
+                    remote_port = remote_port.rstrip("\x00")
                 else:
                     remote_port = match.group("p_id").strip()
                 n["remote_chassis_id"] = match.group("id")

--- a/sa/profiles/EdgeCore/ES/get_vlans.py
+++ b/sa/profiles/EdgeCore/ES/get_vlans.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # EdgeCore.ES.get_vlans
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -12,7 +12,6 @@ import operator
 # NOC Modules
 from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igetvlans import IGetVlans
-from noc.core.comp import smart_text
 
 
 class Script(BaseScript):
@@ -38,7 +37,7 @@ class Script(BaseScript):
             "1.3.6.1.2.1.17.7.1.4.3.1.1", bulk=True
         ):  # dot1qVlanStaticName
             o = oid.split(".")[-1]
-            result += [{"vlan_id": int(o), "name": v.strip().rstrip(smart_text("\x00"))}]
+            result += [{"vlan_id": int(o), "name": v.strip().rstrip("\x00")}]
         return sorted(result, key=operator.itemgetter("vlan_id"))
 
     def execute_cli(self):

--- a/sa/profiles/Generic/get_vlans.py
+++ b/sa/profiles/Generic/get_vlans.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # Generic.get_vlans
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2018 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -12,7 +12,6 @@ import operator
 from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igetvlans import IGetVlans
 from noc.core.mib import mib
-from noc.core.comp import smart_text
 
 
 class Script(BaseScript):
@@ -33,7 +32,7 @@ class Script(BaseScript):
             # dot1qVlanStaticName
             for oid, v in self.snmp.getnext(mib["Q-BRIDGE-MIB::dot1qVlanStaticName"]):
                 o = oid.split(".")[-1]
-                result += [{"vlan_id": int(oids[o]), "name": v.strip().rstrip(smart_text("\x00"))}]
+                result += [{"vlan_id": int(oids[o]), "name": v.strip().rstrip("\x00")}]
         else:
             tmp_vlan = []
             # dot1qVlanStaticName
@@ -41,7 +40,7 @@ class Script(BaseScript):
                 vlan_id = int(oid.split(".")[-1])
                 if vlan_id in tmp_vlan:
                     break
-                result += [{"vlan_id": vlan_id, "name": v.strip().rstrip(smart_text("\x00"))}]
+                result += [{"vlan_id": vlan_id, "name": v.strip().rstrip("\x00")}]
                 tmp_vlan += [vlan_id]
         if result:
             return sorted(result, key=operator.itemgetter("vlan_id"))

--- a/sa/profiles/Huawei/VRP/get_vlans.py
+++ b/sa/profiles/Huawei/VRP/get_vlans.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # Huawei.VRP.get_vlans
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2017 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -12,7 +12,6 @@ import re
 from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igetvlans import IGetVlans
 from noc.core.mib import mib
-from noc.core.comp import smart_text
 
 
 class Script(BaseScript):
@@ -31,7 +30,7 @@ class Script(BaseScript):
             # dot1qVlanStaticName
             for oid, v in self.snmp.getnext(mib["Q-BRIDGE-MIB::dot1qVlanStaticName"]):
                 o = oid.split(".")[-1]
-                result += [{"vlan_id": int(oids[o]), "name": v.strip().rstrip(smart_text("\x00"))}]
+                result += [{"vlan_id": int(oids[o]), "name": v.strip().rstrip("\x00")}]
         else:
             tmp_vlan = []
             # dot1qVlanStaticName
@@ -39,7 +38,7 @@ class Script(BaseScript):
                 vlan_id = int(oid.split(".")[-1])
                 if vlan_id in tmp_vlan:
                     break
-                result += [{"vlan_id": vlan_id, "name": v.strip().rstrip(smart_text("\x00"))}]
+                result += [{"vlan_id": vlan_id, "name": v.strip().rstrip("\x00")}]
                 tmp_vlan += [vlan_id]
         if result:
             return sorted(result, key=lambda x: x["vlan_id"])

--- a/sa/profiles/Juniper/JUNOS/get_capabilities.py
+++ b/sa/profiles/Juniper/JUNOS/get_capabilities.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # Juniper.JUNOS.get_capabilities
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2023 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -10,7 +10,6 @@ from noc.sa.profiles.Generic.get_capabilities import Script as BaseScript
 from noc.sa.profiles.Generic.get_capabilities import false_on_cli_error, false_on_snmp_error
 from noc.core.mib import mib
 from noc.core.validators import is_int
-from noc.core.comp import smart_text
 
 
 class Script(BaseScript):
@@ -45,7 +44,7 @@ class Script(BaseScript):
         Check box has lldp enabled
         """
         for v, r in self.snmp.getnext(mib["LLDP-MIB::lldpPortConfigTLVsTxEnable"], bulk=False):
-            if r != smart_text("\x00"):
+            if r != "\x00":
                 return True
         return False
 

--- a/sa/profiles/Opticin/OS/get_vlans.py
+++ b/sa/profiles/Opticin/OS/get_vlans.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # Opticin.OS.get_vlans
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -12,7 +12,6 @@ import operator
 # NOC Modules
 from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igetvlans import IGetVlans
-from noc.core.comp import smart_text
 
 
 class Script(BaseScript):
@@ -31,7 +30,7 @@ class Script(BaseScript):
             "1.3.6.1.2.1.17.7.1.4.3.1.1", bulk=True
         ):  # dot1qVlanStaticName
             o = oid.split(".")[-1]
-            result += [{"vlan_id": int(oids[o]), "name": v.strip().rstrip(smart_text("\x00"))}]
+            result += [{"vlan_id": int(oids[o]), "name": v.strip().rstrip("\x00")}]
         return sorted(result, key=operator.itemgetter("vlan_id"))
 
     def execute_cli(self):

--- a/sa/profiles/Planar/SDO3000/get_version.py
+++ b/sa/profiles/Planar/SDO3000/get_version.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # Planar.SDO3000.get_version
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2018 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -11,7 +11,6 @@ import re
 # NOC modules
 from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igetversion import IGetVersion
-from noc.core.comp import smart_text
 
 
 class Script(BaseScript):
@@ -41,10 +40,10 @@ class Script(BaseScript):
             return {
                 "vendor": "Planar",
                 "platform": platform.upper(),
-                "version": version.strip(smart_text("\x00")),
+                "version": version.strip("\x00"),
                 "attributes": {
-                    "Serial Number": serial.strip(smart_text("\x00")),
-                    "HW version": hw_ver.strip(smart_text("\x00")),
+                    "Serial Number": serial.strip("\x00"),
+                    "HW version": hw_ver.strip("\x00"),
                 },
             }
         except self.snmp.TimeOutError:

--- a/sa/profiles/TFortis/PSW/get_version.py
+++ b/sa/profiles/TFortis/PSW/get_version.py
@@ -1,5 +1,5 @@
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -10,7 +10,6 @@ import re
 from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igetversion import IGetVersion
 from noc.core.text import strip_html_tags
-from noc.core.comp import smart_text
 
 
 class Script(BaseScript):
@@ -35,7 +34,7 @@ class Script(BaseScript):
         match = self.rx_html_ver.search(v)
         return {
             "vendor": "TFortis",
-            "platform": platform.group("platform").strip(smart_text("\x00")),
+            "platform": platform.group("platform").strip("\x00"),
             "version": match.group("version"),
             "attributes": {"Bootloader": match.group("bootloader")},
         }


### PR DESCRIPTION
Remove unnecessary `smart_text("\x00")` wrapper calls across 11 device profile scripts. Since `"\x00"` is already a string literal, `smart_text()` returns it unchanged — the call adds zero value and introduces an unused import.

**Key changes:**
- Replace `smart_text("\x00")` with `"\x00"` in rstrip/split/strip calls and equality comparisons
- Remove `from noc.core.comp import smart_text` imports where no longer needed (8 of 11 files)
- Update copyright year to 2026 on touched file headers

**Affected vendors:** DLink (DxS, DxS_Smart), ECI (HiFOCuS), EdgeCore (ES), Generic, Huawei (VRP), Juniper (JUNOS), Opticin (OS), Planar (SDO3000), TFortis (PSW)