### PR TITLE
Set typing for __init__ functions

### DIFF
--- a/commands/discovery.py
+++ b/commands/discovery.py
@@ -171,7 +171,7 @@ class Command(BaseCommand):
 
 
 class ServiceStub:
-    def __init__(self):
+    def __init__(self) -> None:
         self.metrics = defaultdict(list)
         self.service_id = "stub"
         self.address = "127.0.0.1"

--- a/commands/mib.py
+++ b/commands/mib.py
@@ -278,7 +278,7 @@ class Command(BaseCommand):
 
 
 class ServiceStub:
-    def __init__(self):
+    def __init__(self) -> None:
         self.service_id = "stub"
         self.logger = logging.getLogger(__name__)
         self.address = "127.0.0.1"

--- a/core/cache/redis.py
+++ b/core/cache/redis.py
@@ -20,7 +20,7 @@ ignorable_redis_errors = (redis.exceptions.ConnectionError, redis.exceptions.Tim
 
 
 class RedisCache(BaseCache):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.redis = redis.StrictRedis(
             host=config.redis.addresses[0].host,

--- a/core/change/policy.py
+++ b/core/change/policy.py
@@ -198,7 +198,7 @@ class BaseChangeTrackerPolicy(metaclass=ABCMeta):
     Base class for change tracker policies
     """
 
-    def __init__(self): ...
+    def __init__(self) -> None: ...
 
     @abstractmethod
     def register(self, item: ChangeItem, audit: bool = False) -> None: ...
@@ -248,7 +248,7 @@ class SimpleChangeTrackerPolicy(BaseChangeTrackerPolicy):
 
 
 class BulkChangeTrackerPolicy(BaseChangeTrackerPolicy):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.changes: dict[str, dict[int, ChangeItem]] = defaultdict(dict)
         self.ds_changes: dict[str, set[str]] = defaultdict(set)

--- a/core/checkers/loader.py
+++ b/core/checkers/loader.py
@@ -20,7 +20,7 @@ class CheckersLoader(BaseLoader):
     base_path = ("core", "checkers")
     ignored_names = {"base", "loader", "registry"}
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.checkers = {}
         self.script_checkers = {}

--- a/core/confdb/db/base.py
+++ b/core/confdb/db/base.py
@@ -12,7 +12,7 @@ from .marshall.loader import loader
 
 
 class ConfDB:
-    def __init__(self):
+    def __init__(self) -> None:
         self.db = Node(None)
 
     def insert(self, tokens):

--- a/core/confdb/engine/base.py
+++ b/core/confdb/engine/base.py
@@ -32,7 +32,7 @@ def visitor(args):
 class Engine:
     CLEANUP_NODES = {"hints"}
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.db = None
 
     def compile(self, expr):

--- a/core/dcs/loader.py
+++ b/core/dcs/loader.py
@@ -25,7 +25,7 @@ DEFAULT_DCS = "consul://%s:%s/%s" % (config.consul.host, config.consul.port, con
 class DCSRunner:
     HANDLERS = {"consul": "noc.core.dcs.consul.ConsulDCS"}
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.lock = Lock()
         self.thread: Thread | None = None
         self.loop: asyncio.BaseEventLoop | None = None

--- a/core/etl/loader/loader.py
+++ b/core/etl/loader/loader.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 class LoaderLoader:
-    def __init__(self):
+    def __init__(self) -> None:
         self.loaders = {}  # Load loaders
         self.lock = threading.Lock()
         self.all_loaders = set()

--- a/core/expr.py
+++ b/core/expr.py
@@ -26,7 +26,7 @@ class _VarVisitor(ast.NodeVisitor):
     Collect all variable names from expression
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.vars: set[str] = set()
         self.skip: set[str] = set()

--- a/core/importer.py
+++ b/core/importer.py
@@ -148,7 +148,7 @@ class NOCCustomLoader(NOCLoader):
 class NOCImportRouter(importlib.abc.MetaPathFinder):
     """Finder that delegates to NOC-specific loaders based on prefix."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._check_custom = config.path.custom_path and os.path.exists(config.path.custom_path)
 
     def find_spec(

--- a/core/interface/loader.py
+++ b/core/interface/loader.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 class InterfaceLoader:
     rx_class = re.compile(r"^class\s+(?P<name>\S+)\(", re.MULTILINE)
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.interfaces = {}  # Load interfaces
         self.lock = threading.Lock()
         self.all_interfaces = set()

--- a/core/ioloop/udpserver.py
+++ b/core/ioloop/udpserver.py
@@ -34,7 +34,7 @@ class UDPServerProtocol(asyncio.DatagramProtocol):
 
 
 class UDPServer:
-    def __init__(self):
+    def __init__(self) -> None:
         self._transports: list[asyncio.BaseTransport] = []
         self._sockaddr: list[tuple[str, int]] = []
 

--- a/core/loader/base.py
+++ b/core/loader/base.py
@@ -24,7 +24,7 @@ class BaseLoader:
     base_path = None  # Tuple of path components
     ignored_names = set()
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.logger = PrefixLoggerAdapter(logger, self.name)
         self.classes = {}
         self.lock = threading.Lock()

--- a/core/mib.py
+++ b/core/mib.py
@@ -23,7 +23,7 @@ class MIBRegistry:
     PATHS = config.get_customized_paths("cmibs")
     load_lock = Lock()
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.mib: dict[str, str] = {}
         self.hints = {}
         self.loaded_mibs = set()

--- a/core/migration/base.py
+++ b/core/migration/base.py
@@ -17,7 +17,7 @@ class BaseMigration:
     db = db
     aliases: list[str] | None = None
 
-    def __init__(self):
+    def __init__(self) -> None:
         # @todo: set_comprehensions
         self.dependencies = {f"{x[0]}.{x[1]}" for x in self.depends_on}
 

--- a/core/migration/db.py
+++ b/core/migration/db.py
@@ -24,7 +24,7 @@ class DB:
 
     MAX_NAME_LENGTH = 63
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.deferred_sql = []
 
     @staticmethod

--- a/core/migration/runner.py
+++ b/core/migration/runner.py
@@ -15,7 +15,7 @@ from .loader import MigrationLoader
 
 
 class MigrationRunner:
-    def __init__(self):
+    def __init__(self) -> None:
         self.db = get_db()
         self.hist_coll = self.db["migrations"]
         self.logger = logging.getLogger("migration")

--- a/core/msgstream/client.py
+++ b/core/msgstream/client.py
@@ -43,7 +43,7 @@ class MessageStreamClient:
     ? MessageQueueBuffer (SaveHeaders)
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.client = self.get_client()
 
     @classmethod

--- a/core/msgstream/kafka.py
+++ b/core/msgstream/kafka.py
@@ -47,7 +47,7 @@ class KafkaClient:
     SUBSCRIBE_BULK = True
     RESOLVE_RETRY = 1.0
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.bootstrap = None
         self.producer: AIOKafkaProducer | None = None
         self.consumer: AIOKafkaConsumer | None = None

--- a/core/msgstream/liftbridge.py
+++ b/core/msgstream/liftbridge.py
@@ -28,7 +28,7 @@ class LiftBridgeClient(GugoLiftbridgeClient):
     SUBSCRIBE_BULK = False
     TIMESTAMP_MULTIPLIER = 1000_0000_00
 
-    def __init__(self):
+    def __init__(self) -> None:
         broker = run_sync(self.resolve_broker)
         super().__init__(
             [broker],

--- a/core/profile/loader.py
+++ b/core/profile/loader.py
@@ -23,7 +23,7 @@ GENERIC_PROFILE = "Generic.Host"
 class ProfileLoader(BaseLoader):
     name = "profile"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.profiles = {}  # Load profiles
         self.lock = threading.Lock()

--- a/core/router/base.py
+++ b/core/router/base.py
@@ -42,7 +42,7 @@ class Router:
     DEFAULT_JOB_CHAIN = "default_job"
     DEFAULT_ETL_EVENT_PUSH_JOB_CHAIN = "default_etl_event_push"
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.chains: defaultdict[bytes, list[Route]] = defaultdict(list)
         self.routes: dict[str, Route] = {
             self.DEFAULT_N_CHAIN: DefaultNotificationRoute(),  # Add default route for notification

--- a/core/router/route.py
+++ b/core/router/route.py
@@ -309,7 +309,7 @@ class DefaultNotificationRoute(Route):
 
     MX_METRIC = MessageType.METRICS.value.encode()
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(name="default", r_type="*", order=-1)
         self.notification_action = NotificationAction(ActionCfg("notification_group"))
         self.message_action = MessageAction(ActionCfg("notification_group"))
@@ -343,7 +343,7 @@ class DefaultJobRoute(Route):
 
     MX_JOB = MessageType.JOB.value.encode()
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(name="jobs", r_type="job", order=999)
         self.job_action = JobAction(ActionCfg("job", stream=JOBS_STREAM))
 
@@ -365,7 +365,7 @@ class DefaultETLEventRoute(Route):
     MX_JOB = MessageType.ETL_PUSH.value.encode()
     DEFAULT_HANDLER = "noc.main.models.remotesystem.processed_remote_event"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(name="etl_jobs", r_type="*", order=999)
         self.job_action = JobAction(
             ActionCfg(

--- a/core/runner/lock.py
+++ b/core/runner/lock.py
@@ -18,7 +18,7 @@ class _Waiter:
 
 
 class LockManager:
-    def __init__(self):
+    def __init__(self) -> None:
         self._lock = asyncio.Lock()
         self._waiters: dict[str, _Waiter] = {}
 

--- a/core/script/beef.py
+++ b/core/script/beef.py
@@ -50,7 +50,7 @@ class MIBData(NamedTuple):
 
 
 class Beef:
-    def __init__(self):
+    def __init__(self) -> None:
         self.version: str | None = None
         self.uuid = None
         self.spec = None

--- a/core/script/loader.py
+++ b/core/script/loader.py
@@ -27,7 +27,7 @@ class ScriptLoader(BaseLoader):
 
     protected_names = {"profile", "__init__"}
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.scripts = {}  # Load scripts
         self.lock = threading.Lock()

--- a/core/script/sessionstore.py
+++ b/core/script/sessionstore.py
@@ -24,7 +24,7 @@ class Session:
 
 
 class SessionStore:
-    def __init__(self):
+    def __init__(self) -> None:
         self._lock = Lock()
         self._sessions: dict[str, Session] = {}
         self._loop: asyncio.BaseEventLoop | None = None

--- a/core/service/base.py
+++ b/core/service/base.py
@@ -113,7 +113,7 @@ class BaseService:
     class RegistrationError(Exception):
         pass
 
-    def __init__(self):
+    def __init__(self) -> None:
         set_service(self)
         sys.excepthook = excepthook
         self.loop: asyncio.BaseEventLoop | None = None

--- a/core/service/fastapi.py
+++ b/core/service/fastapi.py
@@ -35,7 +35,7 @@ class FastAPIService(BaseService):
     # Additional OpenAPI tags docs, tag -> description
     OPENAPI_TAGS_DOCS: dict[str, str] = {}
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.app = None
         # WSGI application of any third-party framework that will be attached to the main

--- a/core/service/stub.py
+++ b/core/service/stub.py
@@ -30,7 +30,7 @@ class ServiceStub:
     name = "stub"
     pooled = False
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.logger = logging.getLogger("stub")
         self.is_ready = threading.Event()
         self.is_publisher_stopped = threading.Event()

--- a/core/techdomain/controller/base.py
+++ b/core/techdomain/controller/base.py
@@ -119,7 +119,7 @@ class BaseController:
     # False - return whole object
     adhoc_endpoints: bool = False
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.logger = PrefixLoggerAdapter(logging.getLogger("controller"), self.name)
         self.constraints = ConstraintSet()
 

--- a/core/techdomain/profile/base.py
+++ b/core/techdomain/profile/base.py
@@ -26,5 +26,5 @@ class BaseProfileController:
 
     name: str
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.logger = PrefixLoggerAdapter(logging.getLogger("controller"), self.name)

--- a/docs/confdb-reference/tokenizer.md
+++ b/docs/confdb-reference/tokenizer.md
@@ -140,7 +140,7 @@ It is advised to call superclass' constructor:
 ```python
 class MyTokenizer(BaseTokenizer):
     ...
-    def __init__(self,  data, param1=default1, ...) -> None:
+    def __init__(self, data, param1=default1, ...) -> None:
         super(MyTokenizer, self).__init__(data)
 ```
 

--- a/docs/confdb-reference/tokenizer.md
+++ b/docs/confdb-reference/tokenizer.md
@@ -140,7 +140,7 @@ It is advised to call superclass' constructor:
 ```python
 class MyTokenizer(BaseTokenizer):
     ...
-    def __init__(self, data, param1=default1, ...):
+    def __init__(self,  data, param1=default1, ...) -> None:
         super(MyTokenizer, self).__init__(data)
 ```
 

--- a/docs/etl/index.md
+++ b/docs/etl/index.md
@@ -236,7 +236,7 @@ class ManagedObjectLoader(BaseLoader):
     model = ManagedObjectModel
     data_model = ManagedObject
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self,  *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.clean_map["pool"] = Pool.get_by_name
         self.clean_map["fm_pool"] = lambda x: Pool.get_by_name(x) if x else None

--- a/docs/etl/index.md
+++ b/docs/etl/index.md
@@ -236,7 +236,7 @@ class ManagedObjectLoader(BaseLoader):
     model = ManagedObjectModel
     data_model = ManagedObject
 
-    def __init__(self,  *args, **kwargs) -> None:
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.clean_map["pool"] = Pool.get_by_name
         self.clean_map["fm_pool"] = lambda x: Pool.get_by_name(x) if x else None

--- a/docs/etl/index.ru.md
+++ b/docs/etl/index.ru.md
@@ -232,7 +232,7 @@ class ManagedObjectLoader(BaseLoader):
     model = ManagedObjectModel
     data_model = ManagedObject
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self,  *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.clean_map["pool"] = Pool.get_by_name
         self.clean_map["fm_pool"] = lambda x: Pool.get_by_name(x) if x else None

--- a/docs/etl/index.ru.md
+++ b/docs/etl/index.ru.md
@@ -232,7 +232,7 @@ class ManagedObjectLoader(BaseLoader):
     model = ManagedObjectModel
     data_model = ManagedObject
 
-    def __init__(self,  *args, **kwargs) -> None:
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.clean_map["pool"] = Pool.get_by_name
         self.clean_map["fm_pool"] = lambda x: Pool.get_by_name(x) if x else None

--- a/docs/tools/collection-to-md.py
+++ b/docs/tools/collection-to-md.py
@@ -313,7 +313,7 @@ class FileWriter:
 class CollectionDoc:
     rx_indent = re.compile(r"^(\s+)-")
 
-    def __init__(self):
+    def __init__(self) -> None:
         full_path = os.path.abspath(sys.argv[0])
         self.src_root = os.path.abspath(os.path.join(os.path.dirname(full_path), "..", ".."))
         self.doc_root = os.path.join(self.src_root, "docs", "en", "docs")

--- a/gis/map.py
+++ b/gis/map.py
@@ -21,7 +21,7 @@ from noc.core.geo import distance, get_bbox
 class Map:
     CONDUITS_LAYERS = ["manholes", "cableentries"]
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.layers = {}
         self.srid_map = {}
         # Database projection

--- a/gis/parsers/geocoding/base.py
+++ b/gis/parsers/geocoding/base.py
@@ -12,7 +12,7 @@ import itertools
 class GeocodingParser:
     ID_ADDR = None
 
-    def __init__(self):
+    def __init__(self) -> None:
         pass
 
     def parse(self, f):

--- a/gis/parsers/geocoding/osm.py
+++ b/gis/parsers/geocoding/osm.py
@@ -15,7 +15,7 @@ from .base import GeocodingParser
 class OSMXMLParser(GeocodingParser):
     ID_ADDR = "OSM_ID"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.xml_parser = ParserCreate()
         self.xml_parser.StartElementHandler = self.xml_start_element

--- a/inv/migrations/0023_interface_classification_rule_labels.py
+++ b/inv/migrations/0023_interface_classification_rule_labels.py
@@ -24,7 +24,7 @@ class InterfaceClassifierLabels:
     Class for convert ManagedObjectSelector Fields to Labels set
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.profiles = {}
         self.regex_label = {}
         self.regex_bulk = []

--- a/sa/migrations/0219_managed_object_selector_resource_group.py
+++ b/sa/migrations/0219_managed_object_selector_resource_group.py
@@ -67,7 +67,7 @@ class ManagedObjectSelectorLabels:
         "filter_tt_system": {"collection": "noc.ttsystem", "category": "ttsystem"},
     }
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.profiles = {}
         self.regex_label = {}
         self.regex_bulk = []

--- a/scripts/deploy/cleanup-pyc
+++ b/scripts/deploy/cleanup-pyc
@@ -9,12 +9,13 @@
 # Python modules
 import os
 import sys
+
 # NOC modules
 from noc.settings import INSTALLED_APPS
 
 
-class Cleanup(object):
-    def __init__(self):
+class Cleanup:
+    def __init__(self) -> None:
         self.errors = []
         self.changed = []
 
@@ -51,14 +52,13 @@ class Cleanup(object):
             for e in self.errors:
                 print(e)
             return 1
-        elif self.changed:
+        if self.changed:
             print("CHANGED")
             for c in self.changed:
                 print("Removed %s" % c)
             return 0
-        else:
-            print("OK")
-            return 0
+        print("OK")
+        return 0
 
 
 if __name__ == "__main__":

--- a/scripts/deploy/compile-bytecode
+++ b/scripts/deploy/compile-bytecode
@@ -14,8 +14,8 @@ import py_compile
 import subprocess
 
 
-class BytecodeCompiler(object):
-    def __init__(self):
+class BytecodeCompiler:
+    def __init__(self) -> None:
         self.errors = []
         self.changed = False
 
@@ -46,7 +46,7 @@ class BytecodeCompiler(object):
     def compile_file(self, f):
         try:
             py_compile.compile(f)
-        except (IOError, SyntaxError) as e:
+        except (OSError, SyntaxError) as e:
             self.error(e)
 
     def compile(self):
@@ -65,12 +65,11 @@ class BytecodeCompiler(object):
             for e in self.errors:
                 print(e)
             return 1
-        elif self.changed:
+        if self.changed:
             print("CHANGED")
             return 0
-        else:
-            print("OK")
-            return 0
+        print("OK")
+        return 0
 
 
 if __name__ == "__main__":

--- a/services/bi/service.py
+++ b/services/bi/service.py
@@ -16,7 +16,7 @@ class BIService(FastAPIService):
     use_mongo = True
     traefik_routes_rule = "PathPrefix(`/api/bi`)"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
 

--- a/services/chwriter/service.py
+++ b/services/chwriter/service.py
@@ -28,7 +28,7 @@ class CHWriterService(FastAPIService):
 
     CH_SUSPEND_ERRORS = {598, 599}
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.channels: dict[str, Channel] = {}
         self.last_ts = None

--- a/services/classifier/abdetector.py
+++ b/services/classifier/abdetector.py
@@ -12,7 +12,7 @@ from noc.inv.models.interface import Interface
 
 
 class AbductDetector:
-    def __init__(self):
+    def __init__(self) -> None:
         self.active: dict[int, list[tuple[int, str]]] = {}
 
     def register_up(self, ts: int, interface: Interface):

--- a/services/classifier/evfilter/base.py
+++ b/services/classifier/evfilter/base.py
@@ -31,7 +31,7 @@ class BaseEvFilter:
 
     update_deadline: bool = False
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.events: dict[int, tuple[int, ObjectId]] = {}
         self.pq: list[tuple[int, int]] = []
 

--- a/services/classifier/patternset.py
+++ b/services/classifier/patternset.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 class PatternSet:
-    def __init__(self):
+    def __init__(self) -> None:
         self.i_patterns: dict[
             str, list[tuple[str, str]]
         ] = {}  # (profile, chain) -> [rule, ..., rule]

--- a/services/classifier/ruleset.py
+++ b/services/classifier/ruleset.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 
 class RuleSet:
-    def __init__(self):
+    def __init__(self) -> None:
         self.rules: dict[
             tuple[str | None, str], RuleLookup
         ] = {}  # (profile, chain) -> [rule, ..., rule]

--- a/services/classifier/service.py
+++ b/services/classifier/service.py
@@ -114,7 +114,7 @@ class ClassifierService(FastAPIService):
 
     _interface_cache = cachetools.TTLCache(maxsize=10000, ttl=60)
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.version: str = version.version
         self.ruleset: RuleSet = RuleSet()

--- a/services/classifier/sourcelookup.py
+++ b/services/classifier/sourcelookup.py
@@ -54,7 +54,7 @@ class SourceConfig:
 
 
 class SourceLookup:
-    def __init__(self):
+    def __init__(self) -> None:
         self.source_configs: dict[str, SourceConfig] = {}  # id -> SourceConfig
         self.source_map: dict[str, str] = {}
 

--- a/services/correlator/alarmrule.py
+++ b/services/correlator/alarmrule.py
@@ -217,7 +217,7 @@ class AlarmRuleSet:
     Full set of alarm rules
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.common_rules = []
         self.alarm_class_rules: dict[str, list[AlarmRule]] = {}
 

--- a/services/correlator/service.py
+++ b/services/correlator/service.py
@@ -90,7 +90,7 @@ class CorrelatorService(FastAPIService):
     _reference_cache = cachetools.TTLCache(100, ttl=60)
     AVAIL_CLS = "NOC | Managed Object | Ping Failed"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.version = version.version
         self.rules: dict[ObjectId, list[EventAlarmRule]] = {}

--- a/services/discovery/service.py
+++ b/services/discovery/service.py
@@ -20,7 +20,7 @@ class DiscoveryService(FastAPIService):
     use_router = True
     process_name = "noc-%(name).10s-%(pool).5s"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.send_callback = None
         self.slot_number = 0

--- a/services/kafkasender/service.py
+++ b/services/kafkasender/service.py
@@ -38,7 +38,7 @@ class KafkaSenderService(FastAPIService):
     use_telemetry = True
     number_message = defaultdict(lambda: AtomicLong(-1))
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.producer: AIOKafkaProducer | None = None
 

--- a/services/login/backends/base.py
+++ b/services/login/backends/base.py
@@ -17,7 +17,7 @@ class BaseAuthBackend:
 
     _methods = {}
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.logger = logger
 
     def authenticate(self, **kwargs) -> str:

--- a/services/login/service.py
+++ b/services/login/service.py
@@ -35,7 +35,7 @@ class LoginService(FastAPIService):
         "ext-ui": "Legacy ExtJS UI services. To be removed with decline of legacy UI",
     }
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.revoked_tokens = set()
         self.revoked_expiry = []

--- a/services/metrics/service.py
+++ b/services/metrics/service.py
@@ -75,7 +75,7 @@ class MetricsService(FastAPIService):
     dcs_check_interval = global_config.metrics.check_interval
     dcs_check_timeout = global_config.metrics.check_timeout
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         # Metric Configs
         self.scopes: dict[str, ScopeInfo] = {}

--- a/services/metricscollector/service.py
+++ b/services/metricscollector/service.py
@@ -85,7 +85,7 @@ class MetricsCollectorService(FastAPIService):
     _rx_name_cache = cachetools.LRUCache(1000)
     _rs_key_cache = cachetools.TTLCache(10, ttl=120)
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.mappings: defaultdict[tuple[str, str], list[CfgItem]] = defaultdict(list)
         self.rx_mappings: defaultdict[tuple[str, re.Pattern], list[CfgItem]] = defaultdict(list)

--- a/services/mx/service.py
+++ b/services/mx/service.py
@@ -23,7 +23,7 @@ class MXService(FastAPIService):
     use_router = False
     traefik_routes_rule = "PathPrefix(`/api/mx`)"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.slot_number = 0
         self.total_slots = 0

--- a/services/nbi/service.py
+++ b/services/nbi/service.py
@@ -18,7 +18,7 @@ class NBIService(FastAPIService):
     use_watchdog = config.watchdog.enable_watchdog
     traefik_routes_rule = "PathPrefix(`/api/nbi`)"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.collect_req_api_metric = True
 

--- a/services/ping/service.py
+++ b/services/ping/service.py
@@ -37,7 +37,7 @@ class PingService(FastAPIService):
 
     PING_CLS = "NOC | Ping Failed"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.mappings_callback = None
         self.probes: dict[str, tuple[ProbeSetting, ...]] = defaultdict(

--- a/services/runner/service.py
+++ b/services/runner/service.py
@@ -38,7 +38,7 @@ class RunnerService(FastAPIService):
     name = "runner"
     use_mongo = True
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.slot_number = 0
         self.total_slots = 0

--- a/services/sae/service.py
+++ b/services/sae/service.py
@@ -26,7 +26,7 @@ class SAEService(FastAPIService):
     require_dcs_health = False
     use_mongo = True
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.pool_cache = {}
         self.activators = {}

--- a/services/selfmon/service.py
+++ b/services/selfmon/service.py
@@ -22,7 +22,7 @@ class SelfMonService(FastAPIService):
     name = "selfmon"
     use_mongo = True
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.collectors = []
         self.runner_thread = None

--- a/services/syslogcollector/service.py
+++ b/services/syslogcollector/service.py
@@ -47,7 +47,7 @@ class SyslogCollectorService(FastAPIService):
     pooled = True
     process_name = "noc-%(name).10s-%(pool).5s"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.mappings_callback = None
         self.report_invalid_callback = None

--- a/services/topo/service.py
+++ b/services/topo/service.py
@@ -26,7 +26,7 @@ class TopoService(FastAPIService):
     name = "topo"
     use_mongo = True
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.topo = Topo(check=config.topo.check)
         self.topo_lock = asyncio.Lock()

--- a/services/trapcollector/service.py
+++ b/services/trapcollector/service.py
@@ -50,7 +50,7 @@ class TrapCollectorService(FastAPIService):
     pooled = True
     process_name = "noc-%(name).10s-%(pool).5s"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.mappings_callback = None
         self.report_invalid_callback = None

--- a/services/web/apps/inv/map/layout.py
+++ b/services/web/apps/inv/map/layout.py
@@ -18,7 +18,7 @@ class Layout:
     SCALE_FACTOR = 130
     LINK_SPACING = 10
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.G = nx.Graph()
         self.seen_links = {}  # n1, n2 -> count
         self.link_ids = defaultdict(list)  # n1, n2 -> [link id]

--- a/services/web/apps/pm/ddash/dashboards/loader.py
+++ b/services/web/apps/pm/ddash/dashboards/loader.py
@@ -24,7 +24,7 @@ class PMDashboardLoader(BaseLoader):
     ignored_names = {"base", "loader", "jinja"}
     caps_map = {}
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         for name in self.find_classes():
             r = self[name]

--- a/services/web/apps/sa/reportobjectdetail.py
+++ b/services/web/apps/sa/reportobjectdetail.py
@@ -80,7 +80,7 @@ class ReportAdPath:
     Return AD path
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.out = self.load()
 
     def load(self):

--- a/services/web/base/access.py
+++ b/services/web/base/access.py
@@ -21,7 +21,7 @@ class Permission:
     and optional queryset method
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.app = None
 
     def queryset(self, request):

--- a/services/web/base/reportdatasources/base.py
+++ b/services/web/base/reportdatasources/base.py
@@ -242,7 +242,7 @@ class ReportModelFilter:
 
     model = ManagedObject  # Set on base class
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.formulas = """2is1.3hs0, 2is1.3hs0.5is1, 2is1.3hs0.5is2,
                 2is1.3hs0.5is2.4hs0, 2is1.3hs0.5is2.4hs1, 2is1.3hs0.5is2.4hs1.5hs1"""
         self.f_map = {

--- a/services/web/base/site.py
+++ b/services/web/base/site.py
@@ -111,7 +111,7 @@ class Site:
     JSON_CONTENT_TYPES = {"text/json", "application/json"}
     _perms_cache = cachetools.TTLCache(maxsize=100, ttl=60)
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.apps = {}  # app_id -> app instance
         self.urlpatterns: list[URLPattern] = []
         self.menu = []

--- a/services/web/service.py
+++ b/services/web/service.py
@@ -29,7 +29,7 @@ class WebService(FastAPIService):
     use_watchdog = config.watchdog.enable_watchdog
     traefik_routes_rule = "!PathPrefix(`/api/`) && !PathPrefix(`/ui/`) && PathPrefix(`/`)"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         os.environ.setdefault("DJANGO_SETTINGS_MODULE", "noc.settings")
         self.wsgi_app = get_wsgi_application()

--- a/services/worker/service.py
+++ b/services/worker/service.py
@@ -22,7 +22,7 @@ class WorkerService(FastAPIService):
     use_mongo = True
     use_router = True
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.slot_number = 0
         self.total_slots = 0

--- a/support/cp.py
+++ b/support/cp.py
@@ -34,7 +34,7 @@ class CPClient:
     CRASHINFO_SERVICE = "/api/v1.0/CrashinfoService/"
     PASTE_SERVICE = "/api/v1.0/PasteService/"
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.cp_url = self.CP_URL
         self.account_uuid = None
         self.account_name = None

--- a/tests/test_telnet.py
+++ b/tests/test_telnet.py
@@ -22,7 +22,7 @@ from noc.core.ioloop.util import IOLoopContext
 class ScriptStub(BaseScript):
     name = "Generic.Host"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(None, {})
 
     def interface(self):
@@ -38,7 +38,7 @@ class ProfileStub:
 
 
 class CLIStub(BaseCLI):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(ScriptStub())
         self.tos = 0
         self.logger = logging.getLogger("CLIStub")
@@ -46,7 +46,7 @@ class CLIStub(BaseCLI):
 
 
 class MyTelnetStream(TelnetStream):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(CLIStub())
         self.writer = BytesIO()
 

--- a/tests/test_udpserver.py
+++ b/tests/test_udpserver.py
@@ -23,7 +23,7 @@ SERVER_ADDRESS = "127.0.0.1"
 
 
 class UDPServerStub(UDPServer):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.received = 0
         self.ready = asyncio.Event()


### PR DESCRIPTION
Add `-> None` return type annotation to all `__init__` constructor methods across the codebase. This is part of an ongoing typing series (#357 for dunder methods, #356 for KPI script) that systematically adds type hints to Python classes.

**Key changes**

- 80 files updated (`core/`, `services/`, `commands/`, `gis/`, `support/`, `docs/`, `scripts/deploy/`, `tests/`)
- All changes follow the pattern: `def __init__(self):` → `def __init__(self) -> None:`
