### PR TITLE
noc.core.script: Convert docstrings to google format

### DIFF
--- a/core/script/base.py
+++ b/core/script/base.py
@@ -47,9 +47,7 @@ from .sessionstore import SessionStore
 
 
 class BaseScriptMetaclass(type):
-    """
-    Process @match decorators
-    """
+    """Process @match decorators"""
 
     def __new__(mcs, name, bases, attrs):
         n = type.__new__(mcs, name, bases, attrs)
@@ -60,9 +58,7 @@ class BaseScriptMetaclass(type):
 
 
 class BaseScript(metaclass=BaseScriptMetaclass):
-    """
-    Service Activation script base class
-    """
+    """Service Activation script base class"""
 
     # Script name in form of <vendor>.<system>.<name>
     name = None
@@ -266,10 +262,7 @@ class BaseScript(metaclass=BaseScriptMetaclass):
         return self._http
 
     def apply_matchers(self):
-        """
-        Process matchers and apply is_XXX properties
-        :return:
-        """
+        """Process matchers and apply is_XXX properties"""
 
         def get_matchers(c, matchers):
             return {m: match(c, matchers[m]) for m in matchers}
@@ -286,21 +279,17 @@ class BaseScript(metaclass=BaseScriptMetaclass):
             setattr(self, k, v[k])
 
     def clean_input(self, args):
-        """
-        Cleanup input parameters against interface
-        """
+        """Cleanup input parameters against interface"""
         return self._interface.script_clean_input(self.profile, **args)
 
     def clean_output(self, result):
-        """
-        Clean script result against interface
-        """
+        """Clean script result against interface"""
         return self._interface.script_clean_result(self.profile, result)
 
     def clean_streaming_result(self, result):
         """
-        :param result:
-        :return:
+        Args:
+            result
         """
         if self.streaming.data and isinstance(result, dict):
             result.update(self.streaming.get_data())
@@ -311,9 +300,7 @@ class BaseScript(metaclass=BaseScriptMetaclass):
         return result
 
     def run(self):
-        """
-        Run script
-        """
+        """Run script"""
         with Span(server="activator", service=self.name, in_label=self.credentials.get("address")):
             self.start_time = perf_counter()
             self.logger.debug("Running. Input arguments: %s, timeout %s", self.args, self.timeout)
@@ -359,8 +346,7 @@ class BaseScript(metaclass=BaseScriptMetaclass):
     @classmethod
     def compile_match_filter(cls, *args, **kwargs):
         # pylint: disable=undefined-variable
-        """
-        Compile arguments into version check function
+        """Compile arguments into version check function
         Returns callable accepting self and version hash arguments
         """
         c = [lambda self, x, g=f: g(x) for f in args]
@@ -423,9 +409,7 @@ class BaseScript(metaclass=BaseScriptMetaclass):
 
     @classmethod
     def match(cls, *args, **kwargs):
-        """
-        execute method decorator
-        """
+        """execute method decorator"""
 
         def wrap(f):
             # Append to the execute chain
@@ -446,16 +430,13 @@ class BaseScript(metaclass=BaseScriptMetaclass):
         return wrap
 
     def match_version(self, *args, **kwargs):
-        """
-        inline version for BaseScript.match
-        """
+        """inline version for BaseScript.match"""
         if not self.version:
             self.version = self.scripts.get_version()
         return self.compile_match_filter(*args, **kwargs)(self, self.version)
 
     def execute(self, **kwargs):
-        """
-        Default script behavior:
+        """Default script behavior:
         Pass through _execute_chain and call appropriate handler
         """
         if self._execute_chain and not self.name.endswith(".get_version"):
@@ -479,13 +460,15 @@ class BaseScript(metaclass=BaseScriptMetaclass):
         )
 
     def call_method(self, cli_handler=None, snmp_handler=None, fallback_handler=None, **kwargs):
-        """
-        Call function depending on access_preference
-        :param cli_handler: String or callable to call on CLI access method
-        :param snmp_handler: String or callable to call on SNMP access method
-        :param fallback_handler: String or callable to call if no access method matched
-        :param kwargs:
-        :return:
+        """Call function depending on access_preference
+
+        Args:
+            cli_handler: String or callable to call on CLI access method
+            snmp_handler: String or callable to call on SNMP access
+                method
+            fallback_handler: String or callable to call if no access
+                method matched
+            **kwargs
         """
         # Select proper handler
         access_preference = self.get_access_preference() + "*"
@@ -536,40 +519,34 @@ class BaseScript(metaclass=BaseScriptMetaclass):
         )
 
     def execute_cli(self, **kwargs):
-        """
-        Process script using CLI
-        :param kwargs:
-        :return:
+        """Process script using CLI
+
+        Args:
+            **kwargs
         """
         raise NotImplementedError("execute_cli() is not implemented")
 
     def execute_snmp(self, **kwargs):
-        """
-        Process script using SNMP
-        :param kwargs:
-        :return:
+        """Process script using SNMP
+
+        Args:
+            **kwargs
         """
         raise NotImplementedError("execute_snmp() is not implemented")
 
     def cleaned_config(self, config):
-        """
-        Clean up config from all unnecessary trash
-        """
+        """Clean up config from all unnecessary trash"""
         return self.profile.cleaned_config(config)
 
     def strip_first_lines(self, text, lines=1):
-        """
-        Strip first *lines*
-        """
+        """Strip first *lines*"""
         t = text.split("\n")
         if len(t) <= lines:
             return ""
         return "\n".join(t[lines:])
 
     def expand_rangelist(self, s):
-        """
-        Expand expressions like "1,2,5-7" to [1, 2, 5, 6, 7]
-        """
+        """Expand expressions like "1,2,5-7" to [1, 2, 5, 6, 7]"""
         result = {}
         for x in s.split(","):
             x = x.strip()
@@ -590,14 +567,14 @@ class BaseScript(metaclass=BaseScriptMetaclass):
     rx_detect_sep = re.compile(r"^(.*?)\d+$")
 
     def expand_interface_range(self, s):
-        """
-        Convert interface range expression to a list
+        """Convert interface range expression to a list
         of interfaces
         "Gi 1/1-3,Gi 1/7" -> ["Gi 1/1", "Gi 1/2", "Gi 1/3", "Gi 1/7"]
         "1:1-3" -> ["1:1", "1:2", "1:3"]
         "1:1-1:3" -> ["1:1", "1:2", "1:3"]
-        :param s: Comma-separated list
-        :return:
+
+        Args:
+            s: Comma-separated list
         """
         r = set()
         for x in s.split(","):
@@ -629,10 +606,13 @@ class BaseScript(metaclass=BaseScriptMetaclass):
         return sorted(r)
 
     def macs_to_ranges(self, macs):
-        """
-        Converts list of macs to rangea
-        :param macs: Iterable yielding mac addresses
-        :returns: [(from, to), ..]
+        """Converts list of macs to rangea
+
+        Args:
+            macs: Iterable yielding mac addresses
+
+        Returns:
+            [(from, to), ..]
         """
         r = []
         for m in sorted(MAC(x) for x in macs):
@@ -676,8 +656,7 @@ class BaseScript(metaclass=BaseScriptMetaclass):
         return ConfigurationContextManager(self)
 
     def cached(self):
-        """
-        Return cached context managed. All nested CLI and SNMP GET/GETNEXT
+        """Return cached context managed. All nested CLI and SNMP GET/GETNEXT
         calls will be cached.
 
         Usage:
@@ -717,16 +696,13 @@ class BaseScript(metaclass=BaseScriptMetaclass):
 
     @property
     def motd(self):
-        """
-        Return message of the day
-        """
+        """Return message of the day"""
         if self._motd:
             return self._motd
         return self.get_cli_stream().get_motd()
 
     def re_search(self, rx, s, flags=0):
-        """
-        Match s against regular expression rx using re.search
+        """Match s against regular expression rx using re.search
         Raise UnexpectedResultError if regular expression is not matched.
         Returns match object.
         rx can be string or compiled regular expression
@@ -739,8 +715,7 @@ class BaseScript(metaclass=BaseScriptMetaclass):
         return match
 
     def re_match(self, rx, s, flags=0):
-        """
-        Match s against regular expression rx using re.match
+        """Match s against regular expression rx using re.match
         Raise UnexpectedResultError if regular expression is not matched.
         Returns match object.
         rx can be string or compiled regular expression
@@ -777,8 +752,7 @@ class BaseScript(metaclass=BaseScriptMetaclass):
         return None
 
     def find_re(self, iter, s):
-        """
-        Find first matching regular expression
+        """Find first matching regular expression
         or raise Unexpected result error
         """
         for r in iter:
@@ -787,12 +761,14 @@ class BaseScript(metaclass=BaseScriptMetaclass):
         raise UnexpectedResultError()
 
     def hex_to_bin(self, s):
-        """
-        Convert hexadecimal string to boolean string.
+        """Convert hexadecimal string to boolean string.
         All non-hexadecimal characters are ignored
-        :param s: Input string
-        :return: Boolean string
-        :rtype: str
+
+        Args:
+            s: Input string
+
+        Returns:
+            str: Boolean string
         """
         return "".join(self.hexbin[c] for c in "".join("%02x" % ord(d) for d in s))
 
@@ -803,9 +779,7 @@ class BaseScript(metaclass=BaseScriptMetaclass):
         self.get_cli_stream().pop_prompt_pattern()
 
     def has_oid(self, oid):
-        """
-        Check object responses to oid
-        """
+        """Check object responses to oid"""
         try:
             return bool(self.snmp.get(oid))
         except self.snmp.TimeOutError:
@@ -830,24 +804,26 @@ class BaseScript(metaclass=BaseScriptMetaclass):
         cmd_stop: Any = None,
         labels: str | set[str] | None = None,
     ) -> str:
-        """
-        Execute CLI command and return result. Initiate cli session
+        """Execute CLI command and return result. Initiate cli session
         when necessary.
 
         if list_re is None, return a string
         if list_re is regular expression object, return a list of dicts (group name -> value),
             one dict per matched line
 
-        :param cmd: CLI command to execute
-        :param command_submit: Optional suffix to submit command. Profile's one used by default
-        :param bulk_lines:
-        :param list_re:
-        :param cached: True if result of execution may be cached
-        :param file: Path to the file containing debugging result
-        :param ignore_errors:
-        :param allow_empty_response: Allow empty output. If False - ignore prompt and wait output
-        :param nowait:
-        :param labels:
+        Args:
+            cmd: CLI command to execute
+            command_submit: Optional suffix to submit command. Profile's
+                one used by default
+            bulk_lines
+            list_re
+            cached: True if result of execution may be cached
+            file: Path to the file containing debugging result
+            ignore_errors
+            allow_empty_response: Allow empty output. If False - ignore
+                prompt and wait output
+            nowait
+            labels
         """
 
         def format_result(result):
@@ -907,12 +883,11 @@ class BaseScript(metaclass=BaseScriptMetaclass):
         return format_result(r)
 
     def echo_cancelation(self, r: str, cmd: str) -> str:
-        """
-        Adaptive echo cancelation
+        """Adaptive echo cancelation
 
-        :param r:
-        :param cmd:
-        :return:
+        Args:
+            r
+            cmd
         """
         if r[:4096].lstrip().startswith(cmd):
             r = r.lstrip()
@@ -979,11 +954,11 @@ class BaseScript(metaclass=BaseScriptMetaclass):
             self._snmp = None
 
     def mml(self, cmd, **kwargs):
-        """
-        Execute MML command and return result. Initiate MML session when necessary
-        :param cmd:
-        :param kwargs:
-        :return:
+        """Execute MML command and return result. Initiate MML session when necessary
+
+        Args:
+            cmd
+            **kwargs
         """
         stream = self.get_mml_stream()
         return stream.execute(cmd, **kwargs)
@@ -1021,12 +996,12 @@ class BaseScript(metaclass=BaseScriptMetaclass):
             self.cli_stream = None
 
     def rtsp(self, method, path, **kwargs):
-        """
-        Execute RTSP command and return result. Initiate RTSP session when necessary
-        :param method:
-        :param path:
-        :param kwargs:
-        :return:
+        """Execute RTSP command and return result. Initiate RTSP session when necessary
+
+        Args:
+            method
+            path
+            **kwargs
         """
         stream = self.get_rtsp_stream()
         return stream.execute(path, method, **kwargs)
@@ -1071,10 +1046,7 @@ class BaseScript(metaclass=BaseScriptMetaclass):
 
     @classmethod
     def close_session(cls, session_id):
-        """
-        Explicit session closing
-        :return:
-        """
+        """Explicit session closing"""
         cls.cli_session_store.remove(session_id, shutdown=True)
         cls.mml_session_store.remove(session_id, shutdown=True)
         cls.rtsp_session_store.remove(session_id, shutdown=True)
@@ -1087,10 +1059,7 @@ class BaseScript(metaclass=BaseScriptMetaclass):
         return r
 
     def get_always_preferred(self):
-        """
-        Return always preferred access method
-        :return:
-        """
+        """Return always preferred access method"""
         return self.always_prefer
 
     def has_cli_access(self):
@@ -1106,9 +1075,7 @@ class BaseScript(metaclass=BaseScriptMetaclass):
         return not self.has_cli_access() and self.has_snmp_access()
 
     def has_snmp(self) -> bool:
-        """
-        Check whether equipment has SNMP enabled
-        """
+        """Check whether equipment has SNMP enabled"""
         # Check Credential
         snmp_version = self.credentials.get("snmp_version") or "v2c"
         if snmp_version != "v3" and not self.credentials.get("snmp_ro"):
@@ -1133,9 +1100,7 @@ class BaseScript(metaclass=BaseScriptMetaclass):
         return self.has_capability("SNMP | v3")
 
     def has_snmp_bulk(self):
-        """
-        Check whether equipment supports SNMP BULK
-        """
+        """Check whether equipment supports SNMP BULK"""
         return self.has_capability("SNMP | Bulk")
 
     def get_snmp_bulk_repetition(self):
@@ -1144,27 +1109,23 @@ class BaseScript(metaclass=BaseScriptMetaclass):
         return self.capabilities.get("SNMP | Bulk | Max Repetition")
 
     def has_capability(self, capability, allow_zero=False):
-        """
-        Check whether equipment supports capability
-        """
+        """Check whether equipment supports capability"""
         if allow_zero:
             return self.capabilities.get(capability) is not None
         return bool(self.capabilities.get(capability))
 
     def ignored_exceptions(self, iterable):
-        """
-        Context manager to silently ignore specified exceptions
-        """
+        """Context manager to silently ignore specified exceptions"""
         return IgnoredExceptionsContextManager(iterable)
 
     def iter_pairs(self, g, offset=0):
-        """
-        Convert iterable g to a pairs
+        """Convert iterable g to a pairs
         i.e.
         [1, 2, 3, 4] -> [(1, 2), (3, 4)]
-        :param g: Iterable
-        :param offset: Skip first recirds
-        :return:
+
+        Args:
+            g: Iterable
+            offset: Skip first recirds
         """
         g = iter(g)
         if offset:
@@ -1202,10 +1163,7 @@ class BaseScript(metaclass=BaseScriptMetaclass):
         self.logger.debug("PUSH SNMP %s: %r", oid, tlv)
 
     def iter_cli_tracking(self):
-        """
-        Yields command, packets for collected data
-        :return:
-        """
+        """Yields command, packets for collected data"""
         for cmd in self.cli_tracked_data:
             self.logger.debug("Collecting %d tracked CLI items", len(self.cli_tracked_data[cmd]))
             yield cmd, self.cli_tracked_data[cmd]
@@ -1216,10 +1174,7 @@ class BaseScript(metaclass=BaseScriptMetaclass):
             yield state, self.cli_fsm_tracked_data[state]
 
     def request_beef(self):
-        """
-        Download and return beef
-        :return:
-        """
+        """Download and return beef"""
         if not hasattr(self, "_beef"):
             self.logger.debug("Requesting beef")
             beef_storage_url = self.credentials.get("beef_storage_url")
@@ -1259,10 +1214,10 @@ class BaseScript(metaclass=BaseScriptMetaclass):
             self.logger.warning("Can't remove a label '%s' from labels", label)
 
     def apply_metrics(self, d):
-        """
-        Apply metrics value to dictionary d
-        :param d: Dictionary
-        :return:
+        """Apply metrics value to dictionary d
+
+        Args:
+            d: Dictionary
         """
         for k, v in self.script_metrics.items():
             if isinstance(v, AtomicLong):
@@ -1272,8 +1227,7 @@ class BaseScript(metaclass=BaseScriptMetaclass):
 
 
 class ScriptsHub:
-    """
-    Object representing Script.scripts structure.
+    """Object representing Script.scripts structure.
     Returns initialized child script which can be used ans callable
     """
 
@@ -1307,9 +1261,7 @@ class ScriptsHub:
         raise AttributeError(item)
 
     def __contains__(self, item):
-        """
-        Check object has script name
-        """
+        """Check object has script name"""
         from .loader import loader as script_loader
 
         if "." not in item:

--- a/core/script/beef.py
+++ b/core/script/beef.py
@@ -196,16 +196,18 @@ class Beef:
         return bz2.decompress(data)
 
     def save(self, storage: ExtStorage, path: str) -> tuple[int, int]:
-        """
-        Write beef to external storage. Compression depends on extension.
+        """Write beef to external storage. Compression depends on extension.
         Following extensions are supported:
         * .json - JSON without compression
         * .json.gz - JSON with gzip compression
         * .json.bz2 - JSON with bzip2 compression
 
-        :param storage: ExtStorage instance
-        :param path: Beef path
-        :return: Compressed, Uncompressed sizes
+        Args:
+            storage: ExtStorage instance
+            path: Beef path
+
+        Returns:
+            Compressed, Uncompressed sizes
         """
         data = orjson.dumps(self.get_data())
         usize = len(data)
@@ -222,11 +224,11 @@ class Beef:
 
     @classmethod
     def load(cls, storage, path):
-        """
-        Load beef from storage
-        :param storage:
-        :param path:
-        :return:
+        """Load beef from storage
+
+        Args:
+            storage
+            path
         """
         if isinstance(storage, str):
             # Load from URL
@@ -248,10 +250,10 @@ class Beef:
         return Beef.from_json(smart_text(data))
 
     def iter_fsm_state_reply(self, state: str) -> bytes:
-        """
-        Iterate fsm states
-        :param state:
-        :return:
+        """Iterate fsm states
+
+        Args:
+            state
         """
         for fsm in self.cli_fsm:
             if fsm.state == state:
@@ -260,10 +262,10 @@ class Beef:
                 break
 
     def iter_cli_reply(self, command: bytes) -> bytes:
-        """
-        Iterate fsm states
-        :param command:
-        :return:
+        """Iterate fsm states
+
+        Args:
+            command
         """
         # typo
         # cmd = smart_bytes(command)
@@ -280,28 +282,28 @@ class Beef:
 
     @staticmethod
     def mib_decode_base64(value: bytes) -> bytes:
-        """
-        Decode base64
-        :param value:
-        :return:
+        """Decode base64
+
+        Args:
+            value
         """
         return codecs.decode(value, "base64")
 
     @staticmethod
     def mib_decode_hex(value):
-        """
-        Decode base64
-        :param value:
-        :return:
+        """Decode base64
+
+        Args:
+            value
         """
         return value.decode("hex")
 
     @staticmethod
     def cli_decode_quopri(value: bytes) -> bytes:
-        """
-        Decode quoted-printable
-        :param value:
-        :return:
+        """Decode quoted-printable
+
+        Args:
+            value
         """
         return codecs.decode(value, "quopri")
 
@@ -311,10 +313,13 @@ class Beef:
         return self.mib_oid_values
 
     def get_mib_value(self, oid: str) -> bytes | None:
-        """
-        Lookup mib and return oid value
-        :param oid:
-        :return: Binary OID data or None
+        """Lookup mib and return oid value
+
+        Args:
+            oid
+
+        Returns:
+            Binary OID data or None
         """
         v = self.get_mib_oid_values().get(oid)
         if v is None:
@@ -322,19 +327,16 @@ class Beef:
         return self._mib_decoder(v)
 
     def get_mib_oids(self):
-        """
-        Return sorted list of MIB oids
-        :return:
-        """
+        """Return sorted list of MIB oids"""
         if self.mib_oids is None:
             self.mib_oids = sorted(tuple(int(c) for c in m.oid.split(".")) for m in self.mib)
         return self.mib_oids
 
     def iter_mib_oids(self, oid):
-        """
-        Generator yielding all consequentive oids
-        :param oid:
-        :return:
+        """Generator yielding all consequentive oids
+
+        Args:
+            oid
         """
         start = tuple(int(c) for c in oid.split("."))
         oids = self.get_mib_oids()

--- a/core/script/caller.py
+++ b/core/script/caller.py
@@ -55,10 +55,10 @@ class Session:
         self._pool = None
 
     def _get_hints(self):
-        """
-        Get activator address
-        :param pool:
-        :return:
+        """Get activator address
+
+        Args:
+            pool
         """
         try:
             svc = get_dcs().resolve_sync("activator-%s" % self._pool, hint=self._hints[0])

--- a/core/script/cli/base.py
+++ b/core/script/cli/base.py
@@ -66,10 +66,7 @@ class BaseCLI:
             self.stream.set_timeout(None)
 
     def get_stream(self) -> "BaseStream":
-        """
-        Stream factory. Must be overriden in subclasses.
-        :return:
-        """
+        """Stream factory. Must be overriden in subclasses."""
         raise NotImplementedError
 
     async def start_stream(self):

--- a/core/script/cli/beef.py
+++ b/core/script/cli/beef.py
@@ -92,7 +92,5 @@ class BeefCLI(CLI):
         return True
 
     async def send_pager_reply(self, data, match):
-        """
-        Beef need no pagers
-        """
+        """Beef need no pagers"""
         self.collected_data += [data]

--- a/core/script/cli/cli.py
+++ b/core/script/cli/cli.py
@@ -163,8 +163,7 @@ class CLI(BaseCLI):
         return False
 
     def cleaned_input(self, s: bytes) -> bytes:
-        """
-        Clean up received input and wipe out control sequences
+        """Clean up received input and wipe out control sequences
         and rogue chars
         """
         # Wipe out rogue chars
@@ -247,14 +246,13 @@ class CLI(BaseCLI):
 
     async def parse_object_stream(self, parser=None, cmd_next=None, cmd_stop=None):
         """
-        :param parser: callable accepting buffer and returning
-                       (key, data, rest) or None.
-                       key - string with object distinguisher
-                       data - dict containing attributes
-                       rest -- unparsed rest of string
-        :param cmd_next: Sequence to go to the next page
-        :param cmd_stop: Sequence to stop
-        :return:
+        Args:
+            parser: callable accepting buffer and returning (key, data,
+                rest) or None. key - string with object distinguisher
+                data - dict containing attributes rest -- unparsed rest
+                of string
+            cmd_next: Sequence to go to the next page
+            cmd_stop: Sequence to stop
         """
         self.logger.debug("Parsing object stream")
         objects = []
@@ -330,9 +328,7 @@ class CLI(BaseCLI):
         return objects
 
     async def send_pager_reply(self, data, match):
-        """
-        Send proper pager reply
-        """
+        """Send proper pager reply"""
         pg = match.group(0)
         for p, c in self.patterns["more_patterns_commands"]:
             if p.search(pg):
@@ -362,9 +358,7 @@ class CLI(BaseCLI):
         timeout: float | None = None,
         error: type[Exception] | None = None,
     ):
-        """
-        Send command if not none and set reply patterns
-        """
+        """Send command if not none and set reply patterns"""
         self.pattern_table = {}
         for pattern_name in patterns:
             rx = self.patterns.get(pattern_name)
@@ -572,9 +566,7 @@ class CLI(BaseCLI):
         await self.on_start(data, match)
 
     def resolve_pattern_prompt(self, match):
-        """
-        Resolve adaptive pattern prompt
-        """
+        """Resolve adaptive pattern prompt"""
         old_pattern_prompt = self.patterns["prompt"].pattern
         pattern_prompt = old_pattern_prompt
         sl = self.profile.can_strip_hostname_to
@@ -599,27 +591,21 @@ class CLI(BaseCLI):
         self.patterns["prompt"] = re.compile(pattern_prompt, re.DOTALL | re.MULTILINE)
 
     def push_prompt_pattern(self, pattern):
-        """
-        Override prompt pattern
-        """
+        """Override prompt pattern"""
         self.logger.debug("New prompt pattern: %s", pattern)
         self.prompt_stack += [self.patterns["prompt"]]
         self.patterns["prompt"] = re.compile(pattern, re.DOTALL | re.MULTILINE)
         self.pattern_table[self.patterns["prompt"]] = self.on_prompt
 
     def pop_prompt_pattern(self):
-        """
-        Restore prompt pattern
-        """
+        """Restore prompt pattern"""
         self.logger.debug("Restore prompt pattern")
         pattern = self.prompt_stack.pop(-1)
         self.patterns["prompt"] = pattern
         self.pattern_table[self.patterns["prompt"]] = self.on_prompt
 
     def get_motd(self):
-        """
-        Return collected message of the day
-        """
+        """Return collected message of the day"""
         return self.motd
 
     def set_script(self, script):
@@ -638,12 +624,12 @@ class CLI(BaseCLI):
             self.profile.shutdown_session(self.script)
 
     async def on_error_sequence(self, seq, command, error_text):
-        """
-        Process error sequence
-        :param seq:
-        :param command:
-        :param error_text:
-        :return:
+        """Process error sequence
+
+        Args:
+            seq
+            command
+            error_text
         """
         if isinstance(seq, str):
             self.logger.debug("Recovering sequece must byte type")

--- a/core/script/cli/ssh.py
+++ b/core/script/cli/ssh.py
@@ -50,9 +50,10 @@ class SSHStream(BaseStream):
     @classmethod
     @cachetools.cachedmethod(operator.attrgetter("_key_cache"), lock=lambda _: key_lock)
     def get_publickey(cls, pool: str) -> tuple[bytes | None, bytes | None]:
-        """
-        Return public, private key pair
-        :return: bytes, bytes or None, None
+        """Return public, private key pair
+
+        Returns:
+            bytes, bytes or None, None
         """
         logger.debug("Getting keys for pool %s", pool)
         pub_path = os.path.join(config.path.ssh_key_prefix, pool, "id_rsa.pub")
@@ -67,9 +68,7 @@ class SSHStream(BaseStream):
             return fpub.read(), fpriv.read()
 
     async def startup(self):
-        """
-        SSH session startup
-        """
+        """SSH session startup"""
         user = self.credentials["user"]
         if user is None:
             user = ""
@@ -159,23 +158,19 @@ class SSHStream(BaseStream):
         super().close()
 
     def get_user(self) -> str:
-        """
-        Get current user
-        """
+        """Get current user"""
         return self.script.credentials["user"] or ""
 
     def get_password(self) -> str:
-        """
-        Get current user's password
-        """
+        """Get current user's password"""
         return self.script.credentials["password"] or ""
 
     def authenticate(self, user: str, methods: list[str]) -> bool:
-        """
-        Try to authenticate. Return True on success
-        :param user: Username
-        :param methods: List of available authentication methods
-        :return:
+        """Try to authenticate. Return True on success
+
+        Args:
+            user: Username
+            methods: List of available authentication methods
         """
         self.logger.debug("Supported authentication methods: %s", ", ".join(methods))
         for method in methods:
@@ -192,9 +187,7 @@ class SSHStream(BaseStream):
         return False
 
     def auth_publickey(self) -> bool:
-        """
-        Public key authentication
-        """
+        """Public key authentication"""
         self.logger.debug("Trying publickey authentication")
         pub_key, priv_key = self.get_publickey(self.script.pool)
         if not pub_key or not priv_key:
@@ -210,9 +203,7 @@ class SSHStream(BaseStream):
             return False
 
     def auth_keyboardinteractive(self):
-        """
-        Keyboard-interactive authentication. Send username and password
-        """
+        """Keyboard-interactive authentication. Send username and password"""
         self.logger.debug("Trying keyboard-interactive")
         if not hasattr(self.session, "userauth_keyboardinteractive"):
             self.logger.debug("keyboard-interactive is not supported by ssh library. Skipping")
@@ -227,9 +218,7 @@ class SSHStream(BaseStream):
             return False
 
     def auth_password(self):
-        """
-        Password authentication. Send username and password
-        """
+        """Password authentication. Send username and password"""
         self.logger.debug("Trying password authentication")
         try:
             self.session.userauth_password(self.get_user(), self.get_password())

--- a/core/script/cli/stream.py
+++ b/core/script/cli/stream.py
@@ -38,12 +38,12 @@ class BaseStream:
         self.connect_timeout: float = config.activator.connect_timeout
 
     async def connect(self, address: str, port: int | None = None, timeout: float | None = None):
-        """
-        Process connection sequence
-        :param address:
-        :param port:
-        :param timeout:
-        :return:
+        """Process connection sequence
+
+        Args:
+            address
+            port
+            timeout
         """
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         if self.tos:
@@ -75,16 +75,10 @@ class BaseStream:
             raise ConnectionRefusedError
 
     async def startup(self):
-        """
-        Setup connection after startup
-        :return:
-        """
+        """Setup connection after startup"""
 
     async def wait_for_read(self):
-        """
-        Wait until data available for read
-        :return:
-        """
+        """Wait until data available for read"""
 
         def on_readable() -> None:
             if not fut.done():
@@ -103,10 +97,7 @@ class BaseStream:
             loop.remove_reader(fileno)
 
     async def wait_for_write(self):
-        """
-        Wait until socket will be available for write
-        :return:
-        """
+        """Wait until socket will be available for write"""
         if not self.socket:
             return
         loop = asyncio.get_running_loop()
@@ -119,11 +110,11 @@ class BaseStream:
             loop.remove_writer(fileno)
 
     async def read(self, n: int) -> bytes:
-        """
-        Read up to n bytes from socket.
+        """Read up to n bytes from socket.
         Return empty bytes on EOF
-        :param n:
-        :return:
+
+        Args:
+            n
         """
         await self.wait_for_read()
         try:
@@ -133,10 +124,10 @@ class BaseStream:
             raise asyncio.TimeoutError
 
     async def write(self, data: bytes):
-        """
-        Write data to socket
-        :param data:
-        :return:
+        """Write data to socket
+
+        Args:
+            data
         """
         while data:
             await self.wait_for_write()

--- a/core/script/cli/telnet.py
+++ b/core/script/cli/telnet.py
@@ -138,11 +138,13 @@ class TelnetStream(BaseStream):
         return data.replace(B_IAC, B_IAC2)
 
     async def feed(self, chunk: bytes) -> bytes:
-        """
-        Feed chunk of data to parser
+        """Feed chunk of data to parser
 
-        :param chunk: String
-        :return: Parsed data
+        Args:
+            chunk: String
+
+        Returns:
+            Parsed data
         """
         if self.iac_seq and chunk:
             # Restore incomplete IAC context
@@ -192,9 +194,7 @@ class TelnetStream(BaseStream):
         return b"".join(r)
 
     def send_iac(self, cmd: int, opt: int) -> None:
-        """
-        Send IAC response
-        """
+        """Send IAC response"""
         self.logger.debug("Send %s", self.iac_repr(cmd, opt))
         self.out_iac_seq += [bytes((IAC, cmd, opt))]
 
@@ -210,9 +210,7 @@ class TelnetStream(BaseStream):
         self.out_iac_seq += sb
 
     def process_iac(self, cmd: int, opt: int) -> None:
-        """
-        Process IAC command.
-        """
+        """Process IAC command."""
         self.logger.debug("Received %s", self.iac_repr(cmd, opt))
         if cmd == DO:
             r = WILL if opt in ACCEPTED_TELNET_OPTIONS else WONT
@@ -238,11 +236,11 @@ class TelnetStream(BaseStream):
 
     @staticmethod
     def iac_repr(cmd: int, opt: int) -> str:
-        """
-        Human-readable IAC sequence
-        :param cmd:
-        :param opt:
-        :return:
+        """Human-readable IAC sequence
+
+        Args:
+            cmd
+            opt
         """
         return "%s %s" % (IAC_CMD.get(cmd, cmd), TELNET_OPTIONS.get(opt, opt))
 

--- a/core/script/context.py
+++ b/core/script/context.py
@@ -7,9 +7,7 @@
 
 
 class ConfigurationContextManager:
-    """
-    Configuration context manager to use with "with" statement
-    """
+    """Configuration context manager to use with "with" statement"""
 
     def __init__(self, script):
         self.script = script
@@ -40,9 +38,7 @@ class CacheContextManager:
 
 
 class IgnoredExceptionsContextManager:
-    """
-    Silently ignore specific exceptions
-    """
+    """Silently ignore specific exceptions"""
 
     def __init__(self, iterable):
         self.exceptions = set(iterable)

--- a/core/script/credentialchecker.py
+++ b/core/script/credentialchecker.py
@@ -90,9 +90,7 @@ SUGGEST_PROTOCOLS: tuple[Protocol, ...] = SUGGEST_SNMP + SUGGEST_CLI
 
 
 class CredentialChecker:
-    """
-    Credential checker for CLI/SNMP credential. Allow suggests credential
-    """
+    """Credential checker for CLI/SNMP credential. Allow suggests credential"""
 
     base_logger = logging.getLogger("credentialchecker")
 
@@ -110,16 +108,16 @@ class CredentialChecker:
         ignoring_rule: bool = False,
     ):
         """
-
-        :param address: Device IP address
-        :param pool: Activator pool for request
-        :param labels: List labels for filter CredentialCheck Rules
-        :param logger: logging instance
-        :param profile: SA Profile
-        :param raise_privilege: Try raise privilege for check
-        :param calling_service: Service name
-        :param credentials: Custom credential for check
-        :param ignoring_rule: Do not use rule for suggest credential
+        Args:
+            address: Device IP address
+            pool: Activator pool for request
+            labels: List labels for filter CredentialCheck Rules
+            logger: logging instance
+            profile: SA Profile
+            raise_privilege: Try raise privilege for check
+            calling_service: Service name
+            credentials: Custom credential for check
+            ignoring_rule: Do not use rule for suggest credential
         """
         self.address = address
         self.pool = pool
@@ -143,10 +141,9 @@ class CredentialChecker:
     @staticmethod
     def iter_protocols(*args, order: tuple[Protocol, ...] = None) -> Iterable[Protocol]:
         """
-
-        :param args:
-        :param order:
-        :return:
+        Args:
+            *args
+            order
         """
         yield from sorted(
             set(args[0]).intersection(*[set(s) for s in args[1:] if s]),
@@ -155,10 +152,10 @@ class CredentialChecker:
 
     @staticmethod
     def is_unsupported_error(message) -> bool:
-        """
-        Todo replace to error_code
-        :param message:
-        :return:
+        """Todo replace to error_code
+
+        Args:
+            message
         """
         if "Exception: TimeoutError()" in message:
             return True
@@ -171,11 +168,10 @@ class CredentialChecker:
     def iter_suggests(
         self, protocols: tuple[Protocol, ...] = None
     ) -> Iterator[SuggestCLIConfig | SuggestSNMPConfig]:
-        """
-        Load ProfileCheckRules and return a list, grouped by preferences
+        """Load ProfileCheckRules and return a list, grouped by preferences
 
-        :param protocols:
-        :return:
+        Args:
+            protocols
         """
         # Try custom credential first
         ordered_cli, ordered_snmp = [], []
@@ -250,10 +246,10 @@ class CredentialChecker:
                     )
 
     def iter_result(self, protocols: Iterable[Protocol] | None = None) -> list[ProtocolResult]:
-        """
-        Iterate over suggest result
-        :param protocols: List protocols for check
-        :return:
+        """Iterate over suggest result
+
+        Args:
+            protocols: List protocols for check
         """
         unsupported_proto = set()
         processed = set()
@@ -280,10 +276,9 @@ class CredentialChecker:
 
     def do_snmp_check(self, protocol: Protocol, cred: SNMPCredential) -> ProtocolResult:
         """
-
-        :param protocol:
-        :param cred:
-        :return:
+        Args:
+            protocol
+            cred
         """
         for oid in cred.oids or CHECK_OIDS:
             status, message = self.check_oid(oid, cred.snmp_ro, f"{protocol.config.alias}_get")
@@ -304,11 +299,11 @@ class CredentialChecker:
         )
 
     def do_cli_check(self, protocol: Protocol, cred: CLICredential) -> ProtocolResult:
-        """
-        Check suggest CLIT config
-        :param protocol:
-        :param cred: Credential for Check
-        :return:
+        """Check suggest CLIT config
+
+        Args:
+            protocol
+            cred: Credential for Check
         """
         if self.ignoring_cli:
             # Skipped
@@ -328,13 +323,13 @@ class CredentialChecker:
         )
 
     def check_oid(self, oid: str, community: str, version="snmp_v2c_get") -> tuple[bool, str]:
-        """
-        Perform SNMP GET. Param is OID or symbolic name, version is activator method
+        """Perform SNMP GET. Param is OID or symbolic name, version is activator method
         todo mass check
-        :param oid:
-        :param community:
-        :param version:
-        :return:
+
+        Args:
+            oid
+            community
+            version
         """
         self.logger.info(
             "Trying community '%s': %s, version: %s", safe_shadow(community), oid, version
@@ -360,14 +355,14 @@ class CredentialChecker:
         protocol: Protocol,
         raise_privilege: bool = True,
     ) -> tuple[bool, str]:
-        """
-        Check user, password for cli proto
-        :param user:
-        :param password:
-        :param super_password:
-        :param protocol:
-        :param raise_privilege:
-        :return:
+        """Check user, password for cli proto
+
+        Args:
+            user
+            password
+            super_password
+            protocol
+            raise_privilege
         """
         self.logger.debug("Checking %s: %s/%s/%s", protocol, user, password, super_password)
         self.logger.info(
@@ -401,10 +396,10 @@ class CredentialChecker:
             return False, ""
 
     def get_first(self, protocols: Iterable[Protocol]) -> list[ProtocolResult]:
-        """
-        Get first result
-        :param protocols:
-        :return:
+        """Get first result
+
+        Args:
+            protocols
         """
         processed_proto = set()
         result = []

--- a/core/script/diagnostic.py
+++ b/core/script/diagnostic.py
@@ -19,9 +19,7 @@ from noc.sa.models.credentialcheckrule import CredentialCheckRule
 
 
 class SNMPSuggestsDiagnostic:
-    """
-    Run diagnostic by config and check status
-    """
+    """Run diagnostic by config and check status"""
 
     def __init__(self, config: DiagnosticConfig, logger=None):
         self.config = config
@@ -85,9 +83,7 @@ class SNMPSuggestsDiagnostic:
 
 
 class CLISuggestsDiagnostic:
-    """
-    Run diagnostic by config and check status
-    """
+    """Run diagnostic by config and check status"""
 
     def __init__(self, config: DiagnosticConfig, logger=None):
         self.config = config

--- a/core/script/http/base.py
+++ b/core/script/http/base.py
@@ -58,15 +58,17 @@ class HTTP:
         use_basic=False,
         raw_result=False,
     ):
-        """
-        Perform HTTP GET request
-        :param path: URI
-        :param headers: Dict of additional headers
-        :param cached: Cache result
-        :param json: Decode json if set to True
-        :param eof_mark: Waiting eof_mark in stream for end session (perhaps device return length 0)
-        :param use_basic: Use basic authentication
-        :param raw_result: Return raw result
+        """Perform HTTP GET request
+
+        Args:
+            path: URI
+            headers: Dict of additional headers
+            cached: Cache result
+            json: Decode json if set to True
+            eof_mark: Waiting eof_mark in stream for end session
+                (perhaps device return length 0)
+            use_basic: Use basic authentication
+            raw_result: Return raw result
         """
         self.ensure_session()
         self.request_id += 1
@@ -123,15 +125,17 @@ class HTTP:
         use_basic=False,
         raw_result=False,
     ):
-        """
-        Perform HTTP GET request
-        :param path: URI
-        :param headers: Dict of additional headers
-        :param cached: Cache result
-        :param json: Decode json if set to True
-        :param eof_mark: Waiting eof_mark in stream for end session (perhaps device return length 0)
-        :param use_basic: Use basic authentication
-        :param raw_result: Return raw result
+        """Perform HTTP GET request
+
+        Args:
+            path: URI
+            headers: Dict of additional headers
+            cached: Cache result
+            json: Decode json if set to True
+            eof_mark: Waiting eof_mark in stream for end session
+                (perhaps device return length 0)
+            use_basic: Use basic authentication
+            raw_result: Return raw result
         """
         self.ensure_session()
         self.request_id += 1
@@ -181,10 +185,10 @@ class HTTP:
             self.shutdown_session()
 
     def _process_cookies(self, headers: dict[str, bytes], allow_multiple_header: bool = False):
-        """
-        Process and store cookies from response headers
-        :param headers:
-        :return:
+        """Process and store cookies from response headers
+
+        Args:
+            headers
         """
         cdata = headers.get("Set-Cookie")
         if not cdata:
@@ -206,20 +210,23 @@ class HTTP:
             self.cookies.load(c.strip())
 
     def get_cookie(self, name):
-        """
-        Get cookie name by value
-        :param name:
-        :return: Morsel object or None
+        """Get cookie name by value
+
+        Args:
+            name
+
+        Returns:
+            Morsel object or None
         """
         if not self.cookies:
             return None
         return self.cookies.get(name)
 
     def _get_effective_headers(self, headers: dict[str, bytes]):
-        """
-        Append session headers when necessary. Apply effective cookies
-        :param headers:
-        :return:
+        """Append session headers when necessary. Apply effective cookies
+
+        Args:
+            headers
         """
         if self.headers:
             if headers:
@@ -236,20 +243,23 @@ class HTTP:
         return headers
 
     def set_header(self, name: str, value: str):
-        """
-        Set HTTP header to be set with all following requests
-        :param name:
-        :param value:
-        :return:
+        """Set HTTP header to be set with all following requests
+
+        Args:
+            name
+            value
         """
         self.logger.debug("Set header: %s = %s", name, value)
         self.headers[name] = str(value).encode()
 
     def set_session_id(self, session_id):
-        """
-        Set session_id to be reused by middleware
-        :param session_id:
-        :return: None
+        """Set session_id to be reused by middleware
+
+        Args:
+            session_id
+
+        Returns:
+            None
         """
         if session_id is not None:
             self.session_id = session_id

--- a/core/script/http/middleware/basicauth.py
+++ b/core/script/http/middleware/basicauth.py
@@ -13,9 +13,7 @@ from .base import BaseMiddleware
 
 
 class BasicAuthMiddeware(BaseMiddleware):
-    """
-    Append HTTP Basic authorisation headers
-    """
+    """Append HTTP Basic authorisation headers"""
 
     name = "basicauth"
 

--- a/core/script/http/middleware/digestauth.py
+++ b/core/script/http/middleware/digestauth.py
@@ -18,9 +18,7 @@ from noc.core.comp import smart_bytes
 
 
 class DigestAuthMiddeware(BaseMiddleware):
-    """
-    Append HTTP Digest authorisation headers
-    """
+    """Append HTTP Digest authorisation headers"""
 
     name = "digestauth"
 
@@ -37,11 +35,11 @@ class DigestAuthMiddeware(BaseMiddleware):
         self.request_id = 1
 
     def get_digest(self, uri, realm):
-        """
-        Calculate credential Digest
-        :param uri:
-        :param realm:
-        :return:
+        """Calculate credential Digest
+
+        Args:
+            uri
+            realm
         """
         A1 = f"{self.user}:{realm}:{self.password}".encode()
         A2 = f"{self.method}:{uri}".encode()
@@ -53,12 +51,10 @@ class DigestAuthMiddeware(BaseMiddleware):
 
     def build_digest_header(self, url, method, digest_response):
         """
-
-        :param url: query URL
-        :param method: GET/POST method
-        :param digest_response:  dict response header
-        :type digest_response: dict
-        :return:
+        Args:
+            url: query URL
+            method: GET/POST method
+            digest_response (dict): dict response header
         """
         self.logger.debug(
             "[%s] Build digest for %s, on response %s", self.name, url, digest_response

--- a/core/script/http/middleware/jsonrequestid.py
+++ b/core/script/http/middleware/jsonrequestid.py
@@ -10,8 +10,7 @@ from .base import BaseMiddleware
 
 
 class JSONRequestIdMiddleware(BaseMiddleware):
-    """
-    Append request_id:XXXXX to requests.
+    """Append request_id:XXXXX to requests.
     Request id is automatically increased with each next request.
     `request_id` name may be changed via `request_id_param`
     """

--- a/core/script/http/middleware/jsonsession.py
+++ b/core/script/http/middleware/jsonsession.py
@@ -10,8 +10,7 @@ from .base import BaseMiddleware
 
 
 class JSONSessionMiddleware(BaseMiddleware):
-    """
-    Append session_id: XXXXX to body.
+    """Append session_id: XXXXX to body.
     `session_id` name may be changed via `session_param`
     """
 

--- a/core/script/http/middleware/urlrequestid.py
+++ b/core/script/http/middleware/urlrequestid.py
@@ -10,8 +10,7 @@ from .base import BaseMiddleware
 
 
 class URLRequestIdMiddleware(BaseMiddleware):
-    """
-    Append &request_id=XXXXX to requests.
+    """Append &request_id=XXXXX to requests.
     Request id is automatically increased with each next request.
     `request_id` name may be changed via `request_id_param`
     """

--- a/core/script/http/middleware/urlsession.py
+++ b/core/script/http/middleware/urlsession.py
@@ -10,8 +10,7 @@ from .base import BaseMiddleware
 
 
 class URLSessionMiddleware(BaseMiddleware):
-    """
-    Append &session_id=XXXXX to requests.
+    """Append &session_id=XXXXX to requests.
     `session_id` name may be changed via `session_param`
     """
 

--- a/core/script/loader.py
+++ b/core/script/loader.py
@@ -34,8 +34,7 @@ class ScriptLoader(BaseLoader):
         self.all_scripts = set()
 
     def get_script(self, name):
-        """
-        Load script and return BaseScript instance.
+        """Load script and return BaseScript instance.
         Returns None when no script found or loading error occured
         """
         if name in self.protected_names:
@@ -80,9 +79,7 @@ class ScriptLoader(BaseLoader):
             return script
 
     def reload(self):
-        """
-        Reset script cache and release all modules
-        """
+        """Reset script cache and release all modules"""
         with self.lock:
             self.logger.info("Reloading scripts")
             for s in self.scripts:
@@ -95,9 +92,7 @@ class ScriptLoader(BaseLoader):
         return ".." not in name
 
     def find_scripts(self):
-        """
-        Scan all available scripts
-        """
+        """Scan all available scripts"""
         ns = set()
         # Load generic scripts
         generics = {}  # Name -> dependencies
@@ -138,17 +133,13 @@ class ScriptLoader(BaseLoader):
             self.all_scripts = ns
 
     def iter_scripts(self):
-        """
-        Returns all available script names
-        """
+        """Returns all available script names"""
         if not self.all_scripts:
             self.find_scripts()
         yield from sorted(self.all_scripts)
 
     def has_script(self, name):
-        """
-        Check script is exists
-        """
+        """Check script is exists"""
         if not self.all_scripts:
             self.find_scripts()
         return name in self.all_scripts

--- a/core/script/metrics.py
+++ b/core/script/metrics.py
@@ -81,7 +81,8 @@ def scale(n, float_round=None):
         float_round: Number of decimal places
 
     Returns:
-        If float_round, return round value
+        A callable that scales values by the given factor.
+        If float_round is set, returns a rounded result with that precision
     """
 
     def inner(v):

--- a/core/script/metrics.py
+++ b/core/script/metrics.py
@@ -11,27 +11,21 @@ from functools import reduce
 
 
 def percent(value, total):
-    """
-    Convert absolute and total values to percent
-    """
+    """Convert absolute and total values to percent"""
     if total:
         return float(value) * 100.0 / float(total)
     return 100.0
 
 
 def percent_usage(value, total):
-    """
-    Convert avail and usage values to percent
-    """
+    """Convert avail and usage values to percent"""
     if total:
         return float(value) * 100.0 / (float(total) + float(value))
     return 100.0
 
 
 def percent_invert(value, total):
-    """
-    Convert avail and total values to percent
-    """
+    """Convert avail and total values to percent"""
     if total:
         v = (float(total) - float(value)) * 100.0 / float(total)
         if v >= 0.0:
@@ -40,8 +34,7 @@ def percent_invert(value, total):
 
 
 def convert_percent_str(x):
-    """
-    Convert 09% to 9.0 value
+    """Convert 09% to 9.0 value
     Convert 09 to 9.0 value
     If x = None, return 0
     """
@@ -51,23 +44,17 @@ def convert_percent_str(x):
 
 
 def sum(*args):
-    """
-    Returns sum of all arguments
-    """
+    """Returns sum of all arguments"""
     return reduce(lambda x, y: x + y, args)
 
 
 def diff(*args):
-    """
-    Returns diff of all arguments
-    """
+    """Returns diff of all arguments"""
     return reduce(lambda x, y: x - y, args)
 
 
 def subtract(*args):
-    """
-    Subtract from first arguments
-    """
+    """Subtract from first arguments"""
     return args[0] - reduce(lambda x, y: x + y, args[1:])
 
 
@@ -76,15 +63,12 @@ def is1(x):
 
 
 def invert0(x):
-    """
-    Invert 0 -> 1 if OK = 0, FALSE > 1
-    """
+    """Invert 0 -> 1 if OK = 0, FALSE > 1"""
     return 0 if x > 0 else 1
 
 
 def scale(n, float_round=None):
-    """
-    High-order function to scale result to arbitrary value.
+    """High-order function to scale result to arbitrary value.
 
     f = scale(10)
     f(5) -> 50
@@ -92,10 +76,12 @@ def scale(n, float_round=None):
     f = scale(0.1, 2)
     f(10) -> 10.2
 
-    :param n: Scaling factor
-    :param float_round: Number of decimal places
-    :return: Callable, performing scaling
-    :return: If float_round, return round value
+    Args:
+        n: Scaling factor
+        float_round: Number of decimal places
+
+    Returns:
+        If float_round, return round value
     """
 
     def inner(v):
@@ -111,12 +97,15 @@ def scale(n, float_round=None):
 
 
 def fix_range(l_left, l_right, over_value=0):
-    """
-    Check value in interval (l_left, l_right), if over - return over_value
-    :param l_left: left endpoint
-    :param l_right: right endpoint
-    :param over_value: return if value over interval
-    :return: Callable, performing scaling
+    """Check value in interval (l_left, l_right), if over - return over_value
+
+    Args:
+        l_left: left endpoint
+        l_right: right endpoint
+        over_value: return if value over interval
+
+    Returns:
+        Callable, performing scaling
     """
 
     def innner_fix_range(v):
@@ -129,9 +118,7 @@ def fix_range(l_left, l_right, over_value=0):
 
 
 def convert_float(value):
-    """
-    Convert absolute and total values to percent
-    """
+    """Convert absolute and total values to percent"""
     if isinstance(value, bytes):
         value = value.decode("utf-8")
     return float(value)

--- a/core/script/mml/base.py
+++ b/core/script/mml/base.py
@@ -98,11 +98,11 @@ class MMLBase(BaseCLI):
         return self.result
 
     def execute(self, cmd, **kwargs):
-        """
-        Perform command and return result
-        :param cmd:
-        :param kwargs:
-        :return:
+        """Perform command and return result
+
+        Args:
+            cmd
+            **kwargs
         """
         self.buffer = b""
         self.command = self.profile.get_mml_command(cmd, **kwargs)

--- a/core/script/oidrules/bool.py
+++ b/core/script/oidrules/bool.py
@@ -10,9 +10,7 @@ from .oid import OIDRule
 
 
 class BooleanRule(OIDRule):
-    """
-    SNMP OID for booleans
-    """
+    """SNMP OID for booleans"""
 
     name = "bool"
     default_type = "bool"

--- a/core/script/oidrules/capindex.py
+++ b/core/script/oidrules/capindex.py
@@ -10,8 +10,7 @@ from .oid import OIDRule
 
 
 class CapabilityIndexRule(OIDRule):
-    """
-    Expand {{index}} to range given in capability
+    """Expand {{index}} to range given in capability
     capability: Integer capability containing number of iterations
     start: starting index
     """

--- a/core/script/oidrules/caplist.py
+++ b/core/script/oidrules/caplist.py
@@ -10,8 +10,7 @@ from .oid import OIDRule
 
 
 class CapabilityListRule(OIDRule):
-    """
-    Expand {{item}} from capability
+    """Expand {{item}} from capability
     capability: String capability, separated by *separator*
     separator: String separator, comma by default
     strip: Strip resulting item, remove spaces from both sides

--- a/core/script/oidrules/caps.py
+++ b/core/script/oidrules/caps.py
@@ -10,8 +10,7 @@ from .loader import load_rule
 
 
 class CapabilityRule:
-    """
-    Capability-based selection
+    """Capability-based selection
 
     oids is the list of (Capability, OIDRule)
     """

--- a/core/script/oidrules/counter.py
+++ b/core/script/oidrules/counter.py
@@ -10,9 +10,7 @@ from .oid import OIDRule
 
 
 class CounterRule(OIDRule):
-    """
-    SNMP OID for SNMP counters
-    """
+    """SNMP OID for SNMP counters"""
 
     name = "counter"
     default_type = "counter"

--- a/core/script/oidrules/hires.py
+++ b/core/script/oidrules/hires.py
@@ -10,8 +10,7 @@ from .loader import load_rule
 
 
 class HiresRule:
-    """
-    Select *hires* chain if SNMP | IF-MIB HC capability set,
+    """Select *hires* chain if SNMP | IF-MIB HC capability set,
     Select *normal* capability otherwise
     """
 

--- a/core/script/oidrules/ifindex.py
+++ b/core/script/oidrules/ifindex.py
@@ -10,9 +10,7 @@ from .oid import OIDRule
 
 
 class InterfaceRule(OIDRule):
-    """
-    Expand {{ifIndex}}
-    """
+    """Expand {{ifIndex}}"""
 
     name = "ifindex"
 

--- a/core/script/oidrules/loader.py
+++ b/core/script/oidrules/loader.py
@@ -15,12 +15,11 @@ cv_oid_rule_resolver: ContextVar[Callable | None] = ContextVar("cv_oid_rule_reso
 
 @contextmanager
 def with_resolver(resolver):
-    """
-    OIDRule resolver context.
+    """OIDRule resolver context.
 
-    :param resolver: callable accepting name and returning
-        OIDRule class with given type
-    :return:
+    Args:
+        resolver: callable accepting name and returning OIDRule class
+            with given type
     """
     cv_oid_rule_resolver.set(resolver)
     yield
@@ -28,11 +27,11 @@ def with_resolver(resolver):
 
 
 def load_rule(data):
-    """
-    Create OIDRule instance from data structure.
+    """Create OIDRule instance from data structure.
     MUST be called within resolver_context
-    :param data: parsed from json file
-    :return:
+
+    Args:
+        data: parsed from json file
     """
     resolver = cv_oid_rule_resolver.get()
     assert resolver, "Should be calles within with_resolver context"

--- a/core/script/oidrules/match.py
+++ b/core/script/oidrules/match.py
@@ -11,9 +11,7 @@ from .loader import load_rule
 
 
 class MatcherRule:
-    """
-    Multiple items for single metric
-    """
+    """Multiple items for single metric"""
 
     name = "match"
 

--- a/core/script/oidrules/oid.py
+++ b/core/script/oidrules/oid.py
@@ -16,9 +16,7 @@ rx_rule_var = re.compile(r"{{\s*([^}]+?)\s*}}")
 
 
 class OIDRule:
-    """
-    SNMP OID generator for SNMP_OIDS
-    """
+    """SNMP OID generator for SNMP_OIDS"""
 
     name = "oid"
     default_type = "gauge"
@@ -35,21 +33,21 @@ class OIDRule:
         self.labels = labels or []
 
     def _convert_scale(self, scale):
-        """
-        Convert scale expression to callable or constant
-        :param scale:
-        :return:
+        """Convert scale expression to callable or constant
+
+        Args:
+            scale
         """
         if isinstance(scale, str):
             return eval(scale, self._scale_locals)
         return scale
 
     def iter_oids(self, script, metric):
-        """
-        Generator yielding oid, type, scale, path
-        :param script:
-        :param metric:
-        :return:
+        """Generator yielding oid, type, scale, path
+
+        Args:
+            script
+            metric
         """
         if self.is_complex:
             yield tuple(self.oid), self.type, self.scale, self.units, self.labels
@@ -66,19 +64,19 @@ class OIDRule:
 
     @classmethod
     def expand(cls, template, context):
-        """
-        Expand {{ var }} expressions in template with given context
-        :param template:
-        :param context:
-        :return:
+        """Expand {{ var }} expressions in template with given context
+
+        Args:
+            template
+            context
         """
         return rx_rule_var.sub(lambda x: str(context[x.group(1)]), template)
 
     def expand_oid(self, **kwargs):
-        """
-        Apply kwargs to template and return resulting oid
-        :param kwargs:
-        :return:
+        """Apply kwargs to template and return resulting oid
+
+        Args:
+            **kwargs
         """
         if self.is_complex:
             oids = tuple(mib[self.expand(o, kwargs)] for o in self.oid)
@@ -89,10 +87,7 @@ class OIDRule:
 
     @classmethod
     def _build_scale_locals(cls):
-        """
-        Build locals for scale evaluation
-        :return:
-        """
+        """Build locals for scale evaluation"""
         import noc.core.script.metrics  # noqa
 
         m = sys.modules["noc.core.script.metrics"]

--- a/core/script/oidrules/oids.py
+++ b/core/script/oidrules/oids.py
@@ -10,9 +10,7 @@ from .oid import OIDRule
 
 
 class OIDsRule:
-    """
-    Multiple items for single metric
-    """
+    """Multiple items for single metric"""
 
     name = "oids"
 

--- a/core/script/rtsp/base.py
+++ b/core/script/rtsp/base.py
@@ -161,12 +161,12 @@ class RTSPBase(BaseCLI):
         return int(code), headers, msg
 
     def execute(self, path, method, **kwargs):
-        """
-        Perform request and return result
-        :param path:
-        :param method:
-        :param kwargs:
-        :return:
+        """Perform request and return result
+
+        Args:
+            path
+            method
+            **kwargs
         """
         self.buffer = b""
         self.path = path
@@ -211,9 +211,7 @@ class RTSPBase(BaseCLI):
 
 
 class DigestAuth:
-    """
-    Append HTTP Digest authorisation headers
-    """
+    """Append HTTP Digest authorisation headers"""
 
     name = "digestauth"
 
@@ -227,11 +225,10 @@ class DigestAuth:
 
     def get_digest(self, uri, realm, method):
         """
-
-        :param uri:
-        :param realm:
-        :param method: GET/POST
-        :return:
+        Args:
+            uri
+            realm
+            method: GET/POST
         """
         # print("Get Digest", uri, realm, method, self.user, self.password)
         A1 = "%s:%s:%s" % (self.user, realm, self.password)
@@ -244,12 +241,10 @@ class DigestAuth:
 
     def build_digest_header(self, url, method, digest_response):
         """
-
-        :param url: query URL
-        :param method: GET/POST method
-        :param digest_response:  dict response header
-        :type digest_response: dict
-        :return:
+        Args:
+            url: query URL
+            method: GET/POST method
+            digest_response (dict): dict response header
         """
         # p_parsed = urlparse(url)
         # uri = p_parsed.path or "/"

--- a/core/script/snmp/base.py
+++ b/core/script/snmp/base.py
@@ -80,9 +80,7 @@ class SNMP:
         self.rate_limit = rate
 
     def _get_auth_key(self) -> Md5Key | Sha1Key:
-        """
-        Getting SNMPv3 Authenticate Key
-        """
+        """Getting SNMPv3 Authenticate Key"""
         if not self.script.credentials["snmp_auth_key"]:
             raise SNMPError("Unknown Authentication Key")
         passphrase = self.script.credentials["snmp_auth_key"].encode("utf-8")
@@ -91,9 +89,7 @@ class SNMP:
         )
 
     def _get_private_key(self) -> DesKey | Aes128Key:
-        """
-        Getting SNMPv3 Private Key
-        """
+        """Getting SNMPv3 Private Key"""
         if not self.script.credentials["snmp_priv_key"]:
             raise SNMPError("Unknown Private Key")
         passphrase = self.script.credentials["snmp_priv_key"].encode("utf-8")
@@ -102,8 +98,7 @@ class SNMP:
         )
 
     def _get_engine_id(self) -> bytes | None:
-        """
-        Get SNMPv3 EngineId from Capabilities 'SNMP | EngineID'
+        """Get SNMPv3 EngineId from Capabilities 'SNMP | EngineID'
         bytes.fromhex(engine_id[2:])
         """
         if self.script and not self.script.reuse_snmpv3_engine_id:
@@ -163,10 +158,10 @@ class SNMP:
         return self._script()
 
     def set_timeout_limits(self, n):
-        """
-        Set sequental timeouts l
-        :param n:
-        :return:
+        """Set sequental timeouts l
+
+        Args:
+            n
         """
         self.timeouts_limit = n
         self.timeouts = n
@@ -226,8 +221,7 @@ class SNMP:
         display_hints: dict[str, Callable] | None = None,
         strict_value=False,
     ) -> Any | dict[str, Any]:
-        """
-        Perform SNMP GET request by gufo_snmp library
+        """Perform SNMP GET request by gufo_snmp library
         Args:
             oids: dict with oids in form {name: oid, ...} or string contains oid
             cached: True if get results can be cached during session
@@ -302,21 +296,23 @@ class SNMP:
         return run_sync(run)
 
     def set(self, *args):
-        """
-        Perform SNMP GET request by gufo_snmp library
-        :param args:
-        :returns:
+        """Perform SNMP GET request by gufo_snmp library
+
+        Args:
+            *args
         """
         raise NotImplementedError(
             "Method `set` is not yet implemented in gufo SNMP implementation."
         )
 
     def count(self, oid, filter=None, version=None, timeout: int = 10) -> int:
-        """
-        Iterate MIB subtree and count matching instances by gufo_snmp library
-        :param oid: OID
-        :param filter: Callable accepting oid and value and returning boolean
-        :param timeout: Timeout for SNMP Response
+        """Iterate MIB subtree and count matching instances by gufo_snmp library
+
+        Args:
+            oid: OID
+            filter: Callable accepting oid and value and returning
+                boolean
+            timeout: Timeout for SNMP Response
         """
 
         async def run(filter: Callable):
@@ -371,22 +367,27 @@ class SNMP:
         display_hints: dict[str, Callable] | None = None,
         max_records: int | None = None,
     ) -> list[tuple[str, Any]]:
-        """
-        Perform SNMP GETNEXT request by gufo_snmp library
-        :param oid: string
-        :param community_suffix:
-        :param filter:
-        :param cached: True if get results can be cached during session
-        :param only_first: Return first result
-        :param bulk: False - disable GetBulk, None - Enable by 'SNMP | Bulk' capabilities
-        :param max_repetitions: Max OID in Bulk result
-        :param version: SNMP Version: 0 - v1, 1 - v2c
-        :param max_retries: Mac count trying when no response
-        :param timeout: Timeout for SNMP Response
-        :param raw_varbinds: Return value in BER encoding
-        :param display_hints: Dict of  oid -> render_function. See BaseProfile.snmp_display_hints for details
-        :param max_records: Return only set record count
-        :returns: result in list of tuples (name, value)
+        """Perform SNMP GETNEXT request by gufo_snmp library
+
+        Args:
+            oid: string
+            community_suffix
+            filter
+            cached: True if get results can be cached during session
+            only_first: Return first result
+            bulk: False - disable GetBulk, None - Enable by 'SNMP |
+                Bulk' capabilities
+            max_repetitions: Max OID in Bulk result
+            version: SNMP Version: 0 - v1, 1 - v2c
+            max_retries: Mac count trying when no response
+            timeout: Timeout for SNMP Response
+            raw_varbinds: Return value in BER encoding
+            display_hints: Dict of  oid -> render_function. See
+                BaseProfile.snmp_display_hints for details
+            max_records: Return only set record count
+
+        Returns:
+            result in list of tuples (name, value)
         """
 
         async def run(max_retries, filter):
@@ -442,9 +443,7 @@ class SNMP:
         return run_sync(partial(run, max_retries, filter or (lambda x, y: True)))
 
     def get_table(self, oid, community_suffix=None, cached=False, display_hints=None):
-        """
-        GETNEXT wrapper. Returns a hash of <index> -> <value>
-        """
+        """GETNEXT wrapper. Returns a hash of <index> -> <value>"""
         r = {}
         for o, v in self.getnext(
             oid, community_suffix=community_suffix, cached=cached, display_hints=display_hints
@@ -453,9 +452,7 @@ class SNMP:
         return r
 
     def join_tables(self, oid1, oid2, community_suffix=None, cached=False, display_hints=None):
-        """
-        Generator returning a rows of two snmp tables joined by index
-        """
+        """Generator returning a rows of two snmp tables joined by index"""
         t1 = self.get_table(
             oid1, community_suffix=community_suffix, cached=cached, display_hints=display_hints
         )
@@ -481,21 +478,21 @@ class SNMP:
         max_retries: int = 0,
         display_hints: dict[str, Callable] | None = None,
     ):
-        """
-        Query list of SNMP tables referenced by oids and yields
+        """Query list of SNMP tables referenced by oids and yields
         tuples of (key, value1, ..., valueN)
 
-        :param oids: List of OIDs
-        :param community_suffix: Optional suffix to be added to community
-        :param bulk: Use BULKGETNEXT if true
-        :param min_index:
-        :param max_index:
-        :param cached:
-        :param max_repetitions: Max OID in Bulk result
-        :param max_retries: Mac count trying when no response
-        :param timeout: Timeout for SNMP Response
-        :param display_hints: Dict of  oid -> render_function. See BaseProfile.snmp_display_hints for details
-        :return:
+        Args:
+            oids: List of OIDs
+            community_suffix: Optional suffix to be added to community
+            bulk: Use BULKGETNEXT if true
+            min_index
+            max_index
+            cached
+            max_repetitions: Max OID in Bulk result
+            max_retries: Mac count trying when no response
+            timeout: Timeout for SNMP Response
+            display_hints: Dict of  oid -> render_function. See
+                BaseProfile.snmp_display_hints for details
         """
 
         def gen_table(oid):
@@ -523,8 +520,7 @@ class SNMP:
             yield [".".join([str(x) for x in i])] + [t.get(i) for t in tables]
 
     def join(self, oids, community_suffix=None, cached=False, join="left"):
-        """
-        Query list of tables, merge by oid index
+        """Query list of tables, merge by oid index
         Tables are records of:
         * <oid>.<index> = value
 
@@ -554,13 +550,15 @@ class SNMP:
                 yield tuple([k] + [t.get(k) for t in tables])
 
     def get_chunked(self, oids, chunk_size=20, timeout_limits=3):
-        """
-        Fetch list of oids splitting to several operations when necessary
+        """Fetch list of oids splitting to several operations when necessary
 
-        :param oids: List of oids
-        :param chunk_size: Maximal GET chunk size
-        :param timeout_limits: SNMP timeout limits
-        :return: dict of oid -> value for all retrieved values
+        Args:
+            oids: List of oids
+            chunk_size: Maximal GET chunk size
+            timeout_limits: SNMP timeout limits
+
+        Returns:
+            dict of oid -> value for all retrieved values
         """
         results = {}
         self.set_timeout_limits(timeout_limits)
@@ -579,9 +577,7 @@ class SNMP:
         return results
 
     def get_engine_id(self, *args):
-        """
-        Getting SNMPv3 EngineId from address
-        """
+        """Getting SNMPv3 EngineId from address"""
 
         async def run():
             address = self.script.credentials["address"]

--- a/core/script/snmp/beef.py
+++ b/core/script/snmp/beef.py
@@ -87,10 +87,13 @@ class BeefSNMPSocket:
         return response, address
 
     def snmp_get_response(self, pdu):
-        """
-        Process SNMP GET request
-        :param pdu: Parsed request PDU
-        :return: error_status, error_index, varbinds
+        """Process SNMP GET request
+
+        Args:
+            pdu: Parsed request PDU
+
+        Returns:
+            error_status, error_index, varbinds
         """
         beef = self.script.request_beef()
         r = []
@@ -108,10 +111,13 @@ class BeefSNMPSocket:
         return err_status, err_index, r
 
     def snmp_getnext_response(self, pdu):
-        """
-        Process SNMP GETNEXT request
-        :param pdu: Parsed request PDU
-        :return: error_status, error_index, varbinds
+        """Process SNMP GETNEXT request
+
+        Args:
+            pdu: Parsed request PDU
+
+        Returns:
+            error_status, error_index, varbinds
         """
         beef = self.script.request_beef()
         err_status = NO_ERROR
@@ -129,10 +135,13 @@ class BeefSNMPSocket:
         return err_status, err_index, r
 
     def snmp_getbulk_response(self, pdu):
-        """
-        Process SNMP GETBULK request
-        :param pdu: Parsed request PDU
-        :return: error_status, error_index, varbinds
+        """Process SNMP GETBULK request
+
+        Args:
+            pdu: Parsed request PDU
+
+        Returns:
+            error_status, error_index, varbinds
         """
         beef = self.script.request_beef()
         r = []


### PR DESCRIPTION
Convert all docstrings in `core/script/` from Sphinx/reStructuredText style (`:param`, `:return`) to Google format (`Args:`, `Returns:`).

## Key Changes
- Convert ~200+ function/class docstrings across 36 files in the SA scripting framework
- Collapse multi-line one-sentence docstrings into single lines where appropriate
- No behavioral or logic changes — documentation-only
