### PR TITLE
Gufo Loader 2.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ node = [
   "gufo-liftbridge==0.2.0",
   "gufo-snmp==0.12.0",
   "gufo_noc_speedup==0.1.0",
-  "gufo-loader==2.0.0",
+  "gufo-loader==2.0.1",
 ]
 ping = ["gufo-ping==0.7.0"]
 prod-tools = [


### PR DESCRIPTION
Update Gufo Loader to 2.0.1.

Version 2.0.0 may raise

```
TypeError: issubclass() arg 1 must be a class
```