### PR TITLE
Replace .encode(DEFAULT_ENCODING) with .encode()

### DIFF
--- a/core/clickhouse/connect.py
+++ b/core/clickhouse/connect.py
@@ -12,7 +12,6 @@ from urllib.parse import quote as urllib_quote
 
 # NOC modules
 from noc.core.http.sync_client import HttpClient
-from noc.core.comp import DEFAULT_ENCODING
 from noc.config import config
 from .error import ClickhouseError
 
@@ -111,7 +110,7 @@ class ClickhouseClient:
         addr = random.choice(self.addresses)
         q_args = "&".join(qs)
         url = f"http://{addr}/?{q_args}"
-        code, _headers, body = self.http_client.post(url, post.encode(DEFAULT_ENCODING))
+        code, _headers, body = self.http_client.post(url, post.encode())
         if code != 200:
             msg = f"{code}: {body}"
             raise ClickhouseError(msg)

--- a/core/config/params.py
+++ b/core/config/params.py
@@ -14,7 +14,7 @@ from typing import TypeVar, Generic, Any, Iterable
 
 # NOC modules
 from noc.core.validators import is_int, is_ipv4, is_uuid
-from noc.core.comp import smart_text, DEFAULT_ENCODING
+from noc.core.comp import smart_text
 
 logger = logging.getLogger(__name__)
 
@@ -93,7 +93,7 @@ class SecretParameter(BaseParameter[str]):
 class UUIDParameter(BaseParameter[str]):
     def clean(self, v: Any) -> str:
         if isinstance(v, bytes):
-            v = v.decode(DEFAULT_ENCODING)
+            v = v.decode()
         if v and not is_uuid(v):
             msg = f"Invalid UUID value: {v}"
             raise ValueError(msg)

--- a/core/consul.py
+++ b/core/consul.py
@@ -14,7 +14,6 @@ from consul.exceptions import Timeout
 # NOC modules
 from noc.config import config
 from noc.core.http.async_client import HttpClient
-from noc.core.comp import DEFAULT_ENCODING
 
 ConsulRepeatableCodes = {500, 503, 598, 599}
 ConsulRepeatableErrors = Timeout
@@ -34,7 +33,7 @@ class ConsulHTTPClient(consul.base.HTTPClient):
             code, headers, body = await client.request(
                 method,
                 url,
-                body=body.encode(DEFAULT_ENCODING) if body is not None else body,
+                body=body.encode() if body is not None else body,
             )
 
             if code in ConsulRepeatableCodes:

--- a/core/datastream/base.py
+++ b/core/datastream/base.py
@@ -23,7 +23,7 @@ from typing import Any, Iterable, Callable
 # NOC modules
 from noc.core.perf import metrics
 from noc.core.mongo.connection import get_db
-from noc.core.comp import smart_text, DEFAULT_ENCODING
+from noc.core.comp import smart_text
 from noc.models import get_model
 from noc.core.hash import hash_int
 from noc.core.mx import send_message, MessageType, MX_CHANGE_ID, MX_DATA_ID
@@ -298,7 +298,7 @@ class DataStream:
             "$set": {
                 cls.F_CHANGEID: change_id,
                 cls.F_HASH: hash,
-                cls.F_DATA: orjson.dumps(data).decode(DEFAULT_ENCODING),
+                cls.F_DATA: orjson.dumps(data).decode(),
             }
         }
         if meta:
@@ -719,8 +719,8 @@ class DataStream:
         data["$changeid"] = str(change_id)
         # Build headers
         headers = {
-            MX_CHANGE_ID: str(change_id).encode(DEFAULT_ENCODING),
-            MX_DATA_ID: str(data["id"]).encode(DEFAULT_ENCODING),
+            MX_CHANGE_ID: str(change_id).encode(),
+            MX_DATA_ID: str(data["id"]).encode(),
         }
         if additional_headers:
             headers.update(additional_headers)

--- a/core/datastream/client.py
+++ b/core/datastream/client.py
@@ -16,7 +16,6 @@ import orjson
 from noc.core.http.async_client import HttpClient, ERR_TIMEOUT, ERR_READ_TIMEOUT
 from noc.core.error import NOCError, ERR_DS_BAD_CODE, ERR_DS_PARSE_ERROR
 from noc.core.dcs.error import ResolutionError
-from noc.core.comp import DEFAULT_ENCODING
 from noc.core.timeout import retry_timeout
 
 logger = logging.getLogger(__name__)
@@ -31,7 +30,7 @@ class DataStreamClient:
         self.service = service
         self._is_ready = False
         self.client = HttpClient(
-            headers={"X-NOC-API-Access": f"datastream:{self.name}".encode(DEFAULT_ENCODING)},
+            headers={"X-NOC-API-Access": f"datastream:{self.name}".encode()},
             resolver=self.resolve,
         )
 
@@ -144,7 +143,7 @@ class DataStreamClient:
                 self._is_ready = True
             # Continue from last change
             if "X-NOC-DataStream-Last-Change" in headers:
-                change_id = headers["X-NOC-DataStream-Last-Change"].decode(DEFAULT_ENCODING)
+                change_id = headers["X-NOC-DataStream-Last-Change"].decode()
                 continue
             if block and self._is_ready:
                 # Do not set block=1 before is_ready, otherwise

--- a/core/diagnostic/hub.py
+++ b/core/diagnostic/hub.py
@@ -20,7 +20,6 @@ from pydantic import BaseModel
 from noc.core.ioloop.util import run_sync
 from noc.core.checkers.base import Check, CheckResult, MetricValue, register_checks
 from noc.core.checkers.registry import DiagnosticCheckRegister
-from noc.core.comp import DEFAULT_ENCODING
 from noc.core.models.inputsources import InputSource
 from noc.config import config
 from noc.models import is_document
@@ -634,7 +633,7 @@ class DiagnosticHub:
         if reason:
             dd["reason"] = reason
         if data:
-            dd["data"] = orjson.dumps(data).decode(DEFAULT_ENCODING)
+            dd["data"] = orjson.dumps(data).decode()
         svc.register_metrics("diagnostichistory", [dd], key=self.__object.bi_id)
         # Send Stream
         # ? always send (from policy)

--- a/core/http/async_client.py
+++ b/core/http/async_client.py
@@ -16,7 +16,6 @@ from gufo.http.async_client import HttpClient as GufoHttpClient
 
 # NOC modules
 from noc.core.perf import metrics
-from noc.core.comp import DEFAULT_ENCODING
 from noc.config import config
 from noc.core.validators import is_ipv4
 from .proxy import SYSTEM_PROXIES
@@ -125,7 +124,7 @@ class HttpClient(GufoHttpClient):
         try:
             url = await self.resolve(url)
         except (TimeoutError, HttpError) as e:
-            return ERR_TIMEOUT, {}, b"Cannot resolve host: %s" % str(e).encode(DEFAULT_ENCODING)
+            return ERR_TIMEOUT, {}, b"Cannot resolve host: %s" % str(e).encode()
         try:
             r = await super().request(m, url, body=body, headers=headers)
         except ConnectionResetError:
@@ -133,7 +132,7 @@ class HttpClient(GufoHttpClient):
             return ERR_TIMEOUT, {}, b"Connection reset while sending request"
         except (ConnectionError, HttpError) as e:
             metrics["httpclient_timeouts"] += 1
-            return ERR_TIMEOUT, {}, b"Connection error: %s" % str(e).encode(DEFAULT_ENCODING)
+            return ERR_TIMEOUT, {}, b"Connection error: %s" % str(e).encode()
         except TimeoutError:
             metrics["httpclient_timeouts"] += 1
             return ERR_TIMEOUT, {}, b"Timed out while sending request"
@@ -146,7 +145,7 @@ class HttpClient(GufoHttpClient):
         try:
             url = await self.resolve(url)
         except TimeoutError as e:
-            return ERR_TIMEOUT, {}, b"Cannot resolve host: %s" % str(e).encode(DEFAULT_ENCODING)
+            return ERR_TIMEOUT, {}, b"Cannot resolve host: %s" % str(e).encode()
         try:
             r = await super().get(url, headers=headers)
         except ConnectionResetError:
@@ -154,7 +153,7 @@ class HttpClient(GufoHttpClient):
             return ERR_TIMEOUT, {}, b"Connection reset while sending request"
         except (ConnectionError, HttpError) as e:
             metrics["httpclient_timeouts"] += 1
-            return ERR_TIMEOUT, {}, b"Connection error: %s" % str(e).encode(DEFAULT_ENCODING)
+            return ERR_TIMEOUT, {}, b"Connection error: %s" % str(e).encode()
         except TimeoutError:
             metrics["httpclient_timeouts"] += 1
             return ERR_TIMEOUT, {}, b"Timed out while sending request"
@@ -171,7 +170,7 @@ class HttpClient(GufoHttpClient):
         try:
             url = await self.resolve(url)
         except TimeoutError as e:
-            return ERR_TIMEOUT, {}, b"Cannot resolve host: %s" % str(e).encode(DEFAULT_ENCODING)
+            return ERR_TIMEOUT, {}, b"Cannot resolve host: %s" % str(e).encode()
         try:
             r = await super().post(url, body, headers=headers)
         except ConnectionResetError:
@@ -179,7 +178,7 @@ class HttpClient(GufoHttpClient):
             return ERR_TIMEOUT, {}, b"Connection reset while sending request"
         except (ConnectionError, HttpError) as e:
             metrics["httpclient_timeouts"] += 1
-            return ERR_TIMEOUT, {}, b"Connection error: %s" % str(e).encode(DEFAULT_ENCODING)
+            return ERR_TIMEOUT, {}, b"Connection error: %s" % str(e).encode()
         except TimeoutError:
             metrics["httpclient_timeouts"] += 1
             return ERR_TIMEOUT, {}, b"Timed out while sending request"
@@ -196,7 +195,7 @@ class HttpClient(GufoHttpClient):
         try:
             url = await self.resolve(url)
         except TimeoutError as e:
-            return ERR_TIMEOUT, {}, b"Cannot resolve host: %s" % str(e).encode(DEFAULT_ENCODING)
+            return ERR_TIMEOUT, {}, b"Cannot resolve host: %s" % str(e).encode()
         try:
             r = await super().put(url, body, headers=headers)
         except ConnectionResetError:
@@ -204,7 +203,7 @@ class HttpClient(GufoHttpClient):
             return ERR_TIMEOUT, {}, b"Connection reset while sending request"
         except (ConnectionError, HttpError) as e:
             metrics["httpclient_timeouts"] += 1
-            return ERR_TIMEOUT, {}, b"Connection error: %s" % str(e).encode(DEFAULT_ENCODING)
+            return ERR_TIMEOUT, {}, b"Connection error: %s" % str(e).encode()
         except TimeoutError:
             metrics["httpclient_timeouts"] += 1
             return ERR_TIMEOUT, {}, b"Timed out while sending request"

--- a/core/http/sync_client.py
+++ b/core/http/sync_client.py
@@ -17,7 +17,6 @@ from gufo.http.sync_client import HttpClient as GufoHttpClient
 
 # NOC modules
 from noc.core.perf import metrics
-from noc.core.comp import DEFAULT_ENCODING
 from noc.config import config
 from noc.core.validators import is_ipv4
 from .proxy import SYSTEM_PROXIES
@@ -202,7 +201,7 @@ class HttpClient(GufoHttpClient):
             return ERR_TIMEOUT, {}, b"Connection reset while sending request"
         except (ConnectionError, HttpError) as e:
             metrics["httpclient_timeouts"] += 1
-            return ERR_TIMEOUT, {}, b"Connection error: %s" % str(e).encode(DEFAULT_ENCODING)
+            return ERR_TIMEOUT, {}, b"Connection error: %s" % str(e).encode()
         except TimeoutError:
             metrics["httpclient_timeouts"] += 1
             return ERR_TIMEOUT, {}, b"Timed out while sending request"
@@ -219,7 +218,7 @@ class HttpClient(GufoHttpClient):
             return ERR_TIMEOUT, {}, b"Connection reset while sending request"
         except (ConnectionError, HttpError) as e:
             metrics["httpclient_timeouts"] += 1
-            return ERR_TIMEOUT, {}, b"Connection error: %s" % str(e).encode(DEFAULT_ENCODING)
+            return ERR_TIMEOUT, {}, b"Connection error: %s" % str(e).encode()
         except TimeoutError:
             metrics["httpclient_timeouts"] += 1
             return ERR_TIMEOUT, {}, b"Timed out while sending request"
@@ -259,7 +258,7 @@ class HttpClient(GufoHttpClient):
             return ERR_TIMEOUT, {}, b"Connection reset while sending request"
         except (ConnectionError, HttpError) as e:
             metrics["httpclient_timeouts"] += 1
-            return ERR_TIMEOUT, {}, b"Connection error: %s" % str(e).encode(DEFAULT_ENCODING)
+            return ERR_TIMEOUT, {}, b"Connection error: %s" % str(e).encode()
         except TimeoutError:
             metrics["httpclient_timeouts"] += 1
             return ERR_TIMEOUT, {}, b"Timed out while sending request"
@@ -280,7 +279,7 @@ class HttpClient(GufoHttpClient):
             return ERR_TIMEOUT, {}, b"Connection reset while sending request"
         except (ConnectionError, HttpError) as e:
             metrics["httpclient_timeouts"] += 1
-            return ERR_TIMEOUT, {}, b"Connection error: %s" % str(e).encode(DEFAULT_ENCODING)
+            return ERR_TIMEOUT, {}, b"Connection error: %s" % str(e).encode()
         except TimeoutError:
             metrics["httpclient_timeouts"] += 1
             return ERR_TIMEOUT, {}, b"Timed out while sending request"

--- a/core/mx.py
+++ b/core/mx.py
@@ -14,7 +14,6 @@ from functools import partial
 
 # NOC services
 from noc.core.service.loader import get_service
-from noc.core.comp import DEFAULT_ENCODING
 from noc.core.ioloop.util import run_sync
 from noc.models import get_model_id
 from noc.core.timepattern import TimePatternList
@@ -164,8 +163,8 @@ class MessageMeta(enum.Enum):
         if self.config.is_list:
             if not isinstance(value, list):
                 value = [value]
-            return MX_H_VALUE_SPLITTER.join([str(x) for x in value]).encode(DEFAULT_ENCODING)
-        return str(value).encode(DEFAULT_ENCODING)
+            return MX_H_VALUE_SPLITTER.join([str(x) for x in value]).encode()
+        return str(value).encode()
 
 
 MESSAGE_HEADERS = {
@@ -219,7 +218,7 @@ def send_message(
     """
     msg_headers = {
         MX_MESSAGE_TYPE: message_type.value,
-        MX_SHARDING_KEY: str(sharding_key).encode(DEFAULT_ENCODING),
+        MX_SHARDING_KEY: str(sharding_key).encode(),
     }
     if headers:
         msg_headers.update(headers)
@@ -257,7 +256,7 @@ def send_notification(
     msg_headers = {
         MX_MESSAGE_TYPE: MessageType.NOTIFICATION.value.encode(),
         MX_NOTIFICATION_METHOD: notification_method.encode(),
-        MX_TO: to.encode(DEFAULT_ENCODING),
+        MX_TO: to.encode(),
     }
     if fwd_to:
         msg_headers[MX_FWD_ROUTER] = fwd_to.encode()

--- a/core/router/action.py
+++ b/core/router/action.py
@@ -16,7 +16,6 @@ import orjson
 
 # NOC modules
 from noc.core.msgstream.message import Message
-from noc.core.comp import DEFAULT_ENCODING
 from noc.core.defer import JOBS_STREAM
 from noc.core.mx import (
     MessageType,
@@ -71,9 +70,7 @@ class Action(metaclass=ActionBase):
     name: ClassVar[str]
 
     def __init__(self, cfg: ActionCfg):
-        self.headers: dict[str, bytes] = {
-            h.header: h.value.encode(encoding=DEFAULT_ENCODING) for h in cfg.headers or []
-        }
+        self.headers: dict[str, bytes] = {h.header: h.value.encode() for h in cfg.headers or []}
 
     @classmethod
     def from_data(cls, data):
@@ -167,7 +164,7 @@ class MetricAction(Action):
 
         for mss in MetricStream.objects.filter():
             if mss.is_active and mss.scope.table_name in set(config.message.enable_metric_scopes):
-                self.mx_metrics_scopes[mss.scope.table_name.encode(DEFAULT_ENCODING)] = mss.to_mx
+                self.mx_metrics_scopes[mss.scope.table_name.encode()] = mss.to_mx
 
     def iter_action(
         self, msg: Message, message_type: bytes
@@ -289,7 +286,7 @@ class MessageAction(Action):
                     "body": body["body"],
                 }
             headers = {
-                MX_TO: c.contact.encode(encoding=DEFAULT_ENCODING),
+                MX_TO: c.contact.encode(),
                 MX_NOTIFICATION_METHOD: c.method.encode(),
             }
             if c.route:

--- a/core/router/base.py
+++ b/core/router/base.py
@@ -27,7 +27,6 @@ from noc.core.mx import (
     MX_FWD_ROUTER,
 )
 from noc.core.service.loader import get_service
-from noc.core.comp import DEFAULT_ENCODING
 from noc.core.perf import metrics
 from noc.core.ioloop.util import run_sync
 from noc.core.msgstream.config import get_stream
@@ -233,8 +232,8 @@ class Router:
             raw_value:
         """
         msg_headers = {
-            MX_MESSAGE_TYPE: message_type.encode(DEFAULT_ENCODING),
-            MX_SHARDING_KEY: str(sharding_key).encode(DEFAULT_ENCODING),
+            MX_MESSAGE_TYPE: message_type.encode(),
+            MX_SHARDING_KEY: str(sharding_key).encode(),
         }
         if headers:
             msg_headers.update(headers)
@@ -284,7 +283,7 @@ class Router:
                 break
             if not routed:
                 logger.debug("[%s] Not routed", msg_id)
-                metrics["route_misses", ("message_type", msg_type.decode(DEFAULT_ENCODING))] += 1
+                metrics["route_misses", ("message_type", msg_type.decode())] += 1
 
     async def to_route(
         self,
@@ -359,8 +358,8 @@ class Router:
                 metrics[("forwards", ("stream", stream))] += 1
                 logger.debug("[%s] Routing to %s:%s", msg_id, stream, partition)
                 if route.telemetry_sample:
-                    headers[MX_SPAN_ID] = str(span.span_id).encode(DEFAULT_ENCODING)
-                    headers[MX_SPAN_CTX] = str(span.span_context).encode(DEFAULT_ENCODING)
+                    headers[MX_SPAN_ID] = str(span.span_id).encode()
+                    headers[MX_SPAN_CTX] = str(span.span_context).encode()
                     span.headers = headers
                 await self.publish(value=body, stream=stream, partition=partition, headers=headers)
                 routed |= True

--- a/core/router/route.py
+++ b/core/router/route.py
@@ -24,7 +24,6 @@ import orjson
 from noc.core.msgstream.message import Message
 from noc.core.matcher import build_matcher
 from noc.core.defer import JOBS_STREAM
-from noc.core.comp import DEFAULT_ENCODING
 from noc.core.mx import (
     MX_H_VALUE_SPLITTER,
     MX_NOTIFICATION_METHOD,
@@ -62,7 +61,7 @@ class TransmuteTemplate:
     template: JTemplate
 
     def render_body(self, ctx: dict[str, Any]) -> dict[str, Any]:
-        return orjson.loads(self.template.render(**ctx).encode(encoding=DEFAULT_ENCODING))
+        return orjson.loads(self.template.render(**ctx).encode())
 
 
 @dataclass
@@ -145,11 +144,11 @@ class MatchItem:
             return r
         for h in self.headers:
             if h.op == "regex":
-                r[h.header] = {"$regex": re.compile(h.value.encode(DEFAULT_ENCODING))}
+                r[h.header] = {"$regex": re.compile(h.value.encode())}
             elif h.op == "!=":
-                r[h.header] = {"$ne": h.value.encode(DEFAULT_ENCODING)}
+                r[h.header] = {"$ne": h.value.encode()}
             else:
-                r[h.header] = h.value.encode(DEFAULT_ENCODING)
+                r[h.header] = h.value.encode()
         return r
 
 
@@ -159,7 +158,7 @@ class Route:
     If condition is matched - do action
     """
 
-    MX_H_VALUE_SPLITTER = MX_H_VALUE_SPLITTER.encode(DEFAULT_ENCODING)
+    MX_H_VALUE_SPLITTER = MX_H_VALUE_SPLITTER.encode()
 
     def __init__(self, name: str, r_type: str, order: int, telemetry_sample: int | None = None):
         self.name = name
@@ -244,7 +243,7 @@ class Route:
 
     def set_type(self, r_type: str | frozenset[bytes]):
         if isinstance(r_type, str):
-            self.type = frozenset([r_type.encode(encoding=DEFAULT_ENCODING)])
+            self.type = frozenset([r_type.encode()])
         else:
             self.type = frozenset(x for x in r_type)
 

--- a/core/script/http/base.py
+++ b/core/script/http/base.py
@@ -16,7 +16,6 @@ from noc.core.log import PrefixLoggerAdapter
 from noc.core.http.sync_client import HttpClient
 from noc.core.error import NOCError, ERR_HTTP_UNKNOWN
 from noc.core.handler import get_handler
-from noc.core.comp import DEFAULT_ENCODING
 from .middleware.base import BaseMiddleware
 from .middleware.loader import loader
 
@@ -107,7 +106,7 @@ class HTTP:
                 except ValueError as e:
                     raise HTTPError("Failed to decode JSON: %s" % e)
             elif not raw_result:
-                result = result.decode(DEFAULT_ENCODING, errors="ignore")
+                result = result.decode(errors="ignore")
             self.logger.debug("Result: %r", result)
             if cached:
                 self.script.root.http_cache[cache_key] = result
@@ -171,7 +170,7 @@ class HTTP:
                 except ValueError as e:
                     raise HTTPError(msg="Failed to decode JSON: %s" % e)
             elif not raw_result:
-                result = result.decode(DEFAULT_ENCODING, errors="ignore")
+                result = result.decode(errors="ignore")
             self.logger.debug("Result: %r", result)
             if cached:
                 self.script.root.http_cache[cache_key] = result
@@ -232,9 +231,7 @@ class HTTP:
             headers = {}
         if self.cookies:
             headers["Cookie"] = (
-                self.cookies.output(header="", sep=";", attrs="value")
-                .lstrip()
-                .encode(DEFAULT_ENCODING)
+                self.cookies.output(header="", sep=";", attrs="value").lstrip().encode()
             )
         return headers
 
@@ -246,7 +243,7 @@ class HTTP:
         :return:
         """
         self.logger.debug("Set header: %s = %s", name, value)
-        self.headers[name] = str(value).encode(DEFAULT_ENCODING)
+        self.headers[name] = str(value).encode()
 
     def set_session_id(self, session_id):
         """

--- a/core/script/http/middleware/digestauth.py
+++ b/core/script/http/middleware/digestauth.py
@@ -13,7 +13,6 @@ from urllib.request import parse_http_list, parse_keqv_list
 
 # NOC modules
 from .base import BaseMiddleware
-from noc.core.comp import DEFAULT_ENCODING
 from noc.core.http.sync_client import HttpClient
 from noc.core.comp import smart_bytes
 
@@ -136,12 +135,10 @@ class DigestAuthMiddeware(BaseMiddleware):
             if "WWW-Authenticate" in resp_headers and resp_headers["WWW-Authenticate"].startswith(
                 b"Digest"
             ):
-                items = parse_http_list(
-                    resp_headers["WWW-Authenticate"].decode(DEFAULT_ENCODING)[7:]
-                )
+                items = parse_http_list(resp_headers["WWW-Authenticate"].decode()[7:])
                 digest_response = parse_keqv_list(items)
                 headers["Authorization"] = self.build_digest_header(
                     url, self.method, digest_response
-                ).encode(DEFAULT_ENCODING)
+                ).encode()
             self.logger.debug("[%s] Set headers, %s", self.name, headers)
             return url, body, headers

--- a/core/service/rpc.py
+++ b/core/service/rpc.py
@@ -24,7 +24,6 @@ from noc.config import config
 from noc.core.span import Span, get_current_span
 from noc.core.ioloop.util import run_sync
 from .error import RPCError, RPCNoService, RPCHTTPError, RPCException, RPCRemoteError
-from noc.core.comp import DEFAULT_ENCODING
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +58,7 @@ class RPCProxy:
         self._client = HttpClient(
             max_redirects=None,
             headers={
-                "X-NOC-Calling-Service": self._service.name.encode(DEFAULT_ENCODING),
+                "X-NOC-Calling-Service": self._service.name.encode(),
                 "Content-Type": b"application/json",
             },
             connect_timeout=CONNECT_TIMEOUT,
@@ -79,10 +78,8 @@ class RPCProxy:
                     parent=span_id,
                 ) as span:
                     if sample:
-                        req_headers["X-NOC-Span-Ctx"] = str(span.span_context).encode(
-                            DEFAULT_ENCODING
-                        )
-                        req_headers["X-NOC-Span"] = str(span.span_id).encode(DEFAULT_ENCODING)
+                        req_headers["X-NOC-Span-Ctx"] = str(span.span_context).encode()
+                        req_headers["X-NOC-Span"] = str(span.span_id).encode()
                     code, headers, data = await self._client.post(url, body, headers=req_headers)
                     # Process response
                     if code == 200:
@@ -93,7 +90,7 @@ class RPCProxy:
                             raise RPCException("Redirects limit exceeded")
                         url = headers.get("location")
                         self._logger.debug("Redirecting to %s", url)
-                        return await make_call(url.decode(DEFAULT_ENCODING), data, limit - 1)
+                        return await make_call(url.decode(), data, limit - 1)
                     if code in (598, 599):
                         span.set_error(code)
                         self._logger.debug("Timed out")

--- a/core/span.py
+++ b/core/span.py
@@ -20,7 +20,6 @@ from contextvars import ContextVar
 # NOC modules
 from noc.core.error import NO_ERROR, ERR_UNKNOWN
 from noc.core.perf import metrics
-from noc.core.comp import DEFAULT_ENCODING
 from noc.config import config
 
 forensic_logger = logging.getLogger("noc.core.forensic")
@@ -164,7 +163,7 @@ class Span:
             sample=self.sample,
             in_label=str(self.in_label or ""),
             out_label=str(self.out_label or ""),
-            in_headers={k: v.decode(DEFAULT_ENCODING) for k, v in self.headers.items()},
+            in_headers={k: v.decode() for k, v in self.headers.items()},
         )
         with span_lock:
             spans += [span]

--- a/main/models/notificationgroup.py
+++ b/main/models/notificationgroup.py
@@ -42,7 +42,7 @@ from noc.core.mx import (
 )
 from noc.core.model.decorator import on_delete_check, on_save
 from noc.core.change.decorator import change
-from noc.core.comp import DEFAULT_ENCODING
+
 from noc.core.prettyjson import to_json
 from noc.core.path import safe_json_path
 from noc.aaa.models.user import User
@@ -809,7 +809,7 @@ class NotificationGroup(NOCModel):
         if MessageMeta.WATCH_FOR in meta:
             obj = meta[MessageMeta.WATCH_FOR].decode()
         for c in self.get_active_contacts(obj, ts=ts):
-            yield c.method, {MX_TO: c.contact.encode(encoding=DEFAULT_ENCODING)}, None
+            yield c.method, {MX_TO: c.contact.encode()}, None
 
     @classmethod
     def render_message(

--- a/sa/models/managedobject.py
+++ b/sa/models/managedobject.py
@@ -140,7 +140,7 @@ from noc.core.change.policy import change_tracker
 from noc.core.resourcegroup.decorator import resourcegroup
 from noc.core.confdb.tokenizer.loader import loader as tokenizer_loader
 from noc.core.confdb.engine.base import Engine
-from noc.core.comp import smart_text, DEFAULT_ENCODING
+from noc.core.comp import smart_text
 from noc.main.models.glyph import Glyph
 from noc.core.topology.types import (
     ShapeOverlayPosition,
@@ -1697,7 +1697,7 @@ class ManagedObject(NOCModel):
                     logger.debug("[%s] Ensuring directory: %s", self.name, dir_path)
                     fs.makedirs(dir_path, recreate=True)
                 logger.debug("[%s] Mirroring %d bytes", self.name, len(data))
-                fs.writebytes(path, data.encode(encoding=DEFAULT_ENCODING))
+                fs.writebytes(path, data.encode())
         except storage.Error as e:
             logger.error("[%s] Failed to mirror config: %s", self.name, e)
 

--- a/services/activator/paths/activator.py
+++ b/services/activator/paths/activator.py
@@ -19,7 +19,7 @@ from noc.core.script.base import BaseScript
 from noc.core.ioloop.snmp import snmp_get, SNMPError
 from noc.core.snmp.version import SNMP_v1, SNMP_v2c
 from noc.core.http.async_client import HttpClient
-from noc.core.comp import DEFAULT_ENCODING, smart_text
+from noc.core.comp import smart_text
 from noc.core.perf import metrics
 from noc.core.debug import error_report
 from noc.core.checkers.loader import loader as checker_loader
@@ -323,13 +323,13 @@ class ActivatorAPI(JSONRPCAPI):
         ) as client:
             code, headers, body = await client.get(url)
             if 200 <= code <= 299:
-                return body.decode(DEFAULT_ENCODING, errors="replace")
+                return body.decode(errors="replace")
             if ignore_errors:
                 metrics["error", ("type", f"http_error_{code}")] += 1
                 self.logger.debug("HTTP GET %s failed: %s %s", url, code, body)
                 return str(
-                    {k: v.decode(DEFAULT_ENCODING, errors="replace") for k, v in headers.items()}
-                ) + body.decode(DEFAULT_ENCODING, errors="replace")
+                    {k: v.decode(errors="replace") for k, v in headers.items()}
+                ) + body.decode(errors="replace")
             metrics["error", ("type", f"http_error_{code}")] += 1
             self.logger.debug("HTTP GET %s failed: %s %s", url, code, body)
             return None

--- a/services/classifier/service.py
+++ b/services/classifier/service.py
@@ -34,7 +34,6 @@ from noc.core.version import version
 from noc.core.debug import error_report
 from noc.core.escape import fm_unescape
 from noc.core.ioloop.timers import PeriodicCallback
-from noc.core.comp import DEFAULT_ENCODING
 from noc.core.msgstream.message import Message
 from noc.core.fm.event import Event, EventSource, Target, Var, EventSeverity
 from noc.core.mx import MessageType
@@ -600,7 +599,7 @@ class ClassifierService(FastAPIService):
             if d.snmp_raw:
                 snmp_vars[d.name] = d.value
             if d.escaped or d.snmp_raw:
-                raw_vars[d.name] = fm_unescape(d.value).decode(DEFAULT_ENCODING, errors="ignore")
+                raw_vars[d.name] = fm_unescape(d.value).decode(errors="ignore")
             else:
                 raw_vars[d.name] = d.value
         # Resolve MIB variables for SNMP Traps
@@ -825,7 +824,7 @@ class ClassifierService(FastAPIService):
             "event_class": event_config.bi_id,
             "source": event.type.source.value,
             "labels": event.labels or [],
-            "data": orjson.dumps([d.to_json() for d in event.data]).decode(DEFAULT_ENCODING),
+            "data": orjson.dumps([d.to_json() for d in event.data]).decode(),
             "message": event.message or "",
             "severity": event.type.severity.value,
             "result_action": str(action.name),

--- a/services/discovery/jobs/box/caps.py
+++ b/services/discovery/jobs/box/caps.py
@@ -10,7 +10,6 @@ import orjson
 
 # NOC modules
 from noc.services.discovery.jobs.base import PolicyDiscoveryCheck
-from noc.core.comp import DEFAULT_ENCODING
 
 
 class CapsCheck(PolicyDiscoveryCheck):
@@ -48,7 +47,7 @@ class CapsCheck(PolicyDiscoveryCheck):
         else:
             self.logger.debug(
                 "Received capabilities: \n%s",
-                orjson.dumps(result, option=orjson.OPT_INDENT_2).decode(DEFAULT_ENCODING),
+                orjson.dumps(result, option=orjson.OPT_INDENT_2).decode(),
             )
             self.update_caps(result, source="discovery")
         object_attrs = self.get_artefact("object_attributes")

--- a/services/mailsender/service.py
+++ b/services/mailsender/service.py
@@ -24,7 +24,6 @@ from noc.core.msgstream.message import Message
 from noc.core.mx import MX_TO
 from noc.core.perf import metrics
 from noc.config import config
-from noc.core.comp import DEFAULT_ENCODING
 
 MAILSENDER_STREAM = "mailsender"
 
@@ -53,9 +52,7 @@ class MailSenderService(FastAPIService):
             metrics["messages_drops"] += 1
             return None
         metrics["messages_processed"] += 1
-        return self.send_mail(
-            msg.offset, orjson.loads(msg.value), dst.decode(encoding=DEFAULT_ENCODING)
-        )
+        return self.send_mail(msg.offset, orjson.loads(msg.value), dst.decode())
 
     def send_mail(
         self, message_id: int, data: dict[str, Any], address_to: str | None = None

--- a/services/syslogcollector/service.py
+++ b/services/syslogcollector/service.py
@@ -38,7 +38,6 @@ from noc.core.checkers.base import register_checks
 from noc.services.syslogcollector.syslogserver import SyslogServer
 from noc.services.syslogcollector.datastream import SysologDataStreamClient
 from noc.services.syslogcollector.sourceconfig import SourceConfig, ManagedObjectData
-from noc.core.comp import DEFAULT_ENCODING
 
 SYSLOGCOLLECTOR_STORM_ALARM_CLASS = "NOC | Managed Object | Storm Control"
 
@@ -227,10 +226,8 @@ class SyslogCollectorService(FastAPIService):
                 partition=int(cfg.id) % n_partitions,
                 headers={
                     MX_MESSAGE_TYPE: MessageType.SYSLOG.value.encode(),
-                    MX_LABELS: MX_H_VALUE_SPLITTER.join(cfg.effective_labels).encode(
-                        DEFAULT_ENCODING
-                    ),
-                    MX_SHARDING_KEY: str(cfg.id).encode(DEFAULT_ENCODING),
+                    MX_LABELS: MX_H_VALUE_SPLITTER.join(cfg.effective_labels).encode(),
+                    MX_SHARDING_KEY: str(cfg.id).encode(),
                 },
             )
 

--- a/services/tgsender/service.py
+++ b/services/tgsender/service.py
@@ -21,7 +21,6 @@ from noc.core.mx import MX_TO, MX_WH_API_URL, MX_NOTIFICATION_METHOD
 from noc.core.perf import metrics
 from noc.config import config
 from noc.core.http.sync_client import HttpClient, ERR_TIMEOUT
-from noc.core.comp import DEFAULT_ENCODING
 from noc.core.text import split_text
 
 TG_API = "https://api.telegram.org/bot"
@@ -68,7 +67,7 @@ class TgSenderService(FastAPIService):
             metrics["messages_drops"] += 1
             return
         metrics["messages_processed"] += 1
-        data, dst = orjson.loads(msg.value), dst.decode(encoding=DEFAULT_ENCODING)
+        data, dst = orjson.loads(msg.value), dst.decode()
         address = self.parse_address(data, dst)
         if not address:
             self.logger.warning("[%s] Message without address", msg.offset)


### PR DESCRIPTION
Remove redundant `DEFAULT_ENCODING` parameter from all `.encode()`/.decode() calls across the codebase. Since Python 3 defaults to UTF-8 encoding and our `DEFAULT_ENCODING` constant is `"utf-8"`, passing it explicitly provides no semantic value and adds boilerplate.

**Key changes:**
- Replaced `.encode(DEFAULT_ENCODING)` → `.encode()` in ~50 call sites across 24 files
- Replaced `.decode(DEFAULT_ENCODING)` → `.decode()` in all equivalent locations
- Removed `from noc.core.comp import DEFAULT_ENCODING` import from 21 files where it was the only usage
- Kept `DEFAULT_ENCODING` definition in `core/comp.py` (still used as default parameter value in `smart_bytes()` and `smart_text()`)

**Affected areas:**
- Core HTTP clients (sync + async) — error message encoding
- Datastream base/client — JSON body encoding, header values
- Message routing (router/action, router/base, router/route) — message type, shard keys, span context headers
- MX layer — notification targets, sharding keys
- Span module — forensic logging header decoding
- Services: classifier, activator, discovery (caps), mailsender, syslogcollector, tgsender
- Models: managedobject (mirror config), notificationgroup