### PR TITLE
fix selection data grid

### DIFF
--- a/ui/web/js/override.js
+++ b/ui/web/js/override.js
@@ -413,6 +413,31 @@ NOC._deferredExtPatches.push(function(){
 });
 
 //
+// ExtJS 6.0.1: CheckboxModel#onHeaderClick ignores showHeaderCheckbox:false —
+// the flag only hides the checkbox visual, while a click on the (empty)
+// checkbox column header still triggers selectAll/deselectAll. selectAll()
+// then crashes on a BufferedStore-backed grid (Ext.selection.Model#selectAll
+// -> store.getRange -> rangeCached/hasRange walks the page map and hits an
+// uncached page: "me.getPage(...) is undefined"). Seen on the sa.managedobject
+// selection grid (checkboxmodel, MULTI, showHeaderCheckbox:false, buffered
+// selectionStore). Backport of the later ExtJS behaviour: respect the flag.
+//
+// Deferred to Ext.application launch: the theme overrides
+// Ext.theme.noc.selection.CheckboxModel, so a parse-time override of the same
+// class would be clobbered (see NOC._deferredExtPatches above).
+//
+NOC._deferredExtPatches.push(function(){
+  Ext.override(Ext.selection.CheckboxModel, {
+    onHeaderClick: function(){
+      if(this.showHeaderCheckbox === false){
+        return;
+      }
+      this.callParent(arguments);
+    },
+  });
+});
+
+//
 // Route Ext.data.Connection.request (and therefore Ext.Ajax and all
 // Ext.data.proxy.Ajax / Rest proxies used by stores and combos) through
 // NOC.api.requestLegacy — a fetch-based transport. This eliminates the

--- a/ui/web/sa/managedobject/Application.js
+++ b/ui/web/sa/managedobject/Application.js
@@ -215,6 +215,7 @@ Ext.define("NOC.sa.managedobject.Application", {
               selModel: {
                 mode: "MULTI",
                 selType: "checkboxmodel",
+                showHeaderCheckbox: false,
               },
               listeners: {
                 selectionchange: "onSelectionChange",

--- a/ui/web/sa/managedobject/Controller.js
+++ b/ui/web/sa/managedobject/Controller.js
@@ -520,7 +520,7 @@ Ext.define("NOC.sa.managedobject.Controller", {
   },
   //
   getNRows: function(m, n){
-    var params, me = this,
+    let params,
       selectionGrid = this.lookupReference("saManagedobjectSelectionGrid"),
       limit = Number.parseInt(n),
       start = Number.parseInt(m);
@@ -539,13 +539,15 @@ Ext.define("NOC.sa.managedobject.Controller", {
         url: this.lookupReference("saManagedobjectSelectionGrid").getStore().rest_url,
         method: "POST",
         jsonData: params,
-        scope: me,
+        scope: this,
         success: function(response){
-          var params = Ext.decode(response.request.requestOptions.data);
+          let store = this.lookupReference("saManagedobjectSelectedGrid1").getStore();
           selectionGrid.unmask();
-          selectionGrid.getSelectionModel().selectRange(params.__start, params.__start + params.__limit - 1);
-          me.lookupReference("saManagedobjectSelectedGrid1").getStore()
-                        .insert(0, Ext.decode(response.responseText));
+          selectionGrid.getSelectionModel().selectRange(start, start + limit - 1);
+          if(store){
+            let data = Ext.decode(response.responseText);
+            store.insert(0, data);
+          }
         },
         failure: function(){
           selectionGrid.unmask();


### PR DESCRIPTION
**Purpose:** Fix a crash that occurs on the SA managed object selection grid when users attempt to click the header row of the checkbox column.

**Root cause:** ExtJS 6.0.1's `CheckboxModel#onHeaderClick` ignores the `showHeaderCheckbox: false` configuration — it only hides the visual checkbox, but clicking the empty header still triggers `selectAll()`, which crashes a `BufferedStore`-backed grid because `getRange()` tries to access uncached pages (resulting in `me.getPage(...) is undefined`).

**Key changes:**
- **ui/web/js/override.js:** Add deferred patch that overrides `CheckboxModel#onHeaderClick` to return early when `showHeaderCheckbox` is `false`, backporting later ExtJS behavior. Uses `_deferredExtPatches` to avoid being clobbered by theme overrides.
- **ui/web/sa/managedobject/Application.js:** Set `showHeaderCheckbox: false` on the selection grid's `selModel` so users won't accidentally select/deselect all rows via header click.
- **ui/web/sa/managedobject/Controller.js:** Refactor `getNRows()` — replace closure variable `me = this` with explicit `scope: this`, use closure-scoped `start`/`limit` instead of re-decoding request parameters, add defensive `if(store)` guard before insert.

**Notable implementation details:**
- The override is deferred via `NOC._deferredExtPatches` because the theme overrides `Ext.theme.noc.selection.CheckboxModel` at launch time; a parse-time override would be clobbered.
- The controller changes are side-by-side cleanup — not strictly required for the bug fix, but improve code quality and prevent potential NPE scenarios.
