### PR TITLE
setuptools >= 83.0.0, prevent PYSEC-2026-3447

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools>=61.2", "wheel"]
+requires = ["setuptools>=83.0.0", "wheel"]
 
 [project]
 authors = [{name = "Gufo Labs"}]


### PR DESCRIPTION
Bump the minimum `setuptools` version in build requirements to mitigate security advisory PYSEC-2026-3447.

### Key Changes
- Updated `[build-system].requires` from `setuptools>=61.2` to `setuptools>=83.0.0` in `pyproject.toml`

### Notable Implementation Details
- This affects only the build-time dependency declaration
- No runtime behavior changes — setuptools is used by `pip install` and wheel building, not at runtime
- Version 83.0.0 should be available on all target deployment systems (Debian Bookworm+, Ubuntu 24.04+, mainstream Python distributors)

### References
- PYSEC-2026-3447: https://scout.docker.com/vulnerabilities/id/CVE-2026-59890
