### PR TITLE
kpi/py-typing: update function names for better readability

### DIFF
--- a/scripts/kpi/py-typing.py
+++ b/scripts/kpi/py-typing.py
@@ -45,9 +45,9 @@ class KPISummary:
         typed_modules: Modules with all typed functions.
         typed_classes: Classes with all typed functions.
         typed_functions: Fully typed functions.
-        typed_modules_percent: Percentage of typed modules, None - if cannot deducted.
-        typed_classes_percent: Percentage of typed classes, None - if cannot deducted.
-        typed_functions_percent: Percentage of typed functions, None - if cannot deducted.
+        typed_modules_percent: Percentage of typed modules, None - if cannot deduced.
+        typed_classes_percent: Percentage of typed classes, None - if cannot deduced.
+        typed_functions_percent: Percentage of typed functions, None - if cannot deduced.
     """
 
     total_packages: int
@@ -263,9 +263,7 @@ def get_module_name(path: Path) -> str:
     return ".".join(("noc", *parts))
 
 
-def estimate_kpi(
-    path: Path,
-) -> Iterable[KPI]:
+def scan_module(path: Path) -> Iterable[KPI]:
     try:
         source = path.read_text(encoding="utf-8")
         tree = ast.parse(source)
@@ -284,7 +282,7 @@ def estimate_kpi(
     return visitor.rows
 
 
-def to_estimate(path: Path) -> bool:
+def can_scan(path: Path) -> bool:
     parts = path.parts
 
     for part in parts:
@@ -311,14 +309,14 @@ def scan_tree() -> Iterable[KPI]:
     seen: set[Path] = set()
     for path in sorted(root.rglob("*.py")):
         rel_path = path.relative_to(root)
-        if not to_estimate(rel_path):
+        if not can_scan(rel_path):
             continue
         canonical_path = canonical_name(rel_path)
         effective_path = canonical_path if canonical_path.exists() else rel_path
         if effective_path in seen:
             continue
 
-        yield from estimate_kpi(effective_path)
+        yield from scan_module(effective_path)
 
 
 def write_csv(

--- a/scripts/kpi/py-typing.py
+++ b/scripts/kpi/py-typing.py
@@ -45,9 +45,9 @@ class KPISummary:
         typed_modules: Modules with all typed functions.
         typed_classes: Classes with all typed functions.
         typed_functions: Fully typed functions.
-        typed_modules_percent: Percentage of typed modules, None - if cannot deduced.
-        typed_classes_percent: Percentage of typed classes, None - if cannot deduced.
-        typed_functions_percent: Percentage of typed functions, None - if cannot deduced.
+        typed_modules_percent: Percentage of typed modules, None - if cannot be calculated.
+        typed_classes_percent: Percentage of typed classes, None - if cannot be calculated.
+        typed_functions_percent: Percentage of typed functions, None - if cannot be calculated.
     """
 
     total_packages: int


### PR DESCRIPTION
mprove the readability of `scripts/kpi/py-typing.py` by renaming internal functions to better reflect their responsibilities and fixing documentation typos.

**Key changes**

- Renamed `estimate_kpi()` → `scan_module()`: the function parses an AST from a single file and yields KPI rows — "scan" is more accurate than "estimate"
- Renamed `to_estimate()` → `can_scan()`: a boolean predicate that determines whether a path should be scanned — new name clearly expresses this intent
- All call sites updated (`scan_tree` function)
- Fixed class-level docstring for `KPISummary`: corrected awkward grammar across 3 fields (`typed_modules_percent`, `typed_classes_percent`, `typed_functions_percent`) — `"cannot deducted"` → `"cannot be calculated"`

**Notable implementation details**

Both renamed functions are internal to the module. The refactoring is purely cosmetic with no behavioural changes.
