### PR TITLE
double-underscore functions typing

### DIFF
--- a/core/cdag/node/alarm.py
+++ b/core/cdag/node/alarm.py
@@ -200,5 +200,5 @@ class AlarmNode(BaseCDAGNode):
             return True
         return super().is_required_input(name)
 
-    def __del__(self):
+    def __del__(self) -> None:
         self.reset_state()

--- a/core/cdag/node/threshold.py
+++ b/core/cdag/node/threshold.py
@@ -243,7 +243,7 @@ class ThresholdNode(BaseCDAGNode):
         svc = get_service()
         svc.publish(orjson.dumps(msg), stream=f"dispose.{pool}", partition=self.config.partition)
 
-    def __del__(self):
+    def __del__(self) -> None:
         self.reset_state()
 
     def clean_state(self, state: dict[str, Any] | None) -> BaseModel | None:

--- a/core/checkers/base.py
+++ b/core/checkers/base.py
@@ -68,7 +68,7 @@ class Check:
     def __str__(self) -> str:
         return f"{self.name}?{self.args}"
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.key)
 
     @property
@@ -190,7 +190,7 @@ class CheckResult:
     def __str__(self) -> str:
         return f"{self.check}?{self.args}: {self.status}"
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.key)
 
     @property

--- a/core/datasources/base.py
+++ b/core/datasources/base.py
@@ -36,7 +36,7 @@ class ClickhouseColumn:
     default_kind: str | None = None  # DEFAULT, MATERIALIZED
     default_expression: str | None = None
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         """"""
         return hash(self.name)
 

--- a/core/etl/bi/stream.py
+++ b/core/etl/bi/stream.py
@@ -34,7 +34,7 @@ class Stream:
         self.chunk_size = 0
         self.ts_field = self.model._meta.ordered_fields[1].name
 
-    def __del__(self):
+    def __del__(self) -> None:
         if self.out:
             os.unlink(self.out_path)
 

--- a/core/ioloop/udp.py
+++ b/core/ioloop/udp.py
@@ -34,7 +34,7 @@ class UDPSocket:
             self.socket.setsockopt(socket.IPPROTO_IP, socket.IP_TOS, tos)
         self.socket.setblocking(False)
 
-    def __del__(self):
+    def __del__(self) -> None:
         self.close()
 
     def close(self):

--- a/core/ip.py
+++ b/core/ip.py
@@ -47,7 +47,7 @@ class IP:
         """Returns string containing prefix."""
         return self.prefix
 
-    def __len__(self):
+    def __len__(self) -> int:
         """Returns mask length (in bits)."""
         return self.mask
 
@@ -358,7 +358,7 @@ class IPv4(IP):
             "%d.%d.%d.%d/%d" % ((s >> 24) & 0xFF, (s >> 16) & 0xFF, (s >> 8) & 0xFF, s & 0xFF, mask)
         )
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         """Hash the IPv4 instance."""
         return self.d
 
@@ -727,7 +727,7 @@ class IPv6(IP):
             )
         return IPv6(":".join(["%x" % p for p in r]) + "/%d" % mask)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         """Hash the IPv6 instance (by prefix string)."""
         return hash(self.prefix)
 

--- a/core/mx.py
+++ b/core/mx.py
@@ -49,7 +49,7 @@ class NotificationContact:
     headers: dict[str, Any] | None = None
     route: str | None = None
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(f"{self.method}_{self.contact}")
 
 

--- a/core/script/cli/ssh.py
+++ b/core/script/cli/ssh.py
@@ -43,7 +43,7 @@ class SSHStream(BaseStream):
         self.channel = None
         self.credentials = cli.script.credentials
 
-    def __del__(self):
+    def __del__(self) -> None:
         self.channel = None
         self.session = None
 

--- a/core/topology/base.py
+++ b/core/topology/base.py
@@ -71,7 +71,7 @@ class TopologyBase:
         self.settings = kwargs or {}
         self.load()  # Load nodes
 
-    def __len__(self):
+    def __len__(self) -> int:
         """Map nodes count."""
         return len(self.G)
 


### PR DESCRIPTION
Add return type annotations to special (dunder) methods across 10 core modules, continuing the typing migration initiated in #349 (`__str__`) and #351 (`__repr__`). These additions improve type-checker accuracy with zero runtime impact.

**Key Changes**
- `core/cdag/node/alarm.py` — `AlarmNode.__del__ -> None`
- `core/cdag/node/threshold.py` — `ThresholdNode.__del__ -> None`
- `core/checkers/base.py` — `Check.__hash__`, `CheckResult.__hash__ -> int`
- `core/datasources/base.py` — `ClickhouseColumn.__hash__ -> int`
- `core/etl/bi/stream.py` — `BIStream.__del__ -> None`
- `core/ioloop/udp.py` — `UDPSocket.__del__ -> None`
- `core/ip.py` — `IPv4.__len__`, `IPv4.__hash__`, `IPv6.__hash__ -> int`
- `core/mx.py` — `NotificationContact.__hash__ -> int`
- `core/script/cli/ssh.py` — `SSHSession.__del__ -> None`
- `core/topology/base.py` — `TopoMap.__len__ -> int`

**Notable Implementation Details**
- All return types follow PEP 484 special method conventions (`__hash__` always returns `int`, `__len__` always returns `int`, `__del__` always returns `None`)
- No semantic or behavioral changes — pure annotation additions
- Consistent with the incremental typing migration approach