### PR TITLE
actions/checkout@v7, actions/setup-python@v6, actions/setup-node@v7

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,6 +14,6 @@ jobs:
       github.event.pull_request.merged &&
       contains(toJSON(github.event.pull_request.labels.*.name), '"backport ')
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Create backport pull requests
         uses: korthout/backport-action@v4

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set Up Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,7 +43,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       # Add any setup steps before running the `github/codeql-action/init` action.
       # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/docker-master.yml
+++ b/.github/workflows/docker-master.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/infra-image.yml
+++ b/.github/workflows/infra-image.yml
@@ -20,7 +20,7 @@ jobs:
       testtelnetd: ${{ steps.filter.outputs.testtelnetd }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Filter Items
         uses: dorny/paths-filter@v3
         id: filter
@@ -50,7 +50,7 @@ jobs:
             changed: ${{ needs.changes.outputs.testsshd }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         if: matrix.changed == 'true'
 
       - name: Log in to GHCR

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Install pnpm
         uses: pnpm/action-setup@v5
@@ -29,7 +29,7 @@ jobs:
           version: latest
 
       - name: Install NodeJS
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: "24"
           cache: "pnpm"
@@ -48,7 +48,7 @@ jobs:
     needs: [js-lint]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Install pnpm
         uses: pnpm/action-setup@v5
@@ -56,7 +56,7 @@ jobs:
           version: latest
 
       - name: Install NodeJS
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: "24"
           cache: "pnpm"

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set Up Python ${{ env.TEST_PYTHON_VERSION }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.TEST_PYTHON_VERSION }}
 
@@ -113,10 +113,10 @@ jobs:
           - 10004:22
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set Up Python ${{ env.TEST_PYTHON_VERSION }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "${{ env.TEST_PYTHON_VERSION }}"
 

--- a/.github/workflows/ui-master.yml
+++ b/.github/workflows/ui-master.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -25,7 +25,7 @@ jobs:
           version: latest
 
       - name: Install NodeJS
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: "24"
           cache: "pnpm"


### PR DESCRIPTION
Bump GitHub Actions core action versions to latest stable releases across all CI workflows, removing ~1-year-old dependency versions.

**Key changes:**  
- `actions/checkout` v5 → v7
- `actions/setup-python` v5 → v6
- `actions/setup-node` v6 → v7

**Affected workflows (8 files):**  
| Workflow | Actions updated |
|---|---|
| `backport.yml` | checkout v6 → v7 |
| `build-docs.yml` | checkout v5 → v7, setup-python v5 → v6 |
| `codeql.yml` | checkout v5 → v7 |
| `docker-master.yml` | checkout v5 → v7 |
| `infra-image.yml` | checkout v5 → v7 (2 jobs) |
| `js-tests.yml` | checkout v5 → v7, setup-node v6 → v7 (2 jobs) |
| `py-tests.yml` | checkout v5 → v7, setup-python v5 → v6 (2 jobs) |
| `ui-master.yml` | checkout v5 → v7, setup-node v6 → v7 |