### PR TITLE
Remove Application.lookup() and Application.lookup_json()

### DIFF
--- a/services/web/base/application.py
+++ b/services/web/base/application.py
@@ -476,29 +476,6 @@ class Application(metaclass=ApplicationBase):
         cursor.execute(sql, args)
         return cursor.fetchall()
 
-    def lookup(self, request, func):
-        """
-        AJAX lookup wrapper
-        @todo: Remove
-        """
-        result = []
-        if request.GET and "q" in request.GET:
-            q = request.GET["q"]
-            if len(q) > 2:  # Ignore requests shorter than 3 letters
-                result = list(func(q))
-        return self.render_plain_text("\n".join(result))
-
-    def lookup_json(self, request, func, id_field="id", name_field="name"):
-        """
-        Ajax lookup wrapper, returns JSON list of hashes
-        """
-        result = []
-        if request.GET and "q" in request.GET:
-            q = request.GET["q"]
-            for r in func(q):
-                result += [{id_field: r, name_field: r}]
-        return self.render_json(result)
-
     def iter_views(self):
         """
         Iterator returning application views


### PR DESCRIPTION
Remove deprecated `Application.lookup()` and `Application.lookup_json()` methods from the web application base class.

**Key changes**
- Deleted 23 lines from `services/web/base/application.py`: removed both methods entirely.

**Notable implementation details**
- Both methods included `@todo: Remove` markers in their docstrings, confirming intent to delete.
- `lookup()`: legacy AJAX text-based lookup wrapper (minimum 3-char query filter).
- `lookup_json()`: JSON variant returning `[{id_field, name_field}]` arrays.
- Superseded by the modern `api_lookup` pattern in subclasses (`ExtModelApplication`, `ExtDocApplication`), which uses `@view` decorators with proper API routing.
