### PR TITLE
__repr__ typing

### DIFF
--- a/core/clickhouse/functions.py
+++ b/core/clickhouse/functions.py
@@ -13,7 +13,7 @@ class AggregateFunction:
         self.function = self.db_name or function
         self.params = params
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.function
 
     # get expression

--- a/core/confdb/db/node.py
+++ b/core/confdb/db/node.py
@@ -16,7 +16,7 @@ class Node:
         self.token = token
         self.children = None
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<Node %s>" % self.token
 
     def find(self, token):

--- a/core/confdb/engine/var.py
+++ b/core/confdb/engine/var.py
@@ -13,7 +13,7 @@ class Var:
     def __str__(self) -> str:
         return self.name
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<Var '%s' at %s>" % (self.name, id(self))
 
     def get(self, ctx):

--- a/core/confdb/normalizer/base.py
+++ b/core/confdb/normalizer/base.py
@@ -35,7 +35,7 @@ class Node:
         self.children: list[Node] = []
         self.matcher = None
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self.handler:
             return "<Node %s (%s)>" % (repr(self.token), self.handler.__name__)
         return "<Node %s>" % repr(self.token)
@@ -99,7 +99,7 @@ class RootNode(Node):
     def __init__(self, token=None):
         super().__init__(token)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<RootNode>"
 
     def match(self, token):

--- a/core/confdb/syntax/patterns.py
+++ b/core/confdb/syntax/patterns.py
@@ -32,7 +32,7 @@ class ANY(BasePattern):
     def match(token):
         return True
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "ANY"
 
 
@@ -43,7 +43,7 @@ class REST(BasePattern):
     def match(token):
         return True
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "REST"
 
 
@@ -55,7 +55,7 @@ class Token(BasePattern):
     def match(self, token):
         return token == self.token
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return repr(self.token)
 
 

--- a/core/config/params.py
+++ b/core/config/params.py
@@ -86,7 +86,7 @@ class SecretParameter(BaseParameter[str]):
     def clean(self, v: Any) -> str:
         return smart_text(v)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "****hidden****"
 
 
@@ -284,7 +284,7 @@ class ServiceItem:
     def __str__(self) -> str:
         return f"{self.host}:{self.port}"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<ServiceItem {self.host}:{self.port}>"
 
     def __contains__(self, item) -> bool:

--- a/core/dns/rr.py
+++ b/core/dns/rr.py
@@ -51,7 +51,7 @@ class RR:
         l_suffix = len(to_idna(zone)) + 1
         self._sorder = self._idna[:-l_suffix]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<RR %s %s %s>" % (self.name, self.type, self.rdata)
 
     def __lt__(self, other):

--- a/core/ip.py
+++ b/core/ip.py
@@ -39,7 +39,7 @@ class IP:
         self.address, self.mask = prefix.split("/")
         self.mask = int(self.mask)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Returns string representation of prefix."""
         return f"<IPv{self.afi} {self.prefix}>"
 

--- a/core/reporter/band.py
+++ b/core/reporter/band.py
@@ -64,7 +64,7 @@ class Band:
     def __str__(self) -> str:
         return f'Band "{self.name}"'
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f'Band "{self.name}" (parent: {self.parent}, '
             f"children_bands: {len(self.children_bands)}, "

--- a/core/reporter/formatter/base.py
+++ b/core/reporter/formatter/base.py
@@ -44,7 +44,7 @@ class DataFormatter:
     def __str__(self) -> str:
         return f"DataFormatter/{self.__class__.__name__}"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"DataFormatter/{self.__class__.__name__} ("
             f"root_band: {self.root_band}, "

--- a/core/reporter/types.py
+++ b/core/reporter/types.py
@@ -90,7 +90,7 @@ class ReportBand(BaseModel):
     def __str__(self) -> str:
         return f'ReportBand "{self.name}"'
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f'ReportBand "{self.name}" ('
             f"queries: {len(self.queries) if self.queries is not None else None}, "
@@ -143,7 +143,7 @@ class BandFormat(BaseModel):
     def __str__(self) -> str:
         return f'BandFormat "{self.title_template}"'
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f'BandFormat "{self.title_template}" ('
             f"title_template: {self.title_template}, "
@@ -175,7 +175,7 @@ class Template(BaseModel):
     def __str__(self) -> str:
         return f'Template "{self.code}"'
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f'Template "{self.code}" (output_type: {self.output_type}, '
             f"content: {self.content}, "
@@ -235,7 +235,7 @@ class ReportConfig(BaseModel):
     def __str__(self) -> str:
         return f'ReportConfig "{self.name}"'
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f'ReportConfig "{self.name}" ('
             f"bands: {len(self.bands)}, "
@@ -268,7 +268,7 @@ class RunParams(BaseModel):
     def __str__(self) -> str:
         return f'RunParams "{self.report_config.name}"'
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f'RunParams "{self.report_config.name}" ('
             f"report_config: {self.report_config}, "

--- a/core/router/route.py
+++ b/core/router/route.py
@@ -177,7 +177,7 @@ class Route:
     def __str__(self) -> str:
         return f"{self.name} ({self.type}, {self.order}): {self.actions}"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.name} ({self.type}, {self.order}): {self.actions}"
 
     @property

--- a/core/snmp/error.py
+++ b/core/snmp/error.py
@@ -99,7 +99,7 @@ class SNMPError(Exception):
         self.code = code
         self.oid = oid
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         try:
             name = SNMPErrorCode(self.code).name
         except ValueError:


### PR DESCRIPTION
**Purpose:** Add return type annotations to all `__repr__` methods across core modules, completing the pair with PR #349 (`__str__` typing). This continues the broader typing initiative tracked in PR #350.

**Key changes:**
- Added `-> str` return type annotation to 21 `__repr__` methods
- 13 files affected across `core/`: clickhouse, confdb, config, dns, ip, reporter, router, snmp
- Zero behavioral changes — pure type annotations only