### PR TITLE
Reduce smart_text() usage

### DIFF
--- a/bi/models/dashboard.py
+++ b/bi/models/dashboard.py
@@ -27,7 +27,6 @@ from noc.aaa.models.user import User
 from noc.aaa.models.group import Group
 from noc.core.mongo.fields import ForeignKeyField
 from noc.core.prettyjson import to_json
-from noc.core.comp import smart_text
 from noc.core.path import safe_json_path
 
 DAL_NONE = -1
@@ -169,7 +168,7 @@ class Dashboard(Document):
                 "uuid": str(self.uuid),
                 "description": self.description,
                 "format": self.format,
-                "config": smart_text(b85encode(self.config)),
+                "config": b85encode(self.config).decode(),
                 "created": self.created.isoformat(),
                 "changed": self.changed.isoformat(),
             },

--- a/core/gridvcs/base.py
+++ b/core/gridvcs/base.py
@@ -67,7 +67,7 @@ class GridVCS:
         :param delta:
         :return:
         """
-        return smart_text(delta)
+        return delta.decode()
 
     @staticmethod
     def apply_delta_b(src: str, delta: bytes) -> str:
@@ -79,14 +79,14 @@ class GridVCS:
         :return:
         """
         last = pos = 0
-        r = []
+        r: list[str] = []
         d_len = len(delta)
 
         while pos < d_len:
             p1, p2, p_len = struct.unpack(">lll", delta[pos : pos + 12])
             pos += 12
             r.append(src[last:p1])
-            r.append(smart_text(delta[pos : pos + p_len]))
+            r.append(delta[pos : pos + p_len].decode())
             pos += p_len
             last = p2
         r.append(src[last:])
@@ -100,18 +100,18 @@ class GridVCS:
         :param delta:
         :return:
         """
-        return smart_text(bsdiff4.patch(src, delta))
+        return bsdiff4.patch(src, delta).decode()
 
     @classmethod
     def compress(cls, data: bytes, method: str | None = None) -> bytes:
         if method:
-            return getattr(cls, "compress_%s" % method)(data)
+            return getattr(cls, f"compress_{method}")(data)
         return data
 
     @classmethod
     def decompress(cls, data: bytes, method: str | None = None) -> bytes:
         if method:
-            return getattr(cls, "decompress_%s" % method)(data)
+            return getattr(cls, f"decompress_{method}")(data)
         return data
 
     @staticmethod

--- a/core/ioloop/whois.py
+++ b/core/ioloop/whois.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # Whois client
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -12,7 +12,7 @@ import socket
 
 # NOC modules
 from noc.core.validators import is_fqdn
-from noc.core.comp import smart_bytes, smart_text
+from noc.core.comp import smart_bytes
 from noc.core.ioloop.util import run_sync
 
 DEFAULT_WHOIS_SERVER = "whois.ripe.net"
@@ -91,7 +91,7 @@ async def whois_async(query, fields=None):
     except socket.gaierror as e:
         logger.error(f"Cannot resolve host {server}: {e}")
         return None
-    data = smart_text(data)
+    data = data.decode()
     data = parse_response(data)
     if fields:
         data = [(k, v) for k, v in data if k in fields]

--- a/fm/models/alarmdiagnostic.py
+++ b/fm/models/alarmdiagnostic.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # AlarmDiagnostic model
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -15,7 +15,7 @@ from mongoengine.fields import StringField, ObjectIdField, DateTimeField, Binary
 import bson
 
 # NOC modules
-from noc.core.comp import smart_bytes, smart_text
+from noc.core.comp import smart_bytes
 
 
 class AlarmDiagnostic(Document):
@@ -53,7 +53,7 @@ class AlarmDiagnostic(Document):
                 {
                     "timestamp": d.timestamp,
                     "state": d.state,
-                    "data": smart_text(zlib.decompress(smart_bytes(d.data))),
+                    "data": zlib.decompress(smart_bytes(d.data)).decode(),
                 }
             ]
         return r

--- a/inv/models/l3link.py
+++ b/inv/models/l3link.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # L3 Link model
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -14,7 +14,6 @@ from mongoengine.fields import StringField, DateTimeField, ListField, IntField
 
 # NOC modules
 from noc.core.mongo.fields import PlainReferenceListField
-from noc.core.comp import smart_text
 from noc.core.model.decorator import on_delete, on_save
 
 
@@ -45,8 +44,9 @@ class L3Link(Document):
     # L3 path cost
     l3_cost = IntField(default=1)
 
-    def __str__(self):
-        return "(%s)" % ", ".join([smart_text(i) for i in self.subinterfaces])
+    def __str__(self) -> str:
+        si = ", ".join(str(i) for i in self.subinterfaces)
+        return f"({si})"
 
     def clean(self):
         self.linked_objects = sorted({i.managed_object.id for i in self.subinterfaces})

--- a/inv/models/link.py
+++ b/inv/models/link.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # Link model
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -20,7 +20,6 @@ from noc.config import config
 from noc.core.mongo.fields import PlainReferenceListField
 from noc.core.model.decorator import on_delete, on_save
 from noc.core.change.decorator import change
-from noc.core.comp import smart_text
 from noc.main.models.label import Label
 
 
@@ -84,8 +83,9 @@ class Link(Document):
 
     def __str__(self):
         if self.interfaces:
-            return "(%s)" % ", ".join(smart_text(i) for i in self.interfaces)
-        return "Stale link (%s)" % self.id
+            si = ", ".join(str(i) for i in self.interfaces)
+            return f"({si})"
+        return f"Stale link ({self.id})"
 
     @classmethod
     def get_by_id(cls, oid: str | ObjectId) -> Optional["Link"]:

--- a/inv/models/object.py
+++ b/inv/models/object.py
@@ -243,8 +243,8 @@ class Object(Document):
 
     REBUILD_CONNECTIONS = ["links", "conduits"]
 
-    def __str__(self):
-        return smart_text(self.name or self.id)
+    def __str__(self) -> str:
+        return self.name or str(self.id)
 
     @classmethod
     @cachetools.cachedmethod(operator.attrgetter("_id_cache"), lock=lambda _: id_lock)

--- a/inv/models/objectconnection.py
+++ b/inv/models/objectconnection.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # ObjectConnection model
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -25,7 +25,6 @@ import geojson
 from noc.inv.models.object import Object
 from noc.core.mongo.fields import PlainReferenceField
 from noc.gis.models.layer import Layer
-from noc.core.comp import smart_text
 from noc.core.change.decorator import change
 from noc.core.model.decorator import on_save, on_delete
 from noc.config import config
@@ -39,7 +38,7 @@ class ObjectConnectionItem(EmbeddedDocument):
     name = StringField()
 
     def __str__(self):
-        return "%s: %s" % (smart_text(self.object), self.name)
+        return f"{self.object}: {self.name}"
 
 
 @change
@@ -65,8 +64,9 @@ class ObjectConnection(Document):
     layer = ReferenceField(Layer)
     line = LineStringField(auto_index=True)
 
-    def __str__(self):
-        return "<%s>" % ", ".join(smart_text(c) for c in self.connection)
+    def __str__(self) -> str:
+        conns = ", ".join(str(c) for c in self.connection)
+        return f"<{conns}>"
 
     @classmethod
     def get_by_id(cls, oid: str | ObjectId) -> Optional["ObjectConnection"]:

--- a/inv/models/objectfile.py
+++ b/inv/models/objectfile.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # ObjectModel model
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -11,7 +11,6 @@ from mongoengine.fields import StringField, ObjectIdField, FileField, DateTimeFi
 from mongoengine import signals
 
 # NOC modules
-from noc.core.comp import smart_text
 from .object import Object
 
 
@@ -35,8 +34,8 @@ class ObjectFile(Document):
     size = IntField()
     mime_type = StringField()
 
-    def __str__(self):
-        return smart_text(self.name or self.id)
+    def __str__(self) -> str:
+        return self.name or str(self.id)
 
     def delete_file(self):
         if self.file:

--- a/ip/models/vrfgroup.py
+++ b/ip/models/vrfgroup.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # VRFGroup model
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -13,7 +13,6 @@ from django.contrib.postgres.fields import ArrayField
 # NOC modules
 from noc.core.model.base import NOCModel
 from noc.core.model.decorator import on_delete_check
-from noc.core.comp import smart_text
 from noc.main.models.label import Label
 
 
@@ -50,9 +49,9 @@ class VRFGroup(NOCModel):
         models.CharField(max_length=250), blank=True, null=True, default=list
     )
 
-    def __str__(self):
-        return smart_text(self.name)
+    def __str__(self) -> str:
+        return self.name
 
     @classmethod
-    def can_set_label(cls, label):
+    def can_set_label(cls, label: str) -> bool:
         return Label.get_effective_setting(label, setting="enable_vrfgroup")

--- a/kb/models/kbglobalbookmark.py
+++ b/kb/models/kbglobalbookmark.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # KBGlobalBookmark
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -11,7 +11,6 @@ from django.db import models
 # NOC modules
 from noc.core.model.base import NOCModel
 from noc.kb.models.kbentry import KBEntry
-from noc.core.comp import smart_text
 
 
 class KBGlobalBookmark(NOCModel):
@@ -31,4 +30,4 @@ class KBGlobalBookmark(NOCModel):
     )
 
     def __str__(self):
-        return smart_text(self.kb_entry)
+        return str(self.kb_entry)

--- a/kb/models/kbuserbookmark.py
+++ b/kb/models/kbuserbookmark.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # KBUserBookmark
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -12,7 +12,6 @@ from django.db import models
 from noc.core.model.base import NOCModel
 from noc.aaa.models.user import User
 from noc.kb.models.kbentry import KBEntry
-from noc.core.comp import smart_text
 
 
 class KBUserBookmark(NOCModel):
@@ -30,5 +29,5 @@ class KBUserBookmark(NOCModel):
     user = models.ForeignKey(User, verbose_name="User", on_delete=models.CASCADE)
     kb_entry = models.ForeignKey(KBEntry, verbose_name="KBEntry", on_delete=models.CASCADE)
 
-    def __str__(self):
-        return "%s: %s" % (smart_text(self.user), smart_text(self.kb_entry))
+    def __str__(self) -> str:
+        return f"{self.user}: {self.kb_entry}"

--- a/sa/interfaces/base.py
+++ b/sa/interfaces/base.py
@@ -1018,7 +1018,7 @@ class TagsParameter(Parameter):
             v = [smart_text(v).strip() for v in value]
             return [x for x in v if x]
         if isinstance(value, str):
-            v = [smart_text(x.strip()) for x in value.split(",")]
+            v = [x.strip() for x in value.split(",")]
             return [x for x in v if x]
         self.raise_error("Invalid tags: %s" % value)
 

--- a/services/login/paths/auth.py
+++ b/services/login/paths/auth.py
@@ -18,7 +18,7 @@ import cachetools
 # NOC modules
 from noc.config import config
 from noc.aaa.models.apikey import APIKey
-from noc.core.comp import smart_text, smart_bytes
+from noc.core.comp import smart_bytes
 from ..auth import (
     authenticate,
     register_last_login,
@@ -200,7 +200,7 @@ async def auth_authorization_basic(
     HTTP Basic authorization handler
     """
     remote_ip = request.client.host
-    auth_data = smart_text(codecs.decode(smart_bytes(data), "base64"))
+    auth_data = codecs.decode(smart_bytes(data), "base64").decode()
     if ":" not in auth_data:
         logger.error("[Authorization|Basic][%s] Denied: Malformed data", remote_ip)
         return JSONResponse({"status": False}, status_code=401)

--- a/services/login/paths/token.py
+++ b/services/login/paths/token.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # /api/login/token handler
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2021 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -16,7 +16,7 @@ from pydantic import ValidationError, TypeAdapter
 
 # NOC modules
 from noc.config import config
-from noc.core.comp import smart_text, smart_bytes
+from noc.core.comp import smart_bytes
 from noc.core.service.deps.service import get_service
 from ..models.token import TokenRequest, TokenResponse
 from ..auth import authenticate, register_last_login, get_jwt_token, get_user_from_jwt
@@ -95,7 +95,7 @@ async def token(
                 },
                 status_code=HTTPStatus.BAD_REQUEST,
             )
-        auth_data = smart_text(codecs.decode(smart_bytes(data), "base64"))
+        auth_data = codecs.decode(smart_bytes(data), "base64").decode()
         if ":" not in auth_data:
             return JSONResponse(
                 content={

--- a/services/mrt/paths/mrt.py
+++ b/services/mrt/paths/mrt.py
@@ -29,7 +29,6 @@ from noc.sa.models.useraccess import UserAccess
 from noc.core.debug import error_report
 from noc.core.error import ERR_UNKNOWN
 from noc.config import config
-from noc.core.comp import smart_text
 
 
 logger = logging.getLogger(__name__)
@@ -38,8 +37,8 @@ router = APIRouter()
 
 
 async def _write_chunk(obj):
-    data = smart_text(orjson.dumps(obj))
-    data_str = "%s|%s" % (len(data), data)
+    data = orjson.dumps(obj).decode()
+    data_str = f"{len(data)}|{data}"
     logger.debug(data_str)
     return data_str
 

--- a/services/web/base/simplereport.py
+++ b/services/web/base/simplereport.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # SimpleReport implementation
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -493,7 +493,7 @@ class TableSection(ReportSection):
         self.columns = []
         for c in columns or []:
             if isinstance(c, str) or hasattr(c, "__unicode__"):
-                self.columns += [TableColumn(smart_text(c))]
+                self.columns += [TableColumn(c)]
             else:
                 self.columns += [c]
         self.data = data or []

--- a/support/models/crashinfo.py
+++ b/support/models/crashinfo.py
@@ -19,7 +19,6 @@ import orjson
 
 # NOC modules
 from noc.support.cp import CPClient
-from noc.core.comp import smart_text
 
 logger = logging.getLogger(__name__)
 
@@ -56,8 +55,8 @@ class Crashinfo(Document):
 
     NEW_ROOT = "local/cp/crashinfo/new"
 
-    def __str__(self):
-        return smart_text(self.uuid)
+    def __str__(self) -> str:
+        return str(self.uuid)
 
     @classmethod
     def scan(cls):


### PR DESCRIPTION
**Purpose**
Remove usage of the `smart_text()` compatibility wrapper across multiple modules. Replace with native `.decode()` for bytes-to-str conversions, direct usage where values are already strings (Django ORM CharFields), and `str()` for objects with proper `__str__` implementations.

**Key Changes**
- **Encoding**: Replaced `smart_text(bytes_result)` with `.decode()` on outputs from `b85encode()`, `zlib.decompress()`, `codecs.decode()`, `orjson.dumps()`, and raw socket data
- **Model `__str__`**: Replaced `smart_text(obj_ref)` with `str(obj_ref)` across MongoDB model references, replacing `%` formatting with f-strings
- **Imports**: Removed unused `smart_text` imports from files no longer using the function
- **String handling**: Removed redundant `smart_text()` in `SimpleReport.__init__` and `sa/interfaces/base.py` where input is already a string

**Notable Implementation Details**
- Files still referencing `smart_text` elsewhere (e.g., `core/gridvcs/base.py`, `sa/interfaces/base.py`) retain the import — no dangling imports introduced
- All replacements use strict UTF-8 decode, matching `smart_text()` default behavior
- No behavioral changes — purely a compatibility layer removal