### PR TITLE
Docker: do not add .worktrees to image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 .docker/
 .mypy_cache/
 .pytest_cache/
+.worktrees/
 etc/
 build/
 docs/


### PR DESCRIPTION
add `.worktrees/` to `.dockerignore

## Why?

- Git worktrees are used for Kanban-based task workflows (each task gets its own worktree under `.worktrees/`). These directories contain full checkouts of the repository including `var/`, `tests/`, and other excluded data, which defeats the purpose of existing `.dockerignore` entries when copied via these worktrees.
- This mirrors similar exclusions for other development artifacts (`.cache/`, `.mypy_cache/`, `var/`, `ui/node_modules/`).
