### PR TITLE
Application: Remove unused render_xxx methods and close_popup

### DIFF
--- a/services/web/base/application.py
+++ b/services/web/base/application.py
@@ -367,30 +367,6 @@ class Application(metaclass=ApplicationBase):
         cls._set_headers(resp, headers)
         return resp
 
-    def render_success(self, request, subject=None, text=None):
-        """
-        Render "success" page
-        """
-        return self.site.views.main.message.success(request, subject=subject, text=text)
-
-    def render_failure(self, request, subject=None, text=None):
-        """
-        Render "failure" page
-        """
-        return self.site.views.main.message.failure(request, subject=subject, text=text)
-
-    def render_wait(self, request, subject=None, text=None, url=None, timeout=5, progress=None):
-        """
-        Render wait page
-        """
-        return self.site.views.main.message.wait(
-            request, subject=subject, text=text, timeout=timeout, url=url, progress=progress
-        )
-
-    def render_static(self, request, path, document_root=None):
-        document_root = document_root or self.document_root
-        return serve_static(request, path, document_root=document_root)
-
     def response_redirect(self, url, *args, **kwargs):
         """
         Redirect to URL
@@ -443,12 +419,6 @@ class Application(metaclass=ApplicationBase):
         if location:
             r["Location"] = location
         return r
-
-    def close_popup(self, request):
-        """
-        Render javascript closing popup window
-        """
-        return self.render(request, "close_popup.html")
 
     def html_escape(self, s):
         """

--- a/services/web/base/application.py
+++ b/services/web/base/application.py
@@ -28,7 +28,6 @@ from django.utils.html import escape
 from django.template import loader
 from django import forms
 from django.utils.timezone import get_current_timezone
-from django.views.static import serve as serve_static
 from django.http import Http404
 import orjson
 import jinja2

--- a/templates/close_popup.html
+++ b/templates/close_popup.html
@@ -1,9 +1,0 @@
-<html>
-    <head></head>
-    <body>
-        <script>
-            parent.hide_popup();
-            parent.location.reload();
-        </script>
-    </body>
-</html>


### PR DESCRIPTION
**Purpose:** Remove five unused legacy rendering methods from `Application` and delete the orphaned `close_popup.html` template.

**Key changes:**
- Deleted `Application.render_success()`, `Application.render_failure()`, `Application.render_wait()` — thin wrappers around `self.site.views.main.message.*` with zero callers in the codebase
- Deleted `Application.render_static()` — direct call to Django's `serve_static`, no remaining callers
- Deleted `Application.close_popup()` — rendered `close_popup.html`, no remaining callers
- Deleted `templates/close_popup.html` — only referenced by the removed `close_popup()` method
