### PR TITLE
kpi/py-typing.py: Fix module name detection

### DIFF
--- a/scripts/kpi/py-typing.py
+++ b/scripts/kpi/py-typing.py
@@ -6,11 +6,13 @@
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
+# Python modules
 from __future__ import annotations
 
 import sys
 import ast
 import csv
+from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, TextIO
@@ -255,11 +257,9 @@ class KPIVisitor:
 
 def get_module_name(path: Path) -> str:
     """Convert path to module name."""
-    if path.parts[:2] == ("src", "noc"):
-        parts = list(path.parts[2:])
-    else:
-        parts = list(path.parts)
-    parts[-1] = parts[-1].rstrip(".py")
+    parts = path.with_suffix("").parts
+    if parts[:2] == ("src", "noc"):
+        parts = parts[2:]
     return ".".join(("noc", *parts))
 
 
@@ -338,19 +338,20 @@ def write_csv(
         ]
     )
 
-    for row in rows:
-        writer.writerow(
-            [
-                row.file,
-                row.module,
-                row.cls,
-                row.function,
-                row.lineno,
-                "yes" if row.args_typed else "no",
-                "yes" if row.return_typed else "no",
-                "yes" if row.uses_any else "no",
-            ]
-        )
+    with suppress(BrokenPipeError):
+        for row in rows:
+            writer.writerow(
+                [
+                    row.file,
+                    row.module,
+                    row.cls,
+                    row.function,
+                    row.lineno,
+                    "yes" if row.args_typed else "no",
+                    "yes" if row.return_typed else "no",
+                    "yes" if row.uses_any else "no",
+                ]
+            )
 
 
 def dump_summary(rows: Iterable[KPI]):


### PR DESCRIPTION
Fix `get_module_name()` to use `Path.with_suffix("")` instead of `.rstrip(".py")` for reliable `.py` suffix removal, and handle BrokenPipeError gracefully when piping CSV output.

## Key Changes

- **`get_module_name()`:** Replace manual `.rstrip(".py")` + slicing with `Path.with_suffix("").parts`. The previous approach (`str.rstrip(".py")`) strips any trailing character from the set `{'.', 'p', 'y'}`, which silently truncates filenames containing those characters (e.g., `foopy.py` → `foo`). `with_suffix("")` correctly removes only the file extension.

- **`write_csv()`:** Wrap the CSV writer loop in `suppress(BrokenPipeError)` to handle SIGPIPE gracefully when stdout is piped and the consuming process terminates early.

## Notable Implementation Details

- Added `from contextlib import suppress` import
- Since py-typing.py only scans `.py` files, the behavioral difference between `rstrip` and `with_suffix` is a pure bug-fix with no regressions for normal inputs
- Indentation matches existing file conventions (4-space indent with aligned list items)
