### PR TITLE
NOC Theme: Set GF icons in navigation tree to black

### DIFF
--- a/ui/web/css/theme-patch-noc.css
+++ b/ui/web/css/theme-patch-noc.css
@@ -1,0 +1,5 @@
+/* Patch NOC theme */
+.x-tree-icon-parent.gf,
+.x-tree-icon-leaf.gf {
+    color: #000000;
+}


### PR DESCRIPTION
Force GF-branded icons in the NOC theme's ExtJS navigation tree to render as black (#000000) instead of inheriting the default tree icon color, ensuring icon visibility against light gray backgrounds.

**Key changes:**
- Create content for `ui/web/css/theme-patch-noc.css` (was empty on branch), adding `.x-tree-icon-parent.gf` and `.x-tree-icon-leaf.gf` selectors with explicit `color: black`

**Implementation details:**
- File is imported by `ui/scripts/theme-noc.css` via `@cssWeb/theme-patch-noc.css` so it participates in the SASS/webpack build chain
- Targets standard ExtJS 4 tree node icon classes (`.x-tree-icon-parent`, `.x-tree-icon-leaf`) qualified with the `.gf` brand class