### PR TITLE
kpi/py-typing: Ignore non-pythonic directories

### DIFF
--- a/scripts/kpi/py-typing.py
+++ b/scripts/kpi/py-typing.py
@@ -282,8 +282,23 @@ def scan_module(path: Path) -> Iterable[KPI]:
     return visitor.rows
 
 
+_ignored_dirs = {
+    "ansible",
+    "ui",
+    "docs",
+    "dist",
+    "build",
+    "docker",
+    "examples",
+    "var",
+}
+
+
 def can_scan(path: Path) -> bool:
     parts = path.parts
+
+    if parts and parts[0] in _ignored_dirs:
+        return False
 
     for part in parts:
         if part.startswith("."):


### PR DESCRIPTION
Speed up the `scripts/kpi/py-typing` KPI scanner by skipping non-Python directories at the root level instead of descending into them and discovering `.py` files that shouldn't be analyzed.

**Key changes:**

- Add `_ignored_dirs` set with top-level directories to skip: `ansible`, `ui`, `docs`, `dist`, `build`, `docker`, `examples`, `var`
- Check first path component against the set before walking deeper in `can_scan()`
