### PR TITLE
__init__ return type typing

### DIFF
--- a/commands/beef.py
+++ b/commands/beef.py
@@ -118,7 +118,7 @@ class Command(BaseCommand):
         from noc.dev.models.spec import Spec
 
         class FakeSpec:
-            def __init__(self, name):
+            def __init__(self, name) -> None:
                 self.name = name
                 self.uuid = "4ec10fd8-3a33-4f23-b96e-91e3967c3b1b"
 
@@ -642,9 +642,9 @@ class Command(BaseCommand):
 
 class ServiceStub:
     class ServiceConfig:
-        def __init__(self, pool, tos=None):
+        def __init__(self, pool, tos=None) -> None:
             self.pool = pool
             self.tos = tos
 
-    def __init__(self, pool):
+    def __init__(self, pool) -> None:
         self.config = self.ServiceConfig(pool=pool)

--- a/commands/check-metric.py
+++ b/commands/check-metric.py
@@ -133,9 +133,9 @@ class Command(BaseCommand):
 
 class ServiceStub:
     class ServiceConfig:
-        def __init__(self, pool, tos=None):
+        def __init__(self, pool, tos=None) -> None:
             self.pool = pool
             self.tos = tos
 
-    def __init__(self, pool):
+    def __init__(self, pool) -> None:
         self.config = self.ServiceConfig(pool=pool)

--- a/commands/convert-xcvr-descr-to-data.py
+++ b/commands/convert-xcvr-descr-to-data.py
@@ -24,7 +24,7 @@ from noc.models import get_model
 
 
 class Dict2Class:
-    def __init__(self, d: dict):
+    def __init__(self, d: dict) -> None:
         for k, v in d.items():
             setattr(self, k, v)
 
@@ -485,9 +485,9 @@ class Command(BaseCommand):
 
 class ServiceStub:
     class ServiceConfig:
-        def __init__(self, pool, tos=None):
+        def __init__(self, pool, tos=None) -> None:
             self.pool = pool
             self.tos = tos
 
-    def __init__(self, pool):
+    def __init__(self, pool) -> None:
         self.config = self.ServiceConfig(pool=pool)

--- a/commands/script.py
+++ b/commands/script.py
@@ -413,41 +413,41 @@ class Command(BaseCommand):
 
 class ServiceStub:
     class ServiceConfig:
-        def __init__(self, pool, tos=None):
+        def __init__(self, pool, tos=None) -> None:
             self.pool = pool
             self.tos = tos
 
-    def __init__(self, pool):
+    def __init__(self, pool) -> None:
         self.config = self.ServiceConfig(pool=pool)
 
 
 class PoolStub:
-    def __init__(self, name):
+    def __init__(self, name) -> None:
         self.name = name
 
 
 class ProfileStub:
-    def __init__(self, name):
+    def __init__(self, name) -> None:
         self.name = name
 
 
 class VendorStub:
-    def __init__(self, name):
+    def __init__(self, name) -> None:
         self.name = name
 
 
 class PlatformStub:
-    def __init__(self, name):
+    def __init__(self, name) -> None:
         self.name = name
 
 
 class VersionStub:
-    def __init__(self, version):
+    def __init__(self, version) -> None:
         self.version = version
 
 
 class JSONObject:
-    def __init__(self, path):
+    def __init__(self, path) -> None:
         with open(path) as f:
             data = orjson.loads(f.read())
         self.scheme = {"telnet": TELNET, "ssh": SSH, "http": HTTP, "https": HTTPS}.get(

--- a/config.py
+++ b/config.py
@@ -1092,7 +1092,7 @@ class Config(BaseConfig):
         ds_limit = IntParameter(default=1000)
 
     # pylint: disable=super-init-not-called
-    def __init__(self, rewrites: Iterable[BaseRewrite] | None = None):
+    def __init__(self, rewrites: Iterable[BaseRewrite] | None = None) -> None:
         super().__init__(rewrites=rewrites)
 
     @property

--- a/core/bi/query.py
+++ b/core/bi/query.py
@@ -18,7 +18,9 @@ class OP:
     :param convert: Convert function name
     """
 
-    def __init__(self, min=None, max=None, join=None, prefix=None, convert=None, function=None):
+    def __init__(
+        self, min=None, max=None, join=None, prefix=None, convert=None, function=None
+    ) -> None:
         self.min = min
         self.max = max
         self.join = join

--- a/core/cdag/factory/base.py
+++ b/core/cdag/factory/base.py
@@ -18,7 +18,9 @@ class BaseCDAGFactory:
     together
     """
 
-    def __init__(self, graph: CDAG, ctx: FactoryCtx | None = None, namespace: str | None = None):
+    def __init__(
+        self, graph: CDAG, ctx: FactoryCtx | None = None, namespace: str | None = None
+    ) -> None:
         self.graph = graph
         self.ctx = ctx
         self.namespace = namespace

--- a/core/cdag/graph.py
+++ b/core/cdag/graph.py
@@ -16,7 +16,7 @@ from .tx import Transaction
 
 
 class CDAG:
-    def __init__(self, graph_id: str, state: dict[str, Any] | None = None):
+    def __init__(self, graph_id: str, state: dict[str, Any] | None = None) -> None:
         self.graph_id = graph_id
         self.state: dict[str, Any] = state or {}
         self.nodes: dict[str, BaseCDAGNode] = {}

--- a/core/cdag/node/base.py
+++ b/core/cdag/node/base.py
@@ -56,7 +56,7 @@ class ConfigProxy:
 
     __slots__ = ("__base", "__override")
 
-    def __init__(self, base: BaseModel, override: dict[str, Any]):
+    def __init__(self, base: BaseModel, override: dict[str, Any]) -> None:
         """
         Base Configuration (on BaseModel)
         :param base:

--- a/core/cdag/node/composeprobe.py
+++ b/core/cdag/node/composeprobe.py
@@ -42,7 +42,7 @@ class ComposeProbeNode(ProbeNode):
 
     __slots__ = ("compose_inputs", "expression")
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.expression: Callable = get_fn(self.config.expression)
         self.compose_inputs: frozenset[str] = self.config.compose_inputs or frozenset(

--- a/core/cdag/node/probe.py
+++ b/core/cdag/node/probe.py
@@ -66,7 +66,7 @@ class ProbeNode(BaseCDAGNode):
 
     __slots__ = "base", "convert", "exp", "fatal_error"
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.convert = self.get_convert(self.config.unit, self.config.is_delta)
         self.base, self.exp = self.get_scale(self.config.scale)

--- a/core/cdag/node/subgraph.py
+++ b/core/cdag/node/subgraph.py
@@ -51,7 +51,7 @@ class SubgraphState(BaseModel):
 
 
 class SubgraphCDAGFactory(ConfigCDAGFactory):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         # node -> [(param, value)]
         self.node_cfg: defaultdict[str, dict[str, Any]] = defaultdict(dict)
         super().__init__(*args, **kwargs)

--- a/core/cdag/tx.py
+++ b/core/cdag/tx.py
@@ -13,7 +13,7 @@ from .typing import ValueType
 
 
 class Transaction:
-    def __init__(self, cdag):
+    def __init__(self, cdag) -> None:
         self.cdag = cdag
         # id(node) -> value
         self.inputs: dict[str, dict[str, ValueType]] = {}

--- a/core/checkers/cli.py
+++ b/core/checkers/cli.py
@@ -26,7 +26,7 @@ class CLIProtocolChecker(BaseChecker):
     PROTO_CHECK_MAP: dict[str, Protocol] = {p.config.check: p for p in Protocol if p.config.check}
     PARAMS = ["profile", "rules"]
 
-    def __init__(self, profile: str | None = None, **kwargs):
+    def __init__(self, profile: str | None = None, **kwargs) -> None:
         super().__init__(**kwargs)
         self.profile = profile
 

--- a/core/checkers/registry.py
+++ b/core/checkers/registry.py
@@ -19,7 +19,7 @@ class DiagnosticCheckRegister:
     Register diagnostic checks for processed result
     """
 
-    def __init__(self, logger=None):
+    def __init__(self, logger=None) -> None:
         self.logger: logging.Logger = logger
         self.checks: dict[str, Check] = {}
         self.w_checks: dict[str, list[Check]] = defaultdict(list)  # Wildcard checks

--- a/core/checkers/snmp.py
+++ b/core/checkers/snmp.py
@@ -48,7 +48,7 @@ class SNMPProtocolChecker(BaseChecker):
     SNMP_TIMEOUT_SEC = 3
     PARAMS = ["rules"]
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
         self.rules: list[SNMPCredential | SNMPv3Credential] = self.load_suggests(
             kwargs.get("rules")

--- a/core/clickhouse/connect.py
+++ b/core/clickhouse/connect.py
@@ -19,7 +19,9 @@ from .error import ClickhouseError
 class ClickhouseClient:
     DEFAULT_PORT = 8123
 
-    def __init__(self, host: str | None = None, port: int | None = None, read_only: bool = True):
+    def __init__(
+        self, host: str | None = None, port: int | None = None, read_only: bool = True
+    ) -> None:
         self.read_only = read_only
         if read_only:
             self.user = config.clickhouse.ro_user

--- a/core/clickhouse/dictionary.py
+++ b/core/clickhouse/dictionary.py
@@ -36,7 +36,7 @@ class DictionaryBase(type):
 
 
 class DictionaryMeta:
-    def __init__(self, name=None, layout=None, lifetime_min=None, lifetime_max=None):
+    def __init__(self, name=None, layout=None, lifetime_min=None, lifetime_max=None) -> None:
         self.name = name
         self.layout = layout
         self.lifetime_min = lifetime_min

--- a/core/clickhouse/fields.py
+++ b/core/clickhouse/fields.py
@@ -23,7 +23,9 @@ class BaseField:
     db_type = None
     default_value = ""
 
-    def __init__(self, default=None, description: str | None = None, low_cardinality: bool = False):
+    def __init__(
+        self, default=None, description: str | None = None, low_cardinality: bool = False
+    ) -> None:
         """
 
         :param default: Default field value (if value not set)
@@ -226,7 +228,7 @@ class BooleanField(UInt8Field):
 
 
 class ArrayField(BaseField):
-    def __init__(self, field_type, description=None):
+    def __init__(self, field_type, description=None) -> None:
         super().__init__(description=description)
         self.field_type = field_type
 
@@ -246,7 +248,7 @@ class ArrayField(BaseField):
 
 
 class MaterializedField(BaseField):
-    def __init__(self, field_type, expression, description=None, low_cardinality=True):
+    def __init__(self, field_type, expression, description=None, low_cardinality=True) -> None:
         super().__init__(description=description, low_cardinality=low_cardinality)
         self.field_type = field_type
         self.expression = expression
@@ -263,7 +265,7 @@ class ReferenceField(BaseField):
     default_value = 0
     SELF_REFERENCE = "self"
 
-    def __init__(self, dict_type, description=None, model=None, low_cardinality=False):
+    def __init__(self, dict_type, description=None, model=None, low_cardinality=False) -> None:
         super().__init__(description=description, low_cardinality=low_cardinality)
         self.is_self_reference = dict_type == self.SELF_REFERENCE
         self.dict_type = dict_type
@@ -326,7 +328,7 @@ class IPv6Field(BaseField):
 
 
 class AggregatedField(BaseField):
-    def __init__(self, expression, field_type, agg_function, params=None, description=None):
+    def __init__(self, expression, field_type, agg_function, params=None, description=None) -> None:
         super().__init__(description=description)
         self.field_type = field_type
         self.agg_function = agg_function
@@ -346,7 +348,7 @@ class AggregatedField(BaseField):
 
 
 class MapField(BaseField):
-    def __init__(self, field_type, description=None):
+    def __init__(self, field_type, description=None) -> None:
         super().__init__(description=description)
         self.field_type = field_type
 

--- a/core/clickhouse/functions.py
+++ b/core/clickhouse/functions.py
@@ -9,7 +9,7 @@
 class AggregateFunction:
     db_name = None
 
-    def __init__(self, function: str | None = None, **params):
+    def __init__(self, function: str | None = None, **params) -> None:
         self.function = self.db_name or function
         self.params = params
 

--- a/core/clickhouse/model.py
+++ b/core/clickhouse/model.py
@@ -99,7 +99,7 @@ class Model(metaclass=ModelBase):
         sample = False
         tags = None
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         self.values = kwargs
 
     @classmethod

--- a/core/collection/base.py
+++ b/core/collection/base.py
@@ -74,7 +74,7 @@ class Collection:
 
     _state_cache = cachetools.TTLCache(maxsize=100, ttl=60)
 
-    def __init__(self, name, stdout=None):
+    def __init__(self, name, stdout=None) -> None:
         self.name = name
         self._model = None
         self._api_version = self.DEFAULT_API_VERSION

--- a/core/compressor/base.py
+++ b/core/compressor/base.py
@@ -14,7 +14,7 @@ class BaseCompressor:
     # Default file extension
     ext = None
 
-    def __init__(self, path: str, mode: str = "r"):
+    def __init__(self, path: str, mode: str = "r") -> None:
         self.path = path
         self.mode = mode
         self.f: io.TextIOBase | None = None

--- a/core/confdb/applicator/base.py
+++ b/core/confdb/applicator/base.py
@@ -7,7 +7,7 @@
 
 
 class BaseApplicator:
-    def __init__(self, object, confdb):
+    def __init__(self, object, confdb) -> None:
         self.object = object
         self.confdb = confdb
         self.config = {}

--- a/core/confdb/applicator/query.py
+++ b/core/confdb/applicator/query.py
@@ -19,7 +19,7 @@ class QueryApplicator(BaseApplicator):
     # List of
     CONFIG = {}
 
-    def __init__(self, object, confdb, **kwargs):
+    def __init__(self, object, confdb, **kwargs) -> None:
         super().__init__(object, confdb)
         for k in self.CONFIG:
             self.config[k] = kwargs.get(k, self.CONFIG[k])

--- a/core/confdb/collator/base.py
+++ b/core/confdb/collator/base.py
@@ -14,7 +14,7 @@ from .typing import PortItem
 
 
 class BaseCollator:
-    def __init__(self, profile: BaseProfile | None):
+    def __init__(self, profile: BaseProfile | None) -> None:
         self.profile = profile
 
     def collate(self, physical_port: PortItem, interfaces: dict[str, Any]) -> str | None:

--- a/core/confdb/collator/ifname.py
+++ b/core/confdb/collator/ifname.py
@@ -12,7 +12,7 @@ from .base import BaseCollator
 class IfNameCollator(BaseCollator):
     """Direct map between connection name and interface name"""
 
-    def __init__(self, profile=None):
+    def __init__(self, profile=None) -> None:
         super().__init__(profile=profile)
         self.names = None
 

--- a/core/confdb/collator/ifpath.py
+++ b/core/confdb/collator/ifpath.py
@@ -32,7 +32,7 @@ class IfPathCollator(BaseCollator):
     4) - If more that one interfaces has equal path, but different if_type, use protocols for detect right
     """
 
-    def __init__(self, profile=None):
+    def __init__(self, profile=None) -> None:
         super().__init__(profile)
         self.paths = defaultdict(list)
 

--- a/core/confdb/db/node.py
+++ b/core/confdb/db/node.py
@@ -12,7 +12,7 @@ from noc.core.text import alnum_key
 class Node:
     __slots__ = ["children", "token"]
 
-    def __init__(self, token):
+    def __init__(self, token) -> None:
         self.token = token
         self.children = None
 

--- a/core/confdb/engine/transformer.py
+++ b/core/confdb/engine/transformer.py
@@ -14,7 +14,7 @@ CVAR_NAME = "_ctx"
 
 
 class PredicateTransformer(ast.NodeTransformer):
-    def __init__(self, engine):
+    def __init__(self, engine) -> None:
         self.engine = engine
         self.input_counter = itertools.count()
         super().__init__()

--- a/core/confdb/engine/var.py
+++ b/core/confdb/engine/var.py
@@ -7,7 +7,7 @@
 
 
 class Var:
-    def __init__(self, name):
+    def __init__(self, name) -> None:
         self.name = name
 
     def __str__(self) -> str:

--- a/core/confdb/normalizer/base.py
+++ b/core/confdb/normalizer/base.py
@@ -26,7 +26,7 @@ REST = REST
 class Node:
     __slots__ = ["children", "handler", "matcher", "token"]
 
-    def __init__(self, token):
+    def __init__(self, token) -> None:
         if isinstance(token, str):
             self.token = Token(token)
         else:
@@ -99,7 +99,7 @@ class Node:
 class RootNode(Node):
     __slots__ = ["children", "handler", "matcher", "token"]
 
-    def __init__(self, token=None):
+    def __init__(self, token=None) -> None:
         super().__init__(token)
 
     def __repr__(self) -> str:
@@ -191,7 +191,7 @@ class BaseNormalizer(metaclass=BaseNormalizerMetaclass):
     # Custom syntax to enrich ConfDB
     SYNTAX = []
 
-    def __init__(self, object, tokenizer, errors_policy: str = "strict"):
+    def __init__(self, object, tokenizer, errors_policy: str = "strict") -> None:
         self.object = object
         self.tokenizer = tokenizer
         self.deferable_contexts = defaultdict(dict)  # Name -> Context

--- a/core/confdb/syntax/patterns.py
+++ b/core/confdb/syntax/patterns.py
@@ -48,7 +48,7 @@ class REST(BasePattern):
 
 
 class Token(BasePattern):
-    def __init__(self, token):
+    def __init__(self, token) -> None:
         super().__init__()
         self.token = token
 

--- a/core/confdb/tokenizer/base.py
+++ b/core/confdb/tokenizer/base.py
@@ -12,7 +12,7 @@ from typing import Iterator
 class BaseTokenizer:
     name = None
 
-    def __init__(self, data: str):
+    def __init__(self, data: str) -> None:
         self.data = data
 
     def __iter__(self) -> Iterator[tuple[str]]:

--- a/core/confdb/tokenizer/context.py
+++ b/core/confdb/tokenizer/context.py
@@ -12,7 +12,7 @@ from .line import LineTokenizer
 class ContextTokenizer(LineTokenizer):
     name = "context"
 
-    def __init__(self, data, end_of_context=None, contexts=None, **kwargs):
+    def __init__(self, data, end_of_context=None, contexts=None, **kwargs) -> None:
         super().__init__(data, **kwargs)
         self.end_of_context = end_of_context
         self.contexts = contexts or []

--- a/core/confdb/tokenizer/indent.py
+++ b/core/confdb/tokenizer/indent.py
@@ -12,7 +12,7 @@ from .line import LineTokenizer
 class IndentTokenizer(LineTokenizer):
     name = "indent"
 
-    def __init__(self, data, end_of_context=None, **kwargs):
+    def __init__(self, data, end_of_context=None, **kwargs) -> None:
         kwargs["keep_indent"] = True
         self.end_of_context = end_of_context
         super().__init__(data, **kwargs)

--- a/core/confdb/tokenizer/ini.py
+++ b/core/confdb/tokenizer/ini.py
@@ -17,7 +17,7 @@ class INITokenizer(BaseTokenizer):
 
     name = "ini"
 
-    def __init__(self, data):
+    def __init__(self, data) -> None:
         super().__init__(data)
         self.config = RawConfigParser()
         self.config.read_string(data)

--- a/core/config/params.py
+++ b/core/config/params.py
@@ -24,7 +24,7 @@ T = TypeVar("T")
 class BaseParameter(Generic[T]):
     PARAM_NUMBER = itertools.count()
 
-    def __init__(self, default: T | str | None = None, help: str | None = None):
+    def __init__(self, default: T | str | None = None, help: str | None = None) -> None:
         self.param_number = next(self.PARAM_NUMBER)
         if default is None:
             self.default = None
@@ -147,7 +147,9 @@ class FloatParameter(BaseParameter[float]):
 
 
 class MapParameter(BaseParameter[T], Generic[T]):
-    def __init__(self, mappings: dict[str, T], default: str | None = None, help: str | None = None):
+    def __init__(
+        self, mappings: dict[str, T], default: str | None = None, help: str | None = None
+    ) -> None:
         self.mappings = mappings or {}
         super().__init__(default=default, help=help)
 
@@ -261,7 +263,9 @@ class BytesSizeParameter(BaseParameter[int]):
 
 
 class ListParameter(BaseParameter[list[T]], Generic[T]):
-    def __init__(self, item: BaseParameter[T], default: Any = None, help: str | None = None):
+    def __init__(
+        self, item: BaseParameter[T], default: Any = None, help: str | None = None
+    ) -> None:
         self.item = item
         super().__init__(default=default, help=help)
 
@@ -277,7 +281,7 @@ class ListParameter(BaseParameter[list[T]], Generic[T]):
 class ServiceItem:
     __slots__ = ["host", "port"]
 
-    def __init__(self, host: str, port: int):
+    def __init__(self, host: str, port: int) -> None:
         self.host = host
         self.port = port
 

--- a/core/config/proto/base.py
+++ b/core/config/proto/base.py
@@ -10,7 +10,7 @@ from urllib.parse import unquote, urlparse
 
 
 class BaseProtocol:
-    def __init__(self, config, url):
+    def __init__(self, config, url) -> None:
         self.config = config
         self.url = url
         # Parse url

--- a/core/config/proto/consul.py
+++ b/core/config/proto/consul.py
@@ -29,7 +29,7 @@ class ConsulProtocol(BaseProtocol):
     REQUEST_TIMEOUT = 30
     CONNECT_TIMEOUT = 30
 
-    def __init__(self, config, url):
+    def __init__(self, config, url) -> None:
         super().__init__(config, url)
         if ":" in self.parsed_url.netloc:
             h, p = self.parsed_url.netloc.rsplit(":", 1)

--- a/core/config/proto/legacy.py
+++ b/core/config/proto/legacy.py
@@ -143,7 +143,7 @@ class LegacyProtocol(BaseProtocol):
         ("web-global-%(node)s.max_threads", "web.max_threads"),
     ]
 
-    def __init__(self, config, url):
+    def __init__(self, config, url) -> None:
         super().__init__(config, url)
         if self.parsed_url.path == "/":
             self.path = config.path.legacy_config

--- a/core/config/proto/yaml.py
+++ b/core/config/proto/yaml.py
@@ -26,7 +26,7 @@ class YAMLProtocol(BaseProtocol):
     INDENT = "  "
     ESCAPE_START = ("@", "%", "&")
 
-    def __init__(self, config, url):
+    def __init__(self, config, url) -> None:
         super().__init__(config, url)
         if self.parsed_url.path == "/":
             self.path = ""

--- a/core/datastream/client.py
+++ b/core/datastream/client.py
@@ -25,7 +25,7 @@ class DataStreamClient:
     RETRY_TIMEOUT = 1.0
     NEXT_GET_DELAY = 2.0
 
-    def __init__(self, name, service=None):
+    def __init__(self, name, service=None) -> None:
         self.name = name
         self.service = service
         self._is_ready = False

--- a/core/dcs/base.py
+++ b/core/dcs/base.py
@@ -32,7 +32,7 @@ class DCSBase:
     # and must be temporary removed from resolver
     HEALTH_FAILED_HTTP_CODE = 429
 
-    def __init__(self, runner, url):
+    def __init__(self, runner, url) -> None:
         self.runner = runner
         self.logger = logging.getLogger(__name__)
         self.url = url
@@ -226,7 +226,7 @@ class DCSBase:
 
 
 class ResolverBase:
-    def __init__(self, dcs, name, critical=False, near=False, track=True):
+    def __init__(self, dcs, name, critical=False, near=False, track=True) -> None:
         self.dcs = dcs
         self.name = name
         self.to_shutdown = False

--- a/core/dcs/consul.py
+++ b/core/dcs/consul.py
@@ -92,7 +92,7 @@ class ConsulDCS(DCSBase):
 
     resolver_cls = ConsulResolver
 
-    def __init__(self, runner, url):
+    def __init__(self, runner, url) -> None:
         self.name = None
         self.consul_host = self.DEFAULT_CONSUL_HOST
         self.consul_port = self.DEFAULT_CONSUL_PORT

--- a/core/debug.py
+++ b/core/debug.py
@@ -399,7 +399,7 @@ class ErrorReport:
     error_report context wrapper
     """
 
-    def __init__(self, reverse=config.traceback.reverse, logger=logger):
+    def __init__(self, reverse=config.traceback.reverse, logger=logger) -> None:
         self.reverse = reverse
         self.logger = logger
 

--- a/core/diagnostic/handler.py
+++ b/core/diagnostic/handler.py
@@ -19,7 +19,7 @@ class DiagnosticHandler:
     Run diagnostic by config and check status
     """
 
-    def __init__(self, config: DiagnosticConfig, logger=None):
+    def __init__(self, config: DiagnosticConfig, logger=None) -> None:
         self.config = config
         self.logger = logger
 

--- a/core/diagnostic/item.py
+++ b/core/diagnostic/item.py
@@ -40,7 +40,7 @@ class DiagnosticItem(BaseModel):
     _config: DiagnosticConfig | None = PrivateAttr()
     _handler: DiagnosticHandler | None = PrivateAttr()
 
-    def __init__(self, cfg: DiagnosticConfig | None = None, **data):
+    def __init__(self, cfg: DiagnosticConfig | None = None, **data) -> None:
         super().__init__(**data)
         self._config: DiagnosticConfig = cfg
 

--- a/core/discriminator.py
+++ b/core/discriminator.py
@@ -85,7 +85,7 @@ class LambdaDiscriminator:
 class VlanDiscriminator:
     scope: str = "vlan"
 
-    def __init__(self, value: str):
+    def __init__(self, value: str) -> None:
         try:
             self.vlan: set[int] = set(ranges_to_list(value))
         except SyntaxError as e:
@@ -156,7 +156,7 @@ ODU_LIMITS = {
 class OduDiscriminator:
     scope: str = "odu"
 
-    def __init__(self, value: str):
+    def __init__(self, value: str) -> None:
         self.odu: list[tuple[str, int]] = list(self._iter_parse(value))
         # Check odu
         prev_odu = None

--- a/core/dns/rr.py
+++ b/core/dns/rr.py
@@ -29,7 +29,7 @@ class RR:
         "zone",
     ]
 
-    def __init__(self, zone, name, ttl, type, rdata, priority=None):
+    def __init__(self, zone, name, ttl, type, rdata, priority=None) -> None:
         self.zone = zone
         self.name = name
         self.ttl = ttl

--- a/core/dns/zonefile.py
+++ b/core/dns/zonefile.py
@@ -26,7 +26,7 @@ class ZoneFile:
     TABSTOP = 8
     MAX_TXT = 128
 
-    def __init__(self, data):
+    def __init__(self, data) -> None:
         records = data.get("records", [])
         if not records:
             raise ValueError("Zone must contain SOA record")

--- a/core/error.py
+++ b/core/error.py
@@ -103,7 +103,7 @@ class NOCError(Exception):
     default_msg = None
     default_code = ERR_UNKNOWN
 
-    def __init__(self, msg=None, code=None):
+    def __init__(self, msg=None, code=None) -> None:
         super().__init__(msg or self.default_msg)
         self.code = code or self.default_code
         metrics[f"err_{self.code}"] += 1

--- a/core/etl/bi/extractor/alarmlogs.py
+++ b/core/etl/bi/extractor/alarmlogs.py
@@ -17,7 +17,7 @@ from .base import BaseExtractor
 class AlarmLogsExtractor(BaseExtractor):
     name = "alarmlogs"
 
-    def __init__(self, prefix, start, stop):
+    def __init__(self, prefix, start, stop) -> None:
         super().__init__(prefix, start, stop)
         self.alarmlogs_stream = Stream(AlarmLogs, prefix)
 

--- a/core/etl/bi/extractor/alarms.py
+++ b/core/etl/bi/extractor/alarms.py
@@ -31,7 +31,7 @@ class AlarmsExtractor(ArchivingExtractor):
     archive_batch_limit = config.bi.alarms_archive_batch_limit
     archive_collection_template = config.bi.alarms_archive_policy
 
-    def __init__(self, prefix, start, stop, use_archive=False):
+    def __init__(self, prefix, start, stop, use_archive=False) -> None:
         self.use_archive = use_archive
         super().__init__(prefix, start, stop)
         self.alarm_stream = Stream(Alarms, prefix)

--- a/core/etl/bi/extractor/base.py
+++ b/core/etl/bi/extractor/base.py
@@ -25,7 +25,7 @@ class BaseExtractor:
     # or just a snapshot of existing data
     is_snapshot = False
 
-    def __init__(self, prefix, start, stop):
+    def __init__(self, prefix, start, stop) -> None:
         self.prefix = prefix
         self.start = start
         self.stop = stop

--- a/core/etl/bi/extractor/managedobject.py
+++ b/core/etl/bi/extractor/managedobject.py
@@ -61,7 +61,7 @@ class ManagedObjectsExtractor(BaseExtractor):
         "xmac": "xmac_links",
     }
 
-    def __init__(self, prefix, start, stop):
+    def __init__(self, prefix, start, stop) -> None:
         super().__init__(prefix, start, stop)
         self.mo_stream = Stream(ManagedObjectBI, prefix)
 

--- a/core/etl/bi/extractor/reboots.py
+++ b/core/etl/bi/extractor/reboots.py
@@ -19,7 +19,7 @@ class RebootsExtractor(BaseExtractor):
     extract_delay = config.bi.extract_delay_reboots
     clean_delay = config.bi.clean_delay_reboots
 
-    def __init__(self, prefix, start, stop):
+    def __init__(self, prefix, start, stop) -> None:
         super().__init__(prefix, start, stop)
         self.reboot_stream = Stream(Reboots, prefix)
 

--- a/core/etl/bi/stream.py
+++ b/core/etl/bi/stream.py
@@ -22,7 +22,7 @@ from noc.core.fileutils import make_persistent
 class Stream:
     CHUNK_SIZE = config.bi.chunk_size
 
-    def __init__(self, model, prefix, date=None):
+    def __init__(self, model, prefix, date=None) -> None:
         self.prefix = prefix
         self.model = model
         self.date = date or datetime.date.today()

--- a/core/etl/extractor/base.py
+++ b/core/etl/extractor/base.py
@@ -64,7 +64,7 @@ class BaseExtractor:
         r"^import-\d{4}(?:-\d{2}){5}.jsonl%s$" % compressor.ext.replace(".", r"\.")
     )
 
-    def __init__(self, system: "BaseRemoteSystem"):
+    def __init__(self, system: "BaseRemoteSystem") -> None:
         self.system = system
         self.config = system.config
         self.logger = PrefixLoggerAdapter(logger, "%s][%s" % (system.name, self.name))

--- a/core/etl/extractor/fias.py
+++ b/core/etl/extractor/fias.py
@@ -86,7 +86,7 @@ class AdmDivExtractor(BaseExtractor):
         "х",
     )
 
-    def __init__(self, system, *args, **kwargs):
+    def __init__(self, system, *args, **kwargs) -> None:
         super().__init__(system)
         self.oktmo_url = str(self.config.get("OKTMO_URL"))
         self.cache_path = str(self.config.get("CACHE_PATH"))
@@ -182,7 +182,7 @@ class StreetExtractor(BaseExtractor):
     name = "street"
     model = Street
 
-    def __init__(self, system, *args, **kwargs):
+    def __init__(self, system, *args, **kwargs) -> None:
         super().__init__(system)
         self.fias_url = str(self.config.get("FIAS_URL"))
         self.cache_path = str(self.config.get("CACHE_PATH"))
@@ -306,7 +306,7 @@ class AddressExtractor(BaseExtractor):
     name = "address"
     model = Address
 
-    def __init__(self, system, *args, **kwargs):
+    def __init__(self, system, *args, **kwargs) -> None:
         super().__init__(system)
         self.fias_url = str(self.config.get("FIAS_URL"))
         self.cache_path = str(self.config.get("CACHE_PATH"))
@@ -401,7 +401,7 @@ class BuildingExtractor(BaseExtractor):
     name = "building"
     model = Building
 
-    def __init__(self, system, *args, **kwargs):
+    def __init__(self, system, *args, **kwargs) -> None:
         super().__init__(system)
         self.fias_url = str(self.config.get("FIAS_URL"))
         self.cache_path = str(self.config.get("CACHE_PATH"))

--- a/core/etl/extractor/mysql.py
+++ b/core/etl/extractor/mysql.py
@@ -26,7 +26,7 @@ class MySQLExtractor(SQLExtractor):
     *MYSQL_CHARSET* - Mysql charset
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.connect = None
 

--- a/core/etl/extractor/netbox.py
+++ b/core/etl/extractor/netbox.py
@@ -55,7 +55,7 @@ class NetBoxExtractor(BaseExtractor):
 
     LIMIT = 300
 
-    def __init__(self, system):
+    def __init__(self, system) -> None:
         super().__init__(system)
         self.url = self.config.get("API_URL", None)
         self.token = self.config.get("API_TOKEN", None)
@@ -114,7 +114,7 @@ class NetBoxObjectExtractor(NetBoxExtractor):
 
     device_mode_mapping = {"Generic | Access | Switch"}
 
-    def __init__(self, system):
+    def __init__(self, system) -> None:
         super().__init__(system)
         self.racks = set()
         self.object_model_map = self.load_model_map()
@@ -395,7 +395,7 @@ class NetBoxHostExtractor(NetBoxExtractor):
     name = "managedobject"
     model = ManagedObject
 
-    def __init__(self, system):
+    def __init__(self, system) -> None:
         super().__init__(system)
         self.pool: str = self.config.get("POOL") or "default"
         self.fm_pool: str = self.config.get("FM_POOL")

--- a/core/etl/extractor/oracle.py
+++ b/core/etl/extractor/oracle.py
@@ -34,7 +34,7 @@ class ORACLEExtractor(SQLExtractor):
     *ORACLE_ARRAYSIZE* - oracle client array size
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.connect = None
 

--- a/core/etl/extractor/vcenter.py
+++ b/core/etl/extractor/vcenter.py
@@ -59,7 +59,7 @@ class VCenterExtractor(BaseExtractor):
         self.client.vcenter.vm.guest.networking.Interfaces.list(x[1].vm)
     """
 
-    def __init__(self, system):
+    def __init__(self, system) -> None:
         super().__init__(system)
 
         self.url = self.config.get("API_URL", None)
@@ -173,7 +173,7 @@ class VCenterManagedObjectExtractor(VCenterExtractor):
     name = "managedobject"
     model = ManagedObject
 
-    def __init__(self, system):
+    def __init__(self, system) -> None:
         super().__init__(system)
         self.links = []
         self.pool: str = self.config.get("POOL") or "default"

--- a/core/etl/extractor/zabbix.py
+++ b/core/etl/extractor/zabbix.py
@@ -234,7 +234,7 @@ class ZabbixRemoteSystem(BaseRemoteSystem):
 
 
 class ZabbixExtractor(BaseExtractor):
-    def __init__(self, system):
+    def __init__(self, system) -> None:
         super().__init__(system)
         self.url = self.config.get("API_URL", None)
         self.token = self.config.get("API_TOKEN", None)
@@ -365,7 +365,7 @@ class ZabbixFMEventExtractor(ZabbixExtractor):
     # def filter(self, row) -> bool:
     #     return False
 
-    def __init__(self, system):
+    def __init__(self, system) -> None:
         super().__init__(system)
         self.targets: dict[int, RemoteObject] = {}
         self.items: dict[int, ZabbixEventItem] = {}

--- a/core/etl/loader/address.py
+++ b/core/etl/loader/address.py
@@ -35,7 +35,7 @@ class AddressLoader(BaseLoader):
         "street": "street",
     }
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         building_dict = {}
         street_dict = {}

--- a/core/etl/loader/base.py
+++ b/core/etl/loader/base.py
@@ -107,7 +107,7 @@ class BaseLoader:
     class Deferred(Exception):
         pass
 
-    def __init__(self, chain):
+    def __init__(self, chain) -> None:
         self.chain = chain
         self.system = chain.system
         self.logger = PrefixLoggerAdapter(logger, "%s][%s" % (self.system.name, self.name))

--- a/core/etl/loader/building.py
+++ b/core/etl/loader/building.py
@@ -33,7 +33,7 @@ class BuildingLoader(BaseLoader):
         "adm_division": "admdiv",
     }
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         division_dict = {}
         for r in Division.objects.all():

--- a/core/etl/loader/chain.py
+++ b/core/etl/loader/chain.py
@@ -16,7 +16,7 @@ from noc.core.etl.loader.base import BaseLoader
 
 
 class LoaderChain:
-    def __init__(self, system):
+    def __init__(self, system) -> None:
         self.system = system
         self.loaders: dict[str, BaseLoader] = {}  # name -> loader
         self.lseq: list[BaseLoader] = []

--- a/core/etl/loader/container.py
+++ b/core/etl/loader/container.py
@@ -23,7 +23,7 @@ class ContainerLoader(BaseLoader):
 
     CONTAINER_MODEL = "Group"
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.model_map = {}
         self.containers = {}  # Path -> Object

--- a/core/etl/loader/maintenance.py
+++ b/core/etl/loader/maintenance.py
@@ -31,7 +31,7 @@ class MaintenanceLoader(BaseLoader):
         "managed_object": "sa.ManagedObject",
     }
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.clean_map["type"] = MaintenanceType.get_by_name
 

--- a/core/etl/loader/managedobject.py
+++ b/core/etl/loader/managedobject.py
@@ -51,7 +51,7 @@ class ManagedObjectLoader(BaseLoader):
         "vrf": VRF,
     }
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.clean_map["pool"] = Pool.get_by_name
         self.clean_map["fm_pool"] = lambda x: Pool.get_by_name(x) if x else None

--- a/core/etl/loader/object.py
+++ b/core/etl/loader/object.py
@@ -40,7 +40,7 @@ class ObjectLoader(BaseLoader):
         "container",
     ]
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         # @todo check None model
         self.clean_map["model"] = clean_model

--- a/core/etl/loader/pmagent.py
+++ b/core/etl/loader/pmagent.py
@@ -36,7 +36,7 @@ class PMAgentLoader(BaseLoader):
 
     post_save_fields = {"capabilities", "addresses"}
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.available_caps = {x.name for x in Capability.objects.filter()}
 

--- a/core/etl/loader/resourcegroup.py
+++ b/core/etl/loader/resourcegroup.py
@@ -21,6 +21,6 @@ class ResourceGroupLoader(BaseLoader):
     model = ResourceGroupModel
     data_model = ResourceGroup
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.clean_map["technology"] = Technology.get_by_name

--- a/core/etl/loader/sensor.py
+++ b/core/etl/loader/sensor.py
@@ -25,6 +25,6 @@ class SensorLoader(BaseLoader):
     workflow_event_model = True
     workflow_seen_supported = True
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.clean_map["units"] = lambda x: MeasurementUnits.get_by_name(x) if x else None

--- a/core/etl/loader/service.py
+++ b/core/etl/loader/service.py
@@ -33,7 +33,7 @@ class ServiceLoader(BaseLoader):
 
     post_save_fields = {"capabilities", "instances"}
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.available_caps = {x.name for x in Capability.objects.filter()}
         self.clean_map["static_service_groups"] = lambda x: [

--- a/core/etl/loader/street.py
+++ b/core/etl/loader/street.py
@@ -34,7 +34,7 @@ class StreetLoader(BaseLoader):
         "parent": "admdiv",
     }
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         division_dict = {}
         for r in Division.objects.all():

--- a/core/etl/models/typing.py
+++ b/core/etl/models/typing.py
@@ -44,7 +44,7 @@ class CapsItem(BaseModel):
 
 
 class Reference(Generic[T]):
-    def __init__(self, name: str, model: T, value: Any, remote_system: str | None = None):
+    def __init__(self, name: str, model: T, value: Any, remote_system: str | None = None) -> None:
         self.name = name
         self.model = model
         self.value = value

--- a/core/etl/portmapper/base.py
+++ b/core/etl/portmapper/base.py
@@ -46,7 +46,7 @@ class BasePortMapper(metaclass=PortMapperBase):
     _profile_to_remote = {}
     _platform_to_remote = {}
 
-    def __init__(self, managed_object):
+    def __init__(self, managed_object) -> None:
         self.managed_object = managed_object
         self.profile = self.managed_object.profile.name
         self.platform = self.managed_object.platform.name if self.managed_object.platform else None

--- a/core/etl/remotesystem/base.py
+++ b/core/etl/remotesystem/base.py
@@ -75,7 +75,7 @@ class BaseRemoteSystem:
         "maintenance",
     ]
 
-    def __init__(self, remote_system):
+    def __init__(self, remote_system) -> None:
         self.remote_system = remote_system
         self.name: str = remote_system.name
         self.config: dict[str, str] = self.remote_system.config

--- a/core/fileutils.py
+++ b/core/fileutils.py
@@ -59,7 +59,7 @@ class temporary_file:
              subprocess.Popen(["wc","-l",p])
     """
 
-    def __init__(self, text=""):
+    def __init__(self, text="") -> None:
         self.text = text
 
     def __enter__(self):

--- a/core/forms.py
+++ b/core/forms.py
@@ -21,7 +21,7 @@ class NOCBoundField(BoundField):
     Bound field with django-admin like label-tag
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.is_checkbox = isinstance(self.field.widget, CheckboxInput)
 
@@ -49,7 +49,7 @@ class NOCForm(Form):
     class Media:
         css = {"all": ["/ui/pkg/django-media/admin/css/forms.css"]}
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.disabled_fields = set()
 

--- a/core/geocoder/base.py
+++ b/core/geocoder/base.py
@@ -29,7 +29,7 @@ class GeoCoderResult:
 class BaseGeocoder:
     name = None
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         pass
 
     def forward(self, query: str, bounds=None) -> GeoCoderResult:

--- a/core/geocoder/google.py
+++ b/core/geocoder/google.py
@@ -20,7 +20,7 @@ from .errors import GeoCoderError
 class GoogleGeocoder(BaseGeocoder):
     name = "google"
 
-    def __init__(self, key=None, language=None, *args, **kwargs):
+    def __init__(self, key=None, language=None, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.key = key or config.geocoding.google_key
         self.language = language or config.geocoding.google_language

--- a/core/gridvcs/base.py
+++ b/core/gridvcs/base.py
@@ -32,7 +32,7 @@ class GridVCS:
     ENCODING = "utf-8"
     DEFAULT_COMPRESS = "z"
 
-    def __init__(self, repo):
+    def __init__(self, repo) -> None:
         self.fs = gridfs.GridFS(get_db(), collection="noc.gridvcs.%s" % repo)
         self.files = self.fs._GridFS__files
 

--- a/core/gridvcs/manager.py
+++ b/core/gridvcs/manager.py
@@ -36,7 +36,7 @@ class GridVCSField:
     print o.data.diff(rev1, rev2)
     """
 
-    def __init__(self, repo):
+    def __init__(self, repo) -> None:
         self.repo = repo
         self.model = None
 
@@ -55,7 +55,7 @@ class GridVCSField:
 
 
 class GridVCSObjectDescriptor:
-    def __init__(self, field):
+    def __init__(self, field) -> None:
         self.field = field
         self.repo = field.repo
 
@@ -66,7 +66,7 @@ class GridVCSObjectDescriptor:
 class GridVCSObjectProxy:
     _cache = {}
 
-    def __init__(self, repo, id):
+    def __init__(self, repo, id) -> None:
         self.repo = repo
         self.id = id
 

--- a/core/hist/base.py
+++ b/core/hist/base.py
@@ -15,7 +15,7 @@ DEFAULT_HIST_SCALE = 1000000
 
 
 class Histogram:
-    def __init__(self, config=None, scale=DEFAULT_HIST_SCALE):
+    def __init__(self, config=None, scale=DEFAULT_HIST_SCALE) -> None:
         self.scale = DEFAULT_HIST_SCALE
         self.labels = [str(x) for x in config] + ["+Inf"]
         self.thresholds = [int(x * scale) for x in config]

--- a/core/importer.py
+++ b/core/importer.py
@@ -29,7 +29,7 @@ class NOCLoader(importlib.abc.Loader):
     INIT_SOURCE = ""
     packages: set[str] = set()
 
-    def __init__(self, path_entry: str | None = None):
+    def __init__(self, path_entry: str | None = None) -> None:
         self.base_path = Path(path_entry or "")
         self.packages.add(self.PREFIX)
 

--- a/core/interface/parameter.py
+++ b/core/interface/parameter.py
@@ -14,7 +14,7 @@ class BaseParameter:
     Abstract parameter
     """
 
-    def __init__(self, required=True, default=None):
+    def __init__(self, required=True, default=None) -> None:
         self.required = required
         self.default = default
         if default is not None:
@@ -129,7 +129,7 @@ class ORParameter(BaseParameter):
     InterfaceTypeError: IPv4Parameter: None.
     """
 
-    def __init__(self, left, right):
+    def __init__(self, left, right) -> None:
         super().__init__()
         self.left = left
         self.right = right

--- a/core/ioloop/timers.py
+++ b/core/ioloop/timers.py
@@ -15,7 +15,7 @@ from typing import Coroutine
 
 
 class PeriodicCallback:
-    def __init__(self, cb: Coroutine, interval: int, delay: int = 0):
+    def __init__(self, cb: Coroutine, interval: int, delay: int = 0) -> None:
         """
         This function sets up a timer that will run the coroutine every
         interval miliseconds, starting after delay seconds
@@ -74,5 +74,5 @@ class PeriodicCallback:
 
 
 class PeriodicOffsetCallback(PeriodicCallback):
-    def __init__(self, cb: Coroutine, interval: int):
+    def __init__(self, cb: Coroutine, interval: int) -> None:
         super().__init__(cb, interval, random.random() * interval)

--- a/core/ioloop/udp.py
+++ b/core/ioloop/udp.py
@@ -28,7 +28,7 @@ class UDPSocket:
         sock.close()
     """
 
-    def __init__(self, tos: int | None = None):
+    def __init__(self, tos: int | None = None) -> None:
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         if tos:
             self.socket.setsockopt(socket.IPPROTO_IP, socket.IP_TOS, tos)
@@ -70,7 +70,7 @@ class UDPSocket:
 
 
 class UDPSocketContext:
-    def __init__(self, sock: UDPSocket | None = None, tos: int | None = None):
+    def __init__(self, sock: UDPSocket | None = None, tos: int | None = None) -> None:
         if sock:
             self.sock = sock
             self.to_close = False

--- a/core/ioloop/udpserver.py
+++ b/core/ioloop/udpserver.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 class UDPServerProtocol(asyncio.DatagramProtocol):
-    def __init__(self, server):
+    def __init__(self, server) -> None:
         super().__init__()
         self._server = server
 

--- a/core/ioloop/util.py
+++ b/core/ioloop/util.py
@@ -30,7 +30,7 @@ if config.features.use_uvloop:
 
 
 class IOLoopContext:
-    def __init__(self, suppress_trace=False):
+    def __init__(self, suppress_trace=False) -> None:
         self.prev_loop = None
         self.new_loop = None
         self.suppress_trace = suppress_trace

--- a/core/ip.py
+++ b/core/ip.py
@@ -29,7 +29,7 @@ class IP:
 
     afi = None
 
-    def __init__(self, prefix: str):
+    def __init__(self, prefix: str) -> None:
         """Return new prefix instance.
 
         Args:
@@ -299,7 +299,7 @@ class IPv4(IP):
 
     afi = "4"
 
-    def __init__(self, prefix: str, netmask: str | None = None):
+    def __init__(self, prefix: str, netmask: str | None = None) -> None:
         """Create a new IPv4 prefix.
 
         Args:
@@ -584,7 +584,7 @@ class IPv6(IP):
 
     afi = "6"
 
-    def __init__(self, prefix: str, netmask: str | None = None):
+    def __init__(self, prefix: str, netmask: str | None = None) -> None:
         """Create a new IPv6 prefix instance.
 
         Args:
@@ -994,7 +994,7 @@ class PrefixDB:
         key: Value stored at this node (None if empty).
     """
 
-    def __init__(self, key=None):
+    def __init__(self, key=None) -> None:
         self.children = [None, None]
         self.key = key
 

--- a/core/lock/base.py
+++ b/core/lock/base.py
@@ -29,7 +29,7 @@ class BaseLock(ABC):
     ```
     """
 
-    def __init__(self, category: str, owner: str, ttl: float | None = None):
+    def __init__(self, category: str, owner: str, ttl: float | None = None) -> None:
         """
         :param category: Lock category name
         :param owner: Lock owner id
@@ -72,7 +72,7 @@ class Token:
     Active lock context manager
     """
 
-    def __init__(self, lock: BaseLock, items: Iterable[str], ttl: float | None = None):
+    def __init__(self, lock: BaseLock, items: Iterable[str], ttl: float | None = None) -> None:
         self.lock = lock
         self.items = list(items)
         self.ttl = ttl

--- a/core/lock/distributed.py
+++ b/core/lock/distributed.py
@@ -42,7 +42,7 @@ class DistributedLock(BaseLock):
     ```
     """
 
-    def __init__(self, category: str, owner: str, ttl: float | None = None):
+    def __init__(self, category: str, owner: str, ttl: float | None = None) -> None:
         """
         :param category: Lock category name
         :param owner: Lock owner id

--- a/core/lock/process.py
+++ b/core/lock/process.py
@@ -32,7 +32,7 @@ class ProcessLock(BaseLock):
     ```
     """
 
-    def __init__(self, category: str, owner: str, ttl: float | None = None):
+    def __init__(self, category: str, owner: str, ttl: float | None = None) -> None:
         """
         :param category: Lock category name
         :param owner: Lock owner id

--- a/core/log.py
+++ b/core/log.py
@@ -19,7 +19,7 @@ class PrefixLoggerAdapter:
     Add [prefix] to log message
     """
 
-    def __init__(self, logger, prefix, target=None):
+    def __init__(self, logger, prefix, target=None) -> None:
         """
         :param logger: Parent logger
         :param prefix: Prefix to add in front of every message
@@ -98,7 +98,7 @@ class ColorFormatter(logging.Formatter):
         logging.ERROR: 1,  # Red
     }
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         self._colors = {}
         self._end_color = ""
         self.setup_colors()

--- a/core/management/base.py
+++ b/core/management/base.py
@@ -26,7 +26,7 @@ class BaseCommand:
     LOG_FORMAT = config.log_format
     help = ""  # Help text (shows ./noc help)
 
-    def __init__(self, stdout=sys.stdout, stderr=sys.stderr):
+    def __init__(self, stdout=sys.stdout, stderr=sys.stderr) -> None:
         self.verbose_level = 0
         self.stdout = stdout
         self.stderr = stderr

--- a/core/migration/db.py
+++ b/core/migration/db.py
@@ -150,7 +150,7 @@ class DB:
         pk_field_kwargs = pk_field_kwargs or {}
 
         class MockOptions:
-            def __init__(self, model):
+            def __init__(self, model) -> None:
                 self.db_table = db_table
                 self.db_tablespace = ""
                 self.object_name = model_name

--- a/core/model/databasestorage.py
+++ b/core/model/databasestorage.py
@@ -29,7 +29,7 @@ class DatabaseStorage(Storage):
       mtime_field
     """
 
-    def __init__(self, option):
+    def __init__(self, option) -> None:
         self.db_table = option["db_table"]
         self.name_field = option["name_field"]
         self.data_field = option["data_field"]

--- a/core/model/fields.py
+++ b/core/model/fields.py
@@ -32,7 +32,7 @@ class CIDRField(models.Field):
     CIDRField maps to PostgreSQL CIDR
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
     def db_type(self, connection):
@@ -208,7 +208,7 @@ class TagsContainsLookup(models.Lookup):
 
 
 class DocumentReferenceDescriptor:
-    def __init__(self, field):
+    def __init__(self, field) -> None:
         self.field = field
         self.document = self.field.document
         self.cache_name = field.get_cache_name()
@@ -293,7 +293,7 @@ class DocumentReferenceDescriptor:
 
 
 class DocumentReferenceField(models.Field):
-    def __init__(self, document, *args, **kwargs):
+    def __init__(self, document, *args, **kwargs) -> None:
         self.document = document
         super().__init__(*args, **kwargs)
 
@@ -342,7 +342,7 @@ class ObjectIDArrayField(ArrayField):
     ObjectIDArrayField maps to PostgreSQL CHAR[] type
     """
 
-    def __init__(self, size=None, **kwargs):
+    def __init__(self, size=None, **kwargs) -> None:
         super().__init__(CharField24(max_length=24), size=size, **kwargs)
 
     def db_type(self, connection):

--- a/core/model/sql.py
+++ b/core/model/sql.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 class SQLNode(Q):
-    def __init__(self, sql):
+    def __init__(self, sql) -> None:
         super().__init__(id__rawsql=sql)
 
 

--- a/core/mongo/fields.py
+++ b/core/mongo/fields.py
@@ -29,7 +29,7 @@ class PlainReferenceField(BaseField):
     dereferenced on access (lazily). Maps to plain ObjectId
     """
 
-    def __init__(self, document_type, *args, **kwargs):
+    def __init__(self, document_type, *args, **kwargs) -> None:
         if not isinstance(document_type, str):
             if not issubclass(document_type, (Document, str)):
                 raise ValidationError(
@@ -165,7 +165,7 @@ class ForeignKeyField(BaseField):
     dereferenced on access (lazily). Maps to integer
     """
 
-    def __init__(self, model, **kwargs):
+    def __init__(self, model, **kwargs) -> None:
         if not issubclass(model, Model):
             raise ValidationError("Argument to ForeignKeyField constructor must be a Model class")
         self.document_type = model

--- a/core/msgstream/queue.py
+++ b/core/msgstream/queue.py
@@ -16,7 +16,7 @@ from .message import PublishRequest
 
 
 class MessageStreamQueue:
-    def __init__(self, loop: asyncio.BaseEventLoop | None = None):
+    def __init__(self, loop: asyncio.BaseEventLoop | None = None) -> None:
         self.queue: deque = deque()
         self.lock = Lock()
         self.waiter: asyncio.Event | None = None

--- a/core/msgstream/queuebuffer.py
+++ b/core/msgstream/queuebuffer.py
@@ -22,7 +22,7 @@ class QBuffer:
     Buffered writes to queue, merge outgoing messages to a larger block
     """
 
-    def __init__(self, max_size: int | None = None):
+    def __init__(self, max_size: int | None = None) -> None:
         self.buf: defaultdict[tuple[str, int], list[bytes]] = defaultdict(list)
         self.lock = Lock()
         self.max_size = max_size or config.liftbridge.max_message_size

--- a/core/pm/utils.py
+++ b/core/pm/utils.py
@@ -526,7 +526,7 @@ class MetricProxy:
         MetricProxy([("managed_object", 22222222, "interface": "1/1/1")]).interface(queries=["load_in", "load_out"]).values()
     """
 
-    def __init__(self, query_ts: datetime.datetime | None = None, **kwargs):
+    def __init__(self, query_ts: datetime.datetime | None = None, **kwargs) -> None:
         self._scopes: dict[str, "MetricScopeProxy"] = {}  # Scope Storage
         self._conditions = kwargs
 

--- a/core/prefixlist.py
+++ b/core/prefixlist.py
@@ -25,7 +25,7 @@ class Node:
 
     __slots__ = ["children", "is_final", "n", "parent", "prefix"]
 
-    def __init__(self, parent=None, prefix=None, prefixes=None):
+    def __init__(self, parent=None, prefix=None, prefixes=None) -> None:
         self.parent = parent
         self.prefix = prefix or []
         self.children = [None, None]

--- a/core/profile/diagnostic.py
+++ b/core/profile/diagnostic.py
@@ -31,7 +31,7 @@ class ProfileDiagnostic:
         "https_get": HTTPS_DIAG,
     }
 
-    def __init__(self, config: DiagnosticConfig, logger=None):
+    def __init__(self, config: DiagnosticConfig, logger=None) -> None:
         self.config = config
         self.logger = logger or logging.getLogger("profilediagnostic")
         self.unsupported_method: set[str] = set()

--- a/core/protodcsources/base.py
+++ b/core/protodcsources/base.py
@@ -23,7 +23,7 @@ class BaseDiscriminatorSource(ABC):
 
     name: str
 
-    def __init__(self, protocol, data: list[DiscriminatorDataItem] = None):
+    def __init__(self, protocol, data: list[DiscriminatorDataItem] = None) -> None:
         self.protocol = protocol
         self.data = data
 

--- a/core/quantile/base.py
+++ b/core/quantile/base.py
@@ -32,7 +32,7 @@ class Stream:
     :param n:
     """
 
-    def __init__(self, buff_size):
+    def __init__(self, buff_size) -> None:
         self.buff_size = buff_size
         self.sorted = False
         self.samples = []
@@ -225,7 +225,7 @@ class BiasedStream(Stream):
     :param epsilon:
     """
 
-    def __init__(self, n, epsilon):
+    def __init__(self, n, epsilon) -> None:
         super().__init__(n)
         self.epsilon = epsilon
 
@@ -270,7 +270,7 @@ class TargetedStream(Stream):
     :param targets: List of (quantile, epsilon)
     """
 
-    def __init__(self, n, targets):
+    def __init__(self, n, targets) -> None:
         super().__init__(n)
         self.targets = targets
 
@@ -298,7 +298,7 @@ class Summary:
     :param *args: `Stream` constructor parameters
     """
 
-    def __init__(self, ttl, n, kls, *args):
+    def __init__(self, ttl, n, kls, *args) -> None:
         self.ttl = ttl
         self.slots = deque()
         for _ in range(n + 1):

--- a/core/quantile/monitor.py
+++ b/core/quantile/monitor.py
@@ -18,7 +18,7 @@ Q_SUFFIX_LEN = len(Q_SUFFIX)
 
 
 class Quantile(Summary):
-    def __init__(self, scale=DEFAULT_QUANTILE_SCALE):
+    def __init__(self, scale=DEFAULT_QUANTILE_SCALE) -> None:
         super().__init__(
             config.perfomance.default_quantiles_window,
             1,

--- a/core/ratelimit/base.py
+++ b/core/ratelimit/base.py
@@ -17,7 +17,7 @@ class BaseRateLimit:
     Limit calls to `wait*` methods to `rate` requests per second.
     """
 
-    def __init__(self, rate: float):
+    def __init__(self, rate: float) -> None:
         self.min_delta: int = int(NS / rate)
         self.next: int | None = None
 

--- a/core/reporter/reportengine.py
+++ b/core/reporter/reportengine.py
@@ -46,7 +46,9 @@ class ReportEngine:
     RunParams -> ReportEngine -> load_data -> Band -> Formatter -> DocumentFile
     """
 
-    def __init__(self, report_execution_history: bool = False, report_print_error: bool = False):
+    def __init__(
+        self, report_execution_history: bool = False, report_print_error: bool = False
+    ) -> None:
         self.logger = logger
         self.report_execution_history = report_execution_history
         self.report_print_error = report_print_error

--- a/core/reporter/types.py
+++ b/core/reporter/types.py
@@ -107,7 +107,7 @@ class ReportBand(BaseModel):
                 return c.value in params[c.param]
         return True
 
-    # def __init__(self, **data):
+    # def __init__(self, **data) -> None:
     #     super().__init__(**data)
     #     self.children = self.children or []
     #     for c in self.children:

--- a/core/router/action.py
+++ b/core/router/action.py
@@ -69,7 +69,7 @@ class ActionBase(type):
 class Action(metaclass=ActionBase):
     name: ClassVar[str]
 
-    def __init__(self, cfg: ActionCfg):
+    def __init__(self, cfg: ActionCfg) -> None:
         self.headers: dict[str, bytes] = {h.header: h.value.encode() for h in cfg.headers or []}
 
     @classmethod
@@ -120,7 +120,7 @@ class DumpAction(Action):
 class StreamAction(Action):
     name = "stream"
 
-    def __init__(self, cfg: ActionCfg):
+    def __init__(self, cfg: ActionCfg) -> None:
         super().__init__(cfg)
         self.stream: str = cfg.stream
 
@@ -133,7 +133,7 @@ class StreamAction(Action):
 class NotificationAction(Action):
     name = "notification"
 
-    def __init__(self, cfg: ActionCfg):
+    def __init__(self, cfg: ActionCfg) -> None:
         super().__init__(cfg)
 
     def iter_action(
@@ -153,7 +153,7 @@ class NotificationAction(Action):
 class MetricAction(Action):
     name = "metrics"
 
-    def __init__(self, cfg: ActionCfg):
+    def __init__(self, cfg: ActionCfg) -> None:
         super().__init__(cfg)
         self.stream: str = cfg.stream
         self.mx_metrics_scopes = {}
@@ -209,7 +209,7 @@ class JobAction(Action):
 class MessageAction(Action):
     name = "message"
 
-    def __init__(self, cfg: ActionCfg):
+    def __init__(self, cfg: ActionCfg) -> None:
         super().__init__(cfg)
         self.ng: str | None = cfg.notification_group
         self.rt: int | None = cfg.render_template

--- a/core/router/route.py
+++ b/core/router/route.py
@@ -160,7 +160,9 @@ class Route:
 
     MX_H_VALUE_SPLITTER = MX_H_VALUE_SPLITTER.encode()
 
-    def __init__(self, name: str, r_type: str, order: int, telemetry_sample: int | None = None):
+    def __init__(
+        self, name: str, r_type: str, order: int, telemetry_sample: int | None = None
+    ) -> None:
         self.name = name
         self.type: frozenset[bytes] = (
             frozenset([r_type.encode()])

--- a/core/runner/actions/base.py
+++ b/core/runner/actions/base.py
@@ -66,7 +66,7 @@ class BaseAction(metaclass=ActionMetaclass):
     inputs: dict[str, bool]  # Set by metaclass
     clean: dict[str, Callable[[Any], Any]]  # Set by metaclass
 
-    def __init__(self, env: Environment, logger: Logger):
+    def __init__(self, env: Environment, logger: Logger) -> None:
         self.env = env
         self.logger = logger
 

--- a/core/runner/lock.py
+++ b/core/runner/lock.py
@@ -49,7 +49,7 @@ class LockManager:
 
 
 class LockCtx:
-    def __init__(self, parent: LockManager, names: Iterable[str]):
+    def __init__(self, parent: LockManager, names: Iterable[str]) -> None:
         self._parent = parent
         self._names = list(names)
 

--- a/core/scheduler/error.py
+++ b/core/scheduler/error.py
@@ -12,6 +12,6 @@ class RetryAfter(Exception):
     execution after delay seconds
     """
 
-    def __init__(self, msg, delay):
+    def __init__(self, msg, delay) -> None:
         super().__init__(msg)
         self.delay = delay

--- a/core/scheduler/job.py
+++ b/core/scheduler/job.py
@@ -96,7 +96,7 @@ class Job:
     # List of exceptions to be considered failed jobs
     failed_exceptions = (JobFailed,)
 
-    def __init__(self, scheduler, attrs):
+    def __init__(self, scheduler, attrs) -> None:
         """
         :param scheduler: Scheduler instance
         :param attrs: dict containing record from scheduler's collection

--- a/core/script/base.py
+++ b/core/script/base.py
@@ -1278,7 +1278,7 @@ class ScriptsHub:
     """
 
     class _CallWrapper:
-        def __init__(self, script_class, parent):
+        def __init__(self, script_class, parent) -> None:
             self.parent = parent
             self.script_class = script_class
 
@@ -1293,7 +1293,7 @@ class ScriptsHub:
                 timeout=self.parent.timeout,
             ).run()
 
-    def __init__(self, script):
+    def __init__(self, script) -> None:
         self._script = script
 
     def __getattr__(self, item):

--- a/core/script/caller.py
+++ b/core/script/caller.py
@@ -21,7 +21,7 @@ DEFAULT_IDLE_TIMEOUT = config.script.caller_timeout
 
 
 class ScriptCaller:
-    def __init__(self, obj, name):
+    def __init__(self, obj, name) -> None:
         if "." in name:
             self.name = name.split(".")[-1]
         else:
@@ -47,7 +47,7 @@ class ScriptCaller:
 
 
 class Session:
-    def __init__(self, object_id, idle_timeout=None):
+    def __init__(self, object_id, idle_timeout=None) -> None:
         self._object_id = object_id
         self._idle_timeout = idle_timeout or config.script.caller_timeout
         self._id = str(uuid.uuid4())
@@ -109,7 +109,7 @@ class SessionContext:
         "cv_sessions_smap", default=None
     )
 
-    def __init__(self, object, idle_timeout=None):
+    def __init__(self, object, idle_timeout=None) -> None:
         self._object_id = object.id
         self._idle_timeout = idle_timeout
 

--- a/core/script/cli/base.py
+++ b/core/script/cli/base.py
@@ -19,7 +19,7 @@ from .error import CLIConnectionReset
 class BaseCLI:
     name = "base"
 
-    def __init__(self, script, tos: int | None = None):
+    def __init__(self, script, tos: int | None = None) -> None:
         self.script = script
         self.profile = script.profile
         self.logger = PrefixLoggerAdapter(self.script.logger, self.name)

--- a/core/script/cli/beef.py
+++ b/core/script/cli/beef.py
@@ -15,7 +15,7 @@ from .telnet import TelnetStream
 
 
 class BeefStream(TelnetStream):
-    def __init__(self, cli: CLI):
+    def __init__(self, cli: CLI) -> None:
         super().__init__(cli)
         self.cli = cli
         self.beef = None
@@ -62,7 +62,7 @@ class BeefStream(TelnetStream):
 class BeefCLI(CLI):
     name = "beef_cli"
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.state = "notconnected"
 

--- a/core/script/cli/cli.py
+++ b/core/script/cli/cli.py
@@ -51,7 +51,7 @@ class CLI(BaseCLI):
     class InvalidPagerCommand(Exception):
         pass
 
-    def __init__(self, script, tos=None):
+    def __init__(self, script, tos=None) -> None:
         super().__init__(script, tos)
         self.motd = ""
         self.command = None

--- a/core/script/cli/ssh.py
+++ b/core/script/cli/ssh.py
@@ -36,7 +36,7 @@ class SSHStream(BaseStream):
 
     _key_cache = cachetools.TTLCache(100, ttl=60)
 
-    def __init__(self, cli: CLI):
+    def __init__(self, cli: CLI) -> None:
         super().__init__(cli)
         self.script = cli.script  # @todo: Remove
         self.session = None

--- a/core/script/cli/stream.py
+++ b/core/script/cli/stream.py
@@ -30,7 +30,7 @@ class BaseStream:
     # Terminate connection after N keepalive failures
     KEEP_CNT = 3
 
-    def __init__(self, cli: BaseCLI):
+    def __init__(self, cli: BaseCLI) -> None:
         self._timeout: float | None = None
         self.logger = cli.logger
         self.tos = cli.tos

--- a/core/script/cli/telnet.py
+++ b/core/script/cli/telnet.py
@@ -104,7 +104,7 @@ OPTS = {B_OPT_TTYPE_IS: "TTYPE IS", B_OPT_WS: "WS"}
 class TelnetStream(BaseStream):
     default_port = 23
 
-    def __init__(self, cli: CLI):
+    def __init__(self, cli: CLI) -> None:
         super().__init__(cli)
         self.send_on_connect = cli.profile.telnet_send_on_connect
         self.naws = cli.profile.get_telnet_naws()

--- a/core/script/context.py
+++ b/core/script/context.py
@@ -11,7 +11,7 @@ class ConfigurationContextManager:
     Configuration context manager to use with "with" statement
     """
 
-    def __init__(self, script):
+    def __init__(self, script) -> None:
         self.script = script
 
     def __enter__(self):
@@ -25,7 +25,7 @@ class ConfigurationContextManager:
 
 
 class CacheContextManager:
-    def __init__(self, script):
+    def __init__(self, script) -> None:
         self.script = script
         self.changed = False
 
@@ -44,7 +44,7 @@ class IgnoredExceptionsContextManager:
     Silently ignore specific exceptions
     """
 
-    def __init__(self, iterable):
+    def __init__(self, iterable) -> None:
         self.exceptions = set(iterable)
 
     def __enter__(self):

--- a/core/script/diagnostic.py
+++ b/core/script/diagnostic.py
@@ -23,7 +23,7 @@ class SNMPSuggestsDiagnostic:
     Run diagnostic by config and check status
     """
 
-    def __init__(self, config: DiagnosticConfig, logger=None):
+    def __init__(self, config: DiagnosticConfig, logger=None) -> None:
         self.config = config
         self.logger = logger or logging.getLogger("snmpsuggestsdiagnostic")
 
@@ -89,7 +89,7 @@ class CLISuggestsDiagnostic:
     Run diagnostic by config and check status
     """
 
-    def __init__(self, config: DiagnosticConfig, logger=None):
+    def __init__(self, config: DiagnosticConfig, logger=None) -> None:
         self.config = config
         self.logger = logger or logging.getLogger("clisuggestsdiagnostic")
 

--- a/core/script/http/base.py
+++ b/core/script/http/base.py
@@ -27,7 +27,7 @@ class HTTPError(NOCError):
 class HTTP:
     HTTPError = HTTPError
 
-    def __init__(self, script):
+    def __init__(self, script) -> None:
         self.script = script
         if script:  # For testing purposes
             self.logger = PrefixLoggerAdapter(script.logger, "http")

--- a/core/script/http/middleware/base.py
+++ b/core/script/http/middleware/base.py
@@ -12,7 +12,7 @@ from typing import Any
 class BaseMiddleware:
     name = None
 
-    def __init__(self, http):
+    def __init__(self, http) -> None:
         self.http = http
 
     def process_request(self, url: str, body: Any, headers: dict[str, bytes]):

--- a/core/script/http/middleware/basicauth.py
+++ b/core/script/http/middleware/basicauth.py
@@ -19,7 +19,7 @@ class BasicAuthMiddeware(BaseMiddleware):
 
     name = "basicauth"
 
-    def __init__(self, http, user=None, password=None):
+    def __init__(self, http, user=None, password=None) -> None:
         super().__init__(http)
         self.user = user
         self.password = password

--- a/core/script/http/middleware/digestauth.py
+++ b/core/script/http/middleware/digestauth.py
@@ -24,7 +24,7 @@ class DigestAuthMiddeware(BaseMiddleware):
 
     name = "digestauth"
 
-    def __init__(self, http, eof_mark=None):
+    def __init__(self, http, eof_mark=None) -> None:
         super().__init__(http)
         self.logger = http.logger
         self.eof_mark = eof_mark

--- a/core/script/http/middleware/jsonrequestid.py
+++ b/core/script/http/middleware/jsonrequestid.py
@@ -18,7 +18,7 @@ class JSONRequestIdMiddleware(BaseMiddleware):
 
     name = "jsonrequestid"
 
-    def __init__(self, http, request_id_param="request_id"):
+    def __init__(self, http, request_id_param="request_id") -> None:
         super().__init__(http)
         self.request_id_param = request_id_param
 

--- a/core/script/http/middleware/jsonsession.py
+++ b/core/script/http/middleware/jsonsession.py
@@ -17,7 +17,7 @@ class JSONSessionMiddleware(BaseMiddleware):
 
     name = "jsonsession"
 
-    def __init__(self, http, session_param="session_id"):
+    def __init__(self, http, session_param="session_id") -> None:
         super().__init__(http)
         self.session_param = session_param
 

--- a/core/script/http/middleware/urlrequestid.py
+++ b/core/script/http/middleware/urlrequestid.py
@@ -18,7 +18,7 @@ class URLRequestIdMiddleware(BaseMiddleware):
 
     name = "urlrequestid"
 
-    def __init__(self, http, request_id_param="request_id"):
+    def __init__(self, http, request_id_param="request_id") -> None:
         super().__init__(http)
         self.request_id_param = request_id_param
 

--- a/core/script/http/middleware/urlsession.py
+++ b/core/script/http/middleware/urlsession.py
@@ -17,7 +17,7 @@ class URLSessionMiddleware(BaseMiddleware):
 
     name = "urlsession"
 
-    def __init__(self, http, session_param="session_id"):
+    def __init__(self, http, session_param="session_id") -> None:
         super().__init__(http)
         self.session_param = session_param
 

--- a/core/script/mml/base.py
+++ b/core/script/mml/base.py
@@ -25,7 +25,7 @@ class MMLBase(BaseCLI):
     MATCH_TAIL = 256
     SYNTAX_ERROR_CODE = b"+@@@NOC:SYNTAXERROR@@@+"
 
-    def __init__(self, script, tos=None):
+    def __init__(self, script, tos=None) -> None:
         super().__init__(script, tos)
         self.command = None
         self.buffer = ""

--- a/core/script/oidrules/capindex.py
+++ b/core/script/oidrules/capindex.py
@@ -18,7 +18,7 @@ class CapabilityIndexRule(OIDRule):
 
     name = "capindex"
 
-    def __init__(self, oid, type=None, scale=1, units="1", start=0, capability=None):
+    def __init__(self, oid, type=None, scale=1, units="1", start=0, capability=None) -> None:
         super().__init__(oid, type=type, scale=scale, units=units)
         self.start = start
         self.capability = capability

--- a/core/script/oidrules/caps.py
+++ b/core/script/oidrules/caps.py
@@ -18,7 +18,7 @@ class CapabilityRule:
 
     name = "caps"
 
-    def __init__(self, oids):
+    def __init__(self, oids) -> None:
         self.oids = oids
 
     def iter_oids(self, script, metric):

--- a/core/script/oidrules/hires.py
+++ b/core/script/oidrules/hires.py
@@ -17,7 +17,7 @@ class HiresRule:
 
     name = "hires"
 
-    def __init__(self, hires, normal):
+    def __init__(self, hires, normal) -> None:
         self.hires = hires
         self.normal = normal
 

--- a/core/script/oidrules/match.py
+++ b/core/script/oidrules/match.py
@@ -17,7 +17,7 @@ class MatcherRule:
 
     name = "match"
 
-    def __init__(self, oids, matchers):
+    def __init__(self, oids, matchers) -> None:
         self.oids = oids
         self.matchers = matchers
 

--- a/core/script/oidrules/oid.py
+++ b/core/script/oidrules/oid.py
@@ -26,7 +26,7 @@ class OIDRule:
 
     _scale_locals = {}
 
-    def __init__(self, oid, type=None, scale=1, units=None, labels=None):
+    def __init__(self, oid, type=None, scale=1, units=None, labels=None) -> None:
         self.oid = oid
         self.is_complex = not isinstance(oid, str)
         self.type = type or self.default_type

--- a/core/script/oidrules/oids.py
+++ b/core/script/oidrules/oids.py
@@ -16,7 +16,7 @@ class OIDsRule:
 
     name = "oids"
 
-    def __init__(self, oids):
+    def __init__(self, oids) -> None:
         self.oids = oids
 
     def iter_oids(self, script, metric):

--- a/core/script/rtsp/base.py
+++ b/core/script/rtsp/base.py
@@ -35,7 +35,7 @@ class RTSPBase(BaseCLI):
     MATCH_TAIL = 256
     SYNTAX_ERROR_CODE = b"+@@@NOC:SYNTAXERROR@@@+"
 
-    def __init__(self, script, tos=None):
+    def __init__(self, script, tos=None) -> None:
         super().__init__(script, tos)
         self.path = None
         self.cseq = 1
@@ -217,7 +217,7 @@ class DigestAuth:
 
     name = "digestauth"
 
-    def __init__(self, user=None, password=None):
+    def __init__(self, user=None, password=None) -> None:
         self.user = user
         self.password = password
         self.last_nonce = None

--- a/core/script/snmp/base.py
+++ b/core/script/snmp/base.py
@@ -69,7 +69,7 @@ class SNMP:
 
     SNMPError = SNMPError
 
-    def __init__(self, script, rate: float | None = None):
+    def __init__(self, script, rate: float | None = None) -> None:
         self._script = weakref.ref(script)
         self.logger = PrefixLoggerAdapter(script.logger, self.name)
         self.timeouts_limit = 0

--- a/core/script/snmp/beef.py
+++ b/core/script/snmp/beef.py
@@ -30,7 +30,7 @@ class BeefSNMP(SNMP):
 
 
 class BeefSNMPSocket:
-    def __init__(self, snmp):
+    def __init__(self, snmp) -> None:
         self.script = snmp.script
         self.logger = snmp.logger
         if not self.script.request_beef():

--- a/core/service/error.py
+++ b/core/service/error.py
@@ -35,6 +35,6 @@ class RPCNoService(RPCError):
 class RPCRemoteError(RPCError):
     default_code = ERR_RPC_REMOTE_ERROR
 
-    def __init__(self, msg, remote_code=None):
+    def __init__(self, msg, remote_code=None) -> None:
         super().__init__(msg)
         self.remote_code = remote_code

--- a/core/service/jsonrpcapi.py
+++ b/core/service/jsonrpcapi.py
@@ -46,7 +46,7 @@ class JSONRPCAPI:
     # Indicates whether the REMOTE-HTTP header is required in the request
     auth_required = False
 
-    def __init__(self, router: APIRouter):
+    def __init__(self, router: APIRouter) -> None:
         self.service = get_service()
         self.logger = self.service.logger
         self.current_user: User | None = None

--- a/core/service/middleware/span.py
+++ b/core/service/middleware/span.py
@@ -14,7 +14,7 @@ from noc.core.span import Span
 
 
 class SpanMiddleware:
-    def __init__(self, app, service_name="service"):
+    def __init__(self, app, service_name="service") -> None:
         self.app = app
         self.service_name = service_name
 

--- a/core/service/rpc.py
+++ b/core/service/rpc.py
@@ -46,7 +46,7 @@ class RPCProxy:
 
     RPCError = RPCError
 
-    def __init__(self, service, service_name, sync=False, hints=None):
+    def __init__(self, service, service_name, sync=False, hints=None) -> None:
         self._logger = PrefixLoggerAdapter(logger, service_name)
         self._service = service
         self._service_name = service_name

--- a/core/snmp/ber.py
+++ b/core/snmp/ber.py
@@ -34,7 +34,7 @@ def did(tag_class: int, is_constructed: int, tag_id: int) -> int:
 
 
 class BERDecoder:
-    def __init__(self, display_hints=None, include_raw=False):
+    def __init__(self, display_hints=None, include_raw=False) -> None:
         self.last_oid: str | None = None
         self.oid_msg: bytes | None = None
         self.raw_pdu: bytes | None = None

--- a/core/snmp/error.py
+++ b/core/snmp/error.py
@@ -94,7 +94,7 @@ class SNMPErrorCode(enum.Enum):
 
 
 class SNMPError(Exception):
-    def __init__(self, code, oid=None):
+    def __init__(self, code, oid=None) -> None:
         super().__init__()
         self.code = code
         self.oid = oid

--- a/core/techdomain/mapper/base.py
+++ b/core/techdomain/mapper/base.py
@@ -91,7 +91,7 @@ class BaseMapper:
     SELECTABLE_CLASS = "ch-selectable"
     ALARM_SYMBOL = "\U0001f525"  # Fire
 
-    def __init__(self, channel: Channel):
+    def __init__(self, channel: Channel) -> None:
         self.logger = PrefixLoggerAdapter(logging.getLogger("tracer"), self.name)
         self.channel = channel
         self.input: str | None = None

--- a/core/timepattern.py
+++ b/core/timepattern.py
@@ -105,7 +105,7 @@ class TimePattern:
     True
     """
 
-    def __init__(self, pattern):
+    def __init__(self, pattern) -> None:
         self.code = compile(self.compile_to_python(pattern), "<string>", "eval")
 
     def match(self, d):
@@ -161,7 +161,7 @@ class TimePatternList:
     Enclosure for a list of time patterns
     """
 
-    def __init__(self, patterns):
+    def __init__(self, patterns) -> None:
         self.patterns = patterns
 
     def match(self, d):

--- a/core/topology/base.py
+++ b/core/topology/base.py
@@ -56,7 +56,7 @@ class TopologyBase:
     DEFAULT_GLYPH = 0xF22C
     CLOUD_GLYPH = 0xF004
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         # Hints
         self.node_hints: dict[str, Any] | None = kwargs.get("node_hints") or {}
         self.link_hints: dict[str, Any] | None = kwargs.get("link_hints") or {}

--- a/core/topology/goal/level.py
+++ b/core/topology/goal/level.py
@@ -22,7 +22,7 @@ class ManagedObjectLevelGoal(BaseGoal):
     SAME_LEVEL_COST = 10
     BACKWARDS_COST = 100
 
-    def __init__(self, level):
+    def __init__(self, level) -> None:
         super().__init__()
         self.level = level
 

--- a/core/topology/layout/base.py
+++ b/core/topology/layout/base.py
@@ -9,7 +9,7 @@
 class LayoutBase:
     DEFAULT_LEVEL = 10
 
-    def __init__(self, topology):
+    def __init__(self, topology) -> None:
         self.topology = topology
 
     def get_layout(self):

--- a/core/topology/map/configured.py
+++ b/core/topology/map/configured.py
@@ -32,7 +32,7 @@ class ConfiguredTopology(TopologyBase):
     NORMALIZE_POSITION = False
     ISOLATED_WIDTH = 600
 
-    def __init__(self, gen_id, **settings):
+    def __init__(self, gen_id, **settings) -> None:
         self.cfgmap: ConfiguredMap = ConfiguredMap.get_by_id(gen_id)
         super().__init__(**settings)
 

--- a/core/topology/map/l2domain.py
+++ b/core/topology/map/l2domain.py
@@ -30,7 +30,7 @@ class L2DomainTopology(TopologyBase):
     name = "l2domain"
     header = _("L2 Domains")
 
-    def __init__(self, l2domain, **settings):
+    def __init__(self, l2domain, **settings) -> None:
         self.l2domain = L2Domain.get_by_id(l2domain)
         self.logger = PrefixLoggerAdapter(logger, self.l2domain.name)
         super().__init__(**settings)

--- a/core/topology/map/objectcontainer.py
+++ b/core/topology/map/objectcontainer.py
@@ -35,7 +35,7 @@ class ObjectContainerTopology(TopologyBase):
     PARAMS = {"container"}
     CONTAINER_MODELS = None
 
-    def __init__(self, container, **settings):
+    def __init__(self, container, **settings) -> None:
         self.container = Object.get_by_id(container)
         self.logger = PrefixLoggerAdapter(logger, self.container.name)
         super().__init__(**settings)

--- a/core/topology/map/objectgroup.py
+++ b/core/topology/map/objectgroup.py
@@ -32,7 +32,7 @@ class ObjectGroupTopology(TopologyBase):
 
     PARAMS = {"resource_group"}
 
-    def __init__(self, resource_group, **settings):
+    def __init__(self, resource_group, **settings) -> None:
         self.rg = ResourceGroup.get_by_id(resource_group)
         self.logger = PrefixLoggerAdapter(logger, self.rg.name)
         super().__init__(**settings)

--- a/core/topology/map/objectlevelneighbor.py
+++ b/core/topology/map/objectlevelneighbor.py
@@ -33,7 +33,7 @@ class ObjectLevelNeighborTopology(TopologyBase):
 
     PARAMS = {"mo_id"}
 
-    def __init__(self, mo_id, **settings):
+    def __init__(self, mo_id, **settings) -> None:
         self.mo = ManagedObject.get_by_id(mo_id)
         self.logger = PrefixLoggerAdapter(logger, self.mo.name)
         super().__init__(**settings)

--- a/core/topology/map/segment.py
+++ b/core/topology/map/segment.py
@@ -37,7 +37,7 @@ class SegmentTopology(TopologyBase):
     CAPS: set[str] = {"Network | STP"}
     PARAMS = {"segment"}
 
-    def __init__(self, segment, **settings):
+    def __init__(self, segment, **settings) -> None:
         self.segment = (
             segment if isinstance(segment, NetworkSegment) else NetworkSegment.get_by_id(segment)
         )

--- a/core/tt/base.py
+++ b/core/tt/base.py
@@ -51,7 +51,7 @@ class BaseTTSystem:
     processed_items = False
     actions: list[TTAction] = []
 
-    def __init__(self, name: str, connection: str):
+    def __init__(self, name: str, connection: str) -> None:
         self.connection = connection
         self.name = name
         self.logger = logging.getLogger(f"tt.{self.name}")

--- a/core/version.py
+++ b/core/version.py
@@ -22,7 +22,7 @@ if os.name == "nt":
 
 
 class cachedproperty:
-    def __init__(self, f):
+    def __init__(self, f) -> None:
         self.f = f
         self.n = "_%s" % f.__name__
         self.__doc__ = f.__doc__

--- a/docs/tools/collection-to-md.py
+++ b/docs/tools/collection-to-md.py
@@ -271,7 +271,7 @@ GENDER_DESC = {
 
 
 class FileWriter:
-    def __init__(self, root: str):
+    def __init__(self, root: str) -> None:
         self.root = root
         self.new_files = 0
         self.changed_files = 0

--- a/fm/models/error.py
+++ b/fm/models/error.py
@@ -7,7 +7,7 @@
 
 
 class MIBRequiredException(Exception):
-    def __init__(self, mib, requires_mib):
+    def __init__(self, mib, requires_mib) -> None:
         super().__init__()
         self.mib = mib
         self.requires_mib = requires_mib
@@ -17,7 +17,7 @@ class MIBRequiredException(Exception):
 
 
 class MIBNotFoundException(Exception):
-    def __init__(self, mib):
+    def __init__(self, mib) -> None:
         super().__init__()
         self.mib = mib
 
@@ -30,7 +30,7 @@ class InvalidTypedef(Exception):
 
 
 class OIDCollision(Exception):
-    def __init__(self, oid, name1, name2, msg=None):
+    def __init__(self, oid, name1, name2, msg=None) -> None:
         super().__init__()
         self.oid = oid
         self.name1 = name1

--- a/gis/overlays/base.py
+++ b/gis/overlays/base.py
@@ -9,7 +9,7 @@
 
 
 class OverlayHandler:
-    def __init__(self, **config):
+    def __init__(self, **config) -> None:
         """
         Overlay configuration will be passed
         :param config:

--- a/gis/overlays/points/__init__.py
+++ b/gis/overlays/points/__init__.py
@@ -21,7 +21,7 @@ class PointsOverlay(OverlayHandler):
         text: text label property name
     """
 
-    def __init__(self, collection, position, text):
+    def __init__(self, collection, position, text) -> None:
         super().__init__()
         self.collection = collection
         self.position = position

--- a/inv/util/pop_links.py
+++ b/inv/util/pop_links.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 class LinkedPoP:
-    def __init__(self, pop_id):
+    def __init__(self, pop_id) -> None:
         self.pop = Object.get_by_id(pop_id)
 
     def iter_db_links(self, level):

--- a/main/models/reportsubscription.py
+++ b/main/models/reportsubscription.py
@@ -53,7 +53,7 @@ class ReportSubscription(Document):
     JCLS = "noc.main.models.reportsubscription.ReportJob"
 
     class RequestStub:
-        def __init__(self, user):
+        def __init__(self, user) -> None:
             self.user = user
 
     @classmethod

--- a/main/refbooks/refbooks/__init__.py
+++ b/main/refbooks/refbooks/__init__.py
@@ -98,7 +98,7 @@ class Field:
     RefBook fields
     """
 
-    def __init__(self, name, description=None, is_required=True, search_method=None):
+    def __init__(self, name, description=None, is_required=True, search_method=None) -> None:
         self.name = name
         self.description = description
         self.is_required = is_required

--- a/main/templatetags/noctags.py
+++ b/main/templatetags/noctags.py
@@ -102,7 +102,7 @@ rx_table = re.compile(r"<table[^>]*>", re.MULTILINE | re.DOTALL)
 
 
 class NOCTableNode(template.Node):
-    def __init__(self, nodelist):
+    def __init__(self, nodelist) -> None:
         super().__init__()
         self.nodelist = nodelist
 

--- a/main/templatetags/python.py
+++ b/main/templatetags/python.py
@@ -58,7 +58,7 @@ def do_python(parser, token):
 # Renderers
 #
 class VarNode(template.Node):
-    def __init__(self, name, vartype):
+    def __init__(self, name, vartype) -> None:
         self.name = name
         self.vartype = vartype
 
@@ -67,7 +67,7 @@ class VarNode(template.Node):
 
 
 class PythonNode(template.Node):
-    def __init__(self, nodelist):
+    def __init__(self, nodelist) -> None:
         py_code = nodelist.render({}).replace("\r", "")
         self.code = compile(py_code, "string", "exec")
 

--- a/main/templatetags/tags.py
+++ b/main/templatetags/tags.py
@@ -12,7 +12,7 @@ register = template.Library()
 
 
 class TagsNode(template.Node):
-    def __init__(self, object):
+    def __init__(self, object) -> None:
         self.object = template.Variable(object)
 
     def render(self, context):

--- a/sa/interfaces/base.py
+++ b/sa/interfaces/base.py
@@ -26,7 +26,7 @@ class NoneParameter(Parameter):
     Checks value is None
     """
 
-    def __init__(self, required=True):
+    def __init__(self, required=True) -> None:
         super().__init__(required=required)
 
     def clean(self, value):
@@ -40,7 +40,9 @@ class StringParameter(Parameter):
     Check value is string
     """
 
-    def __init__(self, required=True, default=None, choices=None, aliases=None, strip_value=False):
+    def __init__(
+        self, required=True, default=None, choices=None, aliases=None, strip_value=False
+    ) -> None:
         self.choices = set(choices) if choices else None
         self.aliases = aliases
         self.strip_value = strip_value
@@ -85,7 +87,7 @@ class REStringParameter(StringParameter):
     Check value is string matching regular expression
     """
 
-    def __init__(self, regexp, required=True, default=None):
+    def __init__(self, regexp, required=True, default=None) -> None:
         self.rx = re.compile(regexp)  # Compile before calling the constructor
         super().__init__(required=required, default=default)
 
@@ -149,7 +151,7 @@ class IntParameter(Parameter):
     Check value is integer
     """
 
-    def __init__(self, required=True, default=None, min_value=None, max_value=None):
+    def __init__(self, required=True, default=None, min_value=None, max_value=None) -> None:
         self.min_value = min_value
         self.max_value = max_value
         super().__init__(required=required, default=default)
@@ -173,7 +175,7 @@ class FloatParameter(Parameter):
     Check value is float
     """
 
-    def __init__(self, required=True, default=None, min_value=None, max_value=None):
+    def __init__(self, required=True, default=None, min_value=None, max_value=None) -> None:
         self.min_value = min_value
         self.max_value = max_value
         super().__init__(required=required, default=default)
@@ -218,7 +220,7 @@ class InstanceOfParameter(Parameter):
     Check value is an instance of class
     """
 
-    def __init__(self, cls, required=True, default=None):
+    def __init__(self, cls, required=True, default=None) -> None:
         super().__init__(required=required, default=default)
         self.cls = cls
         if isinstance(cls, str):
@@ -251,7 +253,7 @@ class SubclassOfParameter(Parameter):
     Check value is subclass of given class
     """
 
-    def __init__(self, cls, required=True, default=None):
+    def __init__(self, cls, required=True, default=None) -> None:
         super().__init__(required=required, default=default)
         self.cls = cls
         if isinstance(cls, str):
@@ -291,7 +293,7 @@ class ListOfParameter(ListParameter):
     Check value is a list of given parameter type
     """
 
-    def __init__(self, element, required=True, default=None, convert=False):
+    def __init__(self, element, required=True, default=None, convert=False) -> None:
         self.element = element
         self.is_list = isinstance(element, (list, tuple))
         self.convert = convert
@@ -335,7 +337,9 @@ class StringListParameter(ListOfParameter):
     Check value is list of strings
     """
 
-    def __init__(self, required=True, default=None, convert=False, choices=None, strict=False):
+    def __init__(
+        self, required=True, default=None, convert=False, choices=None, strict=False
+    ) -> None:
         self.strict = strict
         super().__init__(
             element=StringParameter(choices=choices),
@@ -419,7 +423,7 @@ class DictParameter(Parameter):
     Check value is a dict
     """
 
-    def __init__(self, required=True, default=None, attrs=None, truncate=False):
+    def __init__(self, required=True, default=None, attrs=None, truncate=False) -> None:
         super().__init__(required=required, default=default)
         self.attrs = attrs or {}
         self.truncate = truncate
@@ -503,7 +507,7 @@ class DictListParameter(ListOfParameter):
     Check value is a list of dicts of given structure
     """
 
-    def __init__(self, required=True, default=None, attrs=None, convert=False):
+    def __init__(self, required=True, default=None, attrs=None, convert=False) -> None:
         super().__init__(
             element=DictParameter(attrs=attrs), required=required, default=default, convert=convert
         )
@@ -574,7 +578,7 @@ class IPv4Parameter(StringParameter):
     Check value is IPv4 address
     """
 
-    def __init__(self, required=True, default=None, accept_bin=True):
+    def __init__(self, required=True, default=None, accept_bin=True) -> None:
         self.accept_bin = accept_bin
         super().__init__(required=required, default=default)
 
@@ -704,7 +708,7 @@ class VLANIDParameter(IntParameter):
     Check value is VLAN ID
     """
 
-    def __init__(self, required=True, default=None):
+    def __init__(self, required=True, default=None) -> None:
         super().__init__(required=required, default=default, min_value=1, max_value=4095)
 
 
@@ -713,7 +717,7 @@ class VLANStackParameter(ListOfParameter):
     Check value is a stack of of VLAN ID
     """
 
-    def __init__(self, required=True, default=None):
+    def __init__(self, required=True, default=None) -> None:
         super().__init__(element=IntParameter(), required=required, default=default, convert=True)
 
     def clean(self, value):
@@ -728,7 +732,7 @@ class VLANStackParameter(ListOfParameter):
 class IntEnumParameter(IntParameter):
     """Check Parameter on Enum class"""
 
-    def __init__(self, enum, required=True, default=None):
+    def __init__(self, enum, required=True, default=None) -> None:
         self.enum = enum
         super().__init__(required=required, default=default)
 
@@ -744,7 +748,7 @@ class VLANIDListParameter(ListOfParameter):
     Check value is a list of arbitrary vlans
     """
 
-    def __init__(self, required=True, default=None):
+    def __init__(self, required=True, default=None) -> None:
         super().__init__(element=VLANIDParameter(), required=required, default=default)
 
 
@@ -768,7 +772,7 @@ class MACAddressParameter(StringParameter):
     Check value is MAC address
     """
 
-    def __init__(self, required=True, default=None, accept_bin=True):
+    def __init__(self, required=True, default=None, accept_bin=True) -> None:
         self.accept_bin = accept_bin
         super().__init__(required=required, default=default)
 
@@ -888,7 +892,7 @@ class RDParameter(Parameter):
 
 
 class ObjectIdParameter(REStringParameter):
-    def __init__(self, required=True, default=None):
+    def __init__(self, required=True, default=None) -> None:
         super().__init__("^[0-9a-f]{24}$", required=required, default=default)
 
 
@@ -932,7 +936,7 @@ class ModelParameter(Parameter):
     Model reference parameter
     """
 
-    def __init__(self, model, required=True):
+    def __init__(self, model, required=True) -> None:
         super().__init__(required=required)
         self.model = model
 
@@ -960,7 +964,7 @@ class DocumentParameter(Parameter):
     Document reference parameter
     """
 
-    def __init__(self, document, required=True):
+    def __init__(self, document, required=True) -> None:
         super().__init__(required=required)
         self.document = document
         self.has_get_by_id = bool(getattr(self.document, "get_by_id", None))
@@ -981,7 +985,7 @@ class DocumentParameter(Parameter):
 
 
 class EmbeddedDocumentParameter(Parameter):
-    def __init__(self, document, required=True):
+    def __init__(self, document, required=True) -> None:
         super().__init__(required=required)
         self.document = document
 
@@ -1047,7 +1051,7 @@ class ColorParameter(Parameter):
 class ASNParameter(IntParameter):
     """Check Value is ASN Number"""
 
-    def __init__(self, required=True, default=None):
+    def __init__(self, required=True, default=None) -> None:
         super().__init__(required=required, default=default, min_value=1, max_value=4_294_967_295)
 
     def clean(self, value):

--- a/sa/models/managedobject.py
+++ b/sa/models/managedobject.py
@@ -3558,7 +3558,7 @@ class ManagedObjectWatchers(NOCModel):
 
 # object.scripts. ...
 class ScriptsProxy:
-    def __init__(self, obj, caller=None):
+    def __init__(self, obj, caller=None) -> None:
         self._object = obj
         self._cache = {}
         self._caller = caller or ScriptCaller
@@ -3589,7 +3589,7 @@ class ScriptsProxy:
 
 class ActionsProxy:
     class CallWrapper:
-        def __init__(self, obj, name, action):
+        def __init__(self, obj, name, action) -> None:
             self.name = name
             self.object = obj
             self.action = action
@@ -3597,7 +3597,7 @@ class ActionsProxy:
         def __call__(self, **kwargs):
             return self.action.execute(self.object, **kwargs)
 
-    def __init__(self, obj):
+    def __init__(self, obj) -> None:
         self._object = obj
         self._cache = {}
 
@@ -3613,7 +3613,7 @@ class ActionsProxy:
 
 
 class MatchersProxy:
-    def __init__(self, obj):
+    def __init__(self, obj) -> None:
         self._object = obj
         self._data = None
 
@@ -3651,7 +3651,7 @@ class InteractionHub:
     If interaction is supported - return enabled/disabled
     """
 
-    def __init__(self, obj):
+    def __init__(self, obj) -> None:
         self.logger = logging.getLogger(__name__)
         self.__supported_interactions: set[Interaction] = self.load_supported_interactions()
         self.__state: State = obj.state or obj.object_profile.workflow.get_default_state()

--- a/sa/profiles/DCN/DCWL/profile.py
+++ b/sa/profiles/DCN/DCWL/profile.py
@@ -24,7 +24,7 @@ class Profile(BaseProfile):
     class shell:
         """Switch context manager to use with "with" statement"""
 
-        def __init__(self, script):
+        def __init__(self, script) -> None:
             self.script = script
             self.on_session = False
 

--- a/sa/profiles/Dahua/DH/middleware/dahuaauth.py
+++ b/sa/profiles/Dahua/DH/middleware/dahuaauth.py
@@ -23,7 +23,7 @@ class DahuaAuthMiddeware(BaseMiddleware):
 
     name = "dahuaauth"
 
-    def __init__(self, http):
+    def __init__(self, http) -> None:
         super().__init__(http)
         self.user = self.http.script.credentials.get("user")
         self.password = self.http.script.credentials.get("password")

--- a/sa/profiles/Eltex/LTE/profile.py
+++ b/sa/profiles/Eltex/LTE/profile.py
@@ -29,7 +29,7 @@ class Profile(BaseProfile):
     class switch:
         """Switch context manager to use with "with" statement"""
 
-        def __init__(self, script):
+        def __init__(self, script) -> None:
             self.script = script
 
         def __enter__(self):

--- a/sa/profiles/Eltex/LTP/profile.py
+++ b/sa/profiles/Eltex/LTP/profile.py
@@ -38,7 +38,7 @@ class Profile(BaseProfile):
     class switch:
         """Switch context manager to use with "with" statement"""
 
-        def __init__(self, script):
+        def __init__(self, script) -> None:
             self.script = script
 
         def __enter__(self):

--- a/sa/profiles/Eltex/LTP16N/profile.py
+++ b/sa/profiles/Eltex/LTP16N/profile.py
@@ -62,7 +62,7 @@ class Profile(BaseProfile):
     class switch:
         """Switch context manager to use with "with" statement"""
 
-        def __init__(self, script):
+        def __init__(self, script) -> None:
             self.script = script
 
         def __enter__(self):

--- a/sa/profiles/Eltex/PON/profile.py
+++ b/sa/profiles/Eltex/PON/profile.py
@@ -28,7 +28,7 @@ class Profile(BaseProfile):
     class switch:
         """Switch context manager to use with "with" statement"""
 
-        def __init__(self, script):
+        def __init__(self, script) -> None:
             self.script = script
 
         def __enter__(self):

--- a/sa/profiles/Generic/get_metrics.py
+++ b/sa/profiles/Generic/get_metrics.py
@@ -89,7 +89,7 @@ class ProfileMetricConfig:
 class BatchConfig:
     __slots__ = ("id", "labels", "metric", "scale", "service", "type", "units")
 
-    def __init__(self, id, metric, labels, type, scale, units, service=None):
+    def __init__(self, id, metric, labels, type, scale, units, service=None) -> None:
         self.id: int = id
         self.metric: str = metric
         self.labels: list[str] = labels
@@ -304,7 +304,7 @@ class Script(BaseScript, metaclass=MetricScriptBase):
         OIDsRule,
     ]
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.metrics = []
         self.ts: int | None = None

--- a/sa/profiles/Huawei/MA5600T/profile.py
+++ b/sa/profiles/Huawei/MA5600T/profile.py
@@ -265,7 +265,7 @@ class Profile(BaseProfile):
     class diagnose:
         """Switch context manager to use with "with" statement"""
 
-        def __init__(self, script):
+        def __init__(self, script) -> None:
             self.script = script
 
         def __enter__(self):

--- a/sa/profiles/Rotek/RTBS/profile.py
+++ b/sa/profiles/Rotek/RTBS/profile.py
@@ -35,7 +35,7 @@ class Profile(BaseProfile):
     class shell:
         """Switch context manager to use with "with" statement"""
 
-        def __init__(self, script):
+        def __init__(self, script) -> None:
             self.script = script
 
         def __enter__(self):

--- a/sa/profiles/Rotek/RTBSv1/profile.py
+++ b/sa/profiles/Rotek/RTBSv1/profile.py
@@ -51,7 +51,7 @@ class Profile(BaseProfile):
     class shell:
         """Switch context manager to use with "with" statement"""
 
-        def __init__(self, script):
+        def __init__(self, script) -> None:
             self.script = script
 
         def __enter__(self):

--- a/sa/profiles/SKS/SKS/profile.py
+++ b/sa/profiles/SKS/SKS/profile.py
@@ -100,7 +100,7 @@ class Profile(BaseProfile):
     class e1:
         """E1 context manager to use with "with" statement"""
 
-        def __init__(self, script):
+        def __init__(self, script) -> None:
             self.script = script
 
         def __enter__(self):

--- a/sa/profiles/VMWare/vim.py
+++ b/sa/profiles/VMWare/vim.py
@@ -25,7 +25,7 @@ class VIMError(NOCError):
 class VIM:
     VIMError = VIMError
 
-    def __init__(self, script):
+    def __init__(self, script) -> None:
         self.script = script
         if script:  # For testing purposes
             self.logger = PrefixLoggerAdapter(script.logger, "vim")

--- a/sa/profiles/Zyxel/ZyNOS/profile.py
+++ b/sa/profiles/Zyxel/ZyNOS/profile.py
@@ -64,7 +64,7 @@ class Profile(BaseProfile):
 class ZyNOSContextManager:
     """zynos mode context manager to use with "with" statement"""
 
-    def __init__(self, script):
+    def __init__(self, script) -> None:
         self.script = script
         self.profile = script.profile
 

--- a/scripts/check-labels.py
+++ b/scripts/check-labels.py
@@ -29,7 +29,7 @@ class FatalError(Exception):
 
 
 class TestCase:
-    def __init__(self, name=None, path=None, fatal=False, ref=None):
+    def __init__(self, name=None, path=None, fatal=False, ref=None) -> None:
         self.name = name
         self.path = path
         self.fatal = fatal
@@ -81,7 +81,7 @@ class TestSuite:
     KIND_LABELS = ["kind::feature", "kind::improvement", "kind::bug", "kind::cleanup"]
     BACKPORT = "backport"
 
-    def __init__(self, files, verbose=False):
+    def __init__(self, files, verbose=False) -> None:
         self.files = files
         self.tests = []
         self.start = None

--- a/scripts/deploy/install-packages
+++ b/scripts/deploy/install-packages
@@ -13,16 +13,17 @@ import tempfile
 import json
 import shutil
 from urllib.parse import urlparse, urlunparse
+
 # NOC modules
 from noc.core.fileutils import urlopen
 from noc.config import config
 
 
-class NPkg(object):
+class NPkg:
     VAR = config.path.npkg_root
     CDN = config.path.cdn_url
 
-    def __init__(self, config, verbose=False):
+    def __init__(self, config, verbose=False) -> None:
         self.config = config
         self.url = None
         self.required_versions = None
@@ -86,11 +87,7 @@ class NPkg(object):
             tf.flush()
             f.close()
             # Process archive
-            manifest = {
-                "name": pkg,
-                "version": version,
-                "files": []
-            }
+            manifest = {"name": pkg, "version": version, "files": []}
             tar = tarfile.open(tf.name, "r:bz2")
             for mi in tar.getmembers():
                 if mi.name.startswith("/") or ".." in mi.name:
@@ -124,7 +121,10 @@ class NPkg(object):
         for pkg in self.required_versions:
             if pkg in self.installed_versions:
                 if self.installed_versions[pkg] != self.required_versions[pkg]:
-                    self.log("Installed version mismatch: %s != %s. Uninstalling" % (self.installed_versions[pkg], self.required_versions[pkg]))
+                    self.log(
+                        "Installed version mismatch: %s != %s. Uninstalling"
+                        % (self.installed_versions[pkg], self.required_versions[pkg])
+                    )
                     self.uninstall(pkg)
                 else:
                     self.log("Already installed. Skipping.")

--- a/services/card/base.py
+++ b/services/card/base.py
@@ -35,7 +35,7 @@ class BaseAPI:
     hash = None
     PREFIX = os.getcwd()
 
-    def __init__(self, router: APIRouter):
+    def __init__(self, router: APIRouter) -> None:
         self.service = get_service()
         self.logger = self.service.logger
         self.router = router

--- a/services/card/cards/base.py
+++ b/services/card/cards/base.py
@@ -45,7 +45,7 @@ class BaseCard:
     class NotFoundError(Exception):
         pass
 
-    def __init__(self, handler, id):
+    def __init__(self, handler, id) -> None:
         self.handler = handler
         self.id = id
         self.object = self.dereference(id)

--- a/services/card/paths/card.py
+++ b/services/card/paths/card.py
@@ -35,7 +35,7 @@ MIN_SEARCH = 2
 
 
 class HandlerStub:
-    def __init__(self, user, arguments):
+    def __init__(self, user, arguments) -> None:
         self.user: "User" = user
         self.arguments = {}
         for key in arguments:
@@ -70,7 +70,7 @@ class CardAPI(BaseAPI):
 
     _user_cache = cachetools.TTLCache(maxsize=1000, ttl=60)
 
-    def __init__(self, router: APIRouter):
+    def __init__(self, router: APIRouter) -> None:
         if not self.CARD_TEMPLATE:
             with open(self.CARD_TEMPLATE_PATH) as f:
                 self.CARD_TEMPLATE = Template(f.read())

--- a/services/chwriter/channel.py
+++ b/services/chwriter/channel.py
@@ -19,7 +19,7 @@ from noc.core.msgstream.message import Message
 
 
 class Channel:
-    def __init__(self, service, table: str):
+    def __init__(self, service, table: str) -> None:
         self.service = service
         self.table = table
         self.stream = f"ch.{table}"

--- a/services/classifier/actionset.py
+++ b/services/classifier/actionset.py
@@ -60,7 +60,7 @@ class Action:
 
 
 class ActionSet:
-    def __init__(self, logger=None):
+    def __init__(self, logger=None) -> None:
         # EventClass
         # Abduct Detector
         self.logger = logger or action_logger

--- a/services/classifier/cloningrule.py
+++ b/services/classifier/cloningrule.py
@@ -14,14 +14,14 @@ from noc.services.classifier.exception import InvalidPatternException
 
 class CloningRule:
     class Pattern:
-        def __init__(self, key_re, value_re):
+        def __init__(self, key_re, value_re) -> None:
             self.key_re = key_re
             self.value_re = value_re
 
         def __str__(self):
             return "%s : %s" % (self.key_re, self.value_re)
 
-    def __init__(self, rule):
+    def __init__(self, rule) -> None:
         self.re_mode = rule.re != r"^.*$"  # Search by "re"
         self.name = rule.name
         try:

--- a/services/classifier/rulelookup.py
+++ b/services/classifier/rulelookup.py
@@ -10,7 +10,7 @@ import operator
 
 
 class RuleLookup:
-    def __init__(self, rules):
+    def __init__(self, rules) -> None:
         self.rules = rules
 
     def lookup_rules(self, msg, vars):

--- a/services/classifier/trigger.py
+++ b/services/classifier/trigger.py
@@ -15,7 +15,7 @@ from noc.core.handler import get_handler
 
 
 class Trigger:
-    def __init__(self, t, handler=None):
+    def __init__(self, t, handler=None) -> None:
         self.name = t.name
         # Condition
         self.condition = compile(t.condition, "<string>", "eval")

--- a/services/correlator/alarmrule.py
+++ b/services/correlator/alarmrule.py
@@ -83,7 +83,7 @@ class AlarmRule:
     escalation_profile: str | None = None
     escalation_delay: int = 60
 
-    def __init__(self, name, rid):
+    def __init__(self, name, rid) -> None:
         self.name = name
         self.id = rid
         self.matcher: Callable | None = None

--- a/services/correlator/rcacondition.py
+++ b/services/correlator/rcacondition.py
@@ -13,7 +13,7 @@ from bson import ObjectId
 
 
 class RCACondition:
-    def __init__(self, alarm_class, condition):
+    def __init__(self, alarm_class, condition) -> None:
         self.name = f"{alarm_class.name}::{condition.name}"
         self.window = condition.window
         self.root = condition.root

--- a/services/correlator/rcalock.py
+++ b/services/correlator/rcalock.py
@@ -28,7 +28,7 @@ class RCALock:
     COLL_NAME = "rcalocks"
     _coll: pymongo.collection.Collection | None = None
 
-    def __init__(self, items):
+    def __init__(self, items) -> None:
         self.items = items
         self.lock_id = None
 

--- a/services/correlator/trigger.py
+++ b/services/correlator/trigger.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 class Trigger:
-    def __init__(self, t):
+    def __init__(self, t) -> None:
         self.name = t.name
         # Condition
         self.condition = compile(t.condition, "<string>", "eval")

--- a/services/datastream/paths/datastream.py
+++ b/services/datastream/paths/datastream.py
@@ -48,7 +48,7 @@ def get_access_tokens_set(datastream, fmt: str | None = None) -> set[str]:
 
 
 class DatastreamAPI:
-    def __init__(self, router: APIRouter):
+    def __init__(self, router: APIRouter) -> None:
         self.router = router
         self.openapi_tags = ["api", "datastream"]
         self.api_name = "datastream"

--- a/services/discovery/jobs/base.py
+++ b/services/discovery/jobs/base.py
@@ -67,7 +67,7 @@ class MODiscoveryJob(PeriodicJob):
     # Get diagnostics with enabled discovery (Box/Periodic filtered)
     discovery_diagnostics = set()
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.out_buffer = StringIO()
         self.logger = PrefixLoggerAdapter(self.logger, "", target=self.out_buffer)
@@ -408,7 +408,7 @@ class DiscoveryCheck:
         ERR_CLI_SSH_PROTOCOL_ERROR: "Discovery | Error | SSH Protocol",
     }
 
-    def __init__(self, job):
+    def __init__(self, job) -> None:
         self.service = job.service
         self.job = job
         self.object: ManagedObject = self.job.object
@@ -786,7 +786,7 @@ class TopologyDiscoveryCheck(DiscoveryCheck):
     # clean_interface settings
     aliased_names_only = False
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.neighbor_hostname_cache = {}  # (method, id) -> managed object
         self.neighbor_ip_cache = {}  # (method, ip) -> managed object

--- a/services/discovery/jobs/box/asset.py
+++ b/services/discovery/jobs/box/asset.py
@@ -49,7 +49,7 @@ class AssetCheck(DiscoveryCheck):
 
     fatal_errors = {}
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.unknown_part_no: dict[str, set[str]] = {}  # part_no -> list of variants
         self.pn_description: dict[str, str] = {}  # part_no -> Description

--- a/services/discovery/jobs/box/ifdesc.py
+++ b/services/discovery/jobs/box/ifdesc.py
@@ -27,7 +27,7 @@ class IfDescCheck(TopologyDiscoveryCheck):
     IFACE_REF_NAMES = {"interface", "ifindex"}
     MAX_MO_CANDIDATES = 100
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.if_cache: dict[int, dict[str, Interface]] = {}
 

--- a/services/discovery/jobs/box/interface.py
+++ b/services/discovery/jobs/box/interface.py
@@ -67,7 +67,7 @@ class InterfaceCheck(PolicyDiscoveryCheck):
         Match("protocols", "lacp", "interface", if_name, "mode", lacp_status)
     ) and Group("if_name")"""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         # self.get_interface_profile = partial(Label.get_instance_profile, InterfaceProfile)
         self.get_interface_profile = InterfaceProfile.get_profiles_matcher()

--- a/services/discovery/jobs/periodic/diagnostic.py
+++ b/services/discovery/jobs/periodic/diagnostic.py
@@ -31,7 +31,7 @@ class DiagnosticCheck(DiscoveryCheck):
 
     name = "diagnostic"
 
-    def __init__(self, job, run_order: Literal["S", "E"] | None = None):
+    def __init__(self, job, run_order: Literal["S", "E"] | None = None) -> None:
         super().__init__(job)
         self.run_order = run_order
         self.suggest_rules = CredentialCheckRule.get_suggests(self.object)

--- a/services/discovery/jobs/segment/mac.py
+++ b/services/discovery/jobs/segment/mac.py
@@ -32,7 +32,7 @@ class MACDiscoveryCheck(TopologyDiscoveryCheck):
 
     MAC_WINDOW = 2 * 86400
 
-    def __init__(self, job):
+    def __init__(self, job) -> None:
         super().__init__(job)
 
     def handler(self):

--- a/services/escalator/escalation.py
+++ b/services/escalator/escalation.py
@@ -1017,7 +1017,7 @@ class DeescalationSequence(BaseSequence):
 
 
 class CloseCheckSequence(BaseSequence):
-    def __init__(self, doc_id: str):
+    def __init__(self, doc_id: str) -> None:
         super().__init__(doc_id)
         self.escalation_doc = self.get_escalation_doc(doc_id)
 

--- a/services/escalator/jobs/base.py
+++ b/services/escalator/jobs/base.py
@@ -23,7 +23,7 @@ next_retry = datetime.datetime.now()
 
 
 class SequenceJob(Job):
-    def __init__(self, job, attrs):
+    def __init__(self, job, attrs) -> None:
         super().__init__(job, attrs)
         self.error: str | None = None
 

--- a/services/escalator/jobs/escalation.py
+++ b/services/escalator/jobs/escalation.py
@@ -41,7 +41,7 @@ class EscalationJob(SequenceJob):
     model = Escalation
     lock = ProcessLock(category="escalator", owner="escalator")
 
-    def __init__(self, job, attrs, dry_run: bool = False):
+    def __init__(self, job, attrs, dry_run: bool = False) -> None:
         super().__init__(job, attrs)
         # self.object: Escalation
         self.dry_run = dry_run

--- a/services/escalator/service.py
+++ b/services/escalator/service.py
@@ -24,7 +24,7 @@ class EscalatorService(FastAPIService):
     use_mongo = True
     use_router = True
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.shards: dict[str, Scheduler] = {}
 

--- a/services/escalator/tt/stub.py
+++ b/services/escalator/tt/stub.py
@@ -24,7 +24,7 @@ class StubTTSystem(BaseTTSystem):
 
     promote_group_tt = True
 
-    def __init__(self, name, connection):
+    def __init__(self, name, connection) -> None:
         super().__init__(name, connection)
         self.logger = logging.getLogger("StubTTSystem.%s" % name)
 

--- a/services/escalator/tt/tg_bot.py
+++ b/services/escalator/tt/tg_bot.py
@@ -31,7 +31,7 @@ class TGBotTTSystem(BaseTTSystem):
     TU_REQUEST_TIMEOUT = 30
     actions = [TTAction.ACK, TTAction.UN_ACK]
 
-    def __init__(self, name, connection):
+    def __init__(self, name, connection) -> None:
         """
         Connection is WSDL path
         """

--- a/services/grafanads/jsonds.py
+++ b/services/grafanads/jsonds.py
@@ -84,7 +84,7 @@ class JsonDSAPI:
     variable_payload = None
     allow_interval_limit: bool = True
 
-    def __init__(self, router: APIRouter):
+    def __init__(self, router: APIRouter) -> None:
         self.service = get_service()
         self.logger = self.service.logger
         self.router = router

--- a/services/metrics/changelog.py
+++ b/services/metrics/changelog.py
@@ -36,7 +36,7 @@ class ChangeLog:
     COLL_NAME = "metricslog"
     MAX_DATA = 15_000_000
 
-    def __init__(self, slot: int):
+    def __init__(self, slot: int) -> None:
         self.slot = slot
         self.state: dict[str, dict[str, Any]] = {}
         self.logger = logging.getLogger(__name__)

--- a/services/metricscollector/paths/vmagent.py
+++ b/services/metricscollector/paths/vmagent.py
@@ -44,7 +44,7 @@ class VMAgentAPI:
     # https://github.com/leegin/remote_pb2
     """
 
-    def __init__(self, router: APIRouter):
+    def __init__(self, router: APIRouter) -> None:
         self.router = router
         self.openapi_tags = ["api", "metricscollector"]
         self.api_name = "metricscollector"

--- a/services/metricscollector/paths/zabbix.py
+++ b/services/metricscollector/paths/zabbix.py
@@ -41,7 +41,7 @@ class ValueType(enum.Enum):
 
 
 class ZabbixAPI:
-    def __init__(self, router: APIRouter):
+    def __init__(self, router: APIRouter) -> None:
         self.router = router
         self.openapi_tags = ["api", "metricscollector"]
         self.api_name = "metricscollector"

--- a/services/nbi/base.py
+++ b/services/nbi/base.py
@@ -30,7 +30,7 @@ class NBIAPI:
     # Tags for OpenAPI documentation
     openapi_tags: list[str] = []
 
-    def __init__(self, router: APIRouter):
+    def __init__(self, router: APIRouter) -> None:
         self.service = get_service()
         self.logger = self.service.logger
         self.router = router

--- a/services/selfmon/collectors/base.py
+++ b/services/selfmon/collectors/base.py
@@ -26,7 +26,7 @@ Metric = tuple[tuple[Any], int]
 class BaseCollector:
     name = None
 
-    def __init__(self, service):
+    def __init__(self, service) -> None:
         self.service = service
         self.ttl = getattr(config.selfmon, "%s_ttl" % self.name, 30)
         self.last_metrics = {}

--- a/services/selfmon/collectors/task.py
+++ b/services/selfmon/collectors/task.py
@@ -27,7 +27,7 @@ class TaskObjectCollector(BaseCollector):
         ("discovery", Pool.objects.all().order_by("name").values_list("name")),
     ]  # Schedulers (name, shards)
 
-    def __init__(self, service):
+    def __init__(self, service) -> None:
         self.schedulers_list = self.load_discovery()
         super().__init__(service)
 

--- a/services/syslogcollector/syslogserver.py
+++ b/services/syslogcollector/syslogserver.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 class SyslogServer(UDPServer):
-    def __init__(self, service):
+    def __init__(self, service) -> None:
         super().__init__()
         self.service = service
 

--- a/services/topo/topo.py
+++ b/services/topo/topo.py
@@ -29,7 +29,7 @@ class Topo:
         check: Check if uplink is really adjaced to node.
     """
 
-    def __init__(self, check: bool = False):
+    def __init__(self, check: bool = False) -> None:
         self.check = check
         self.graph = nx.Graph()
         self.dirty_nodes: set[int] = set()

--- a/services/trapcollector/trapserver.py
+++ b/services/trapcollector/trapserver.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 class TrapServer(UDPServer):
-    def __init__(self, service):
+    def __init__(self, service) -> None:
         super().__init__()
         self.service = service
 

--- a/services/ui/utils/rest/base.py
+++ b/services/ui/utils/rest/base.py
@@ -61,7 +61,7 @@ class BaseResourceAPI(Generic[T], metaclass=ABCMeta):
     list_ops: list[ListOp] = []
     sort_fields: list[str | tuple[str, str]] = []
 
-    def __init__(self, router: APIRouter):
+    def __init__(self, router: APIRouter) -> None:
         def split_sort(x: str | tuple[str, str]) -> tuple[str, str]:
             if isinstance(x, str):
                 return x, x

--- a/services/ui/utils/rest/op.py
+++ b/services/ui/utils/rest/op.py
@@ -23,7 +23,7 @@ TDoc = TypeVar("TDoc", bound=Document)
 
 
 class ListOp:
-    def __init__(self, name: str):
+    def __init__(self, name: str) -> None:
         self.name = name
 
     def __str__(self):
@@ -47,7 +47,7 @@ class FilterExact(ListOp):
 
 
 class RefFilter(ListOp):
-    def __init__(self, name: str, model: TModel | TDoc):
+    def __init__(self, name: str, model: TModel | TDoc) -> None:
         super().__init__(name)
         self.model = model
 
@@ -86,7 +86,7 @@ class RefFilter(ListOp):
 
 
 class FuncFilter(ListOp):
-    def __init__(self, name: str, function: Callable):
+    def __init__(self, name: str, function: Callable) -> None:
         super().__init__(name)
         self.function = function
 

--- a/services/web/apps/fm/alarm/plugins/base.py
+++ b/services/web/apps/fm/alarm/plugins/base.py
@@ -9,7 +9,7 @@
 class AlarmPlugin:
     name = None
 
-    def __init__(self, app):
+    def __init__(self, app) -> None:
         self.app = app
 
     def get_data(self, alarm, config):

--- a/services/web/apps/fm/alarm/views.py
+++ b/services/web/apps/fm/alarm/views.py
@@ -110,7 +110,7 @@ class AlarmApplication(ExtApplication):
 
     DEFAULT_ARCH_ALARM = datetime.timedelta(seconds=config.web.api_arch_alarm_limit)
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         ExtApplication.__init__(self, *args, **kwargs)
         from .plugins.base import AlarmPlugin
 

--- a/services/web/apps/fm/event/plugins/base.py
+++ b/services/web/apps/fm/event/plugins/base.py
@@ -9,7 +9,7 @@
 class EventPlugin:
     name = None
 
-    def __init__(self, app):
+    def __init__(self, app) -> None:
         self.app = app
 
     def get_data(self, event, config):

--- a/services/web/apps/inv/inv/plugins/base.py
+++ b/services/web/apps/inv/inv/plugins/base.py
@@ -19,7 +19,7 @@ class InvPlugin:
     js = None
     required_feature: Feature | None = None
 
-    def __init__(self, app: InvApplication):
+    def __init__(self, app: InvApplication) -> None:
         self.app = app
         self.logger = logging.getLogger("%s.%s" % (__name__.rsplit(".", 1)[0], self.name))
         self.init_plugin()

--- a/services/web/apps/inv/inv/views.py
+++ b/services/web/apps/inv/inv/views.py
@@ -79,7 +79,7 @@ class InvApplication(ExtApplication):
     }
     _id_cache = cachetools.TTLCache(1000, ttl=60)
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         ExtApplication.__init__(self, *args, **kwargs)
         # Load plugins
         from .plugins.base import InvPlugin

--- a/services/web/apps/inv/reportifacestatus.py
+++ b/services/web/apps/inv/reportifacestatus.py
@@ -58,7 +58,7 @@ def get_column_width(name):
 class ReportInterfaceStatus:
     """Report interface status."""
 
-    def __init__(self, mo_ids, zero, def_profile, interface_profile):
+    def __init__(self, mo_ids, zero, def_profile, interface_profile) -> None:
         self.mo_ids = mo_ids
         self.out = self.load(mo_ids, zero, def_profile, interface_profile)
 

--- a/services/web/apps/inv/reportlinkdetail.py
+++ b/services/web/apps/inv/reportlinkdetail.py
@@ -59,7 +59,7 @@ def get_column_width(name):
 class ReportLinksDetail:
     """Report for MO links detail"""
 
-    def __init__(self, mo_ids):
+    def __init__(self, mo_ids) -> None:
         self.mo_ids = mo_ids
         self.out = self.load(mo_ids)
 

--- a/services/web/apps/inv/reportpendinglinks.py
+++ b/services/web/apps/inv/reportpendinglinks.py
@@ -30,7 +30,7 @@ from noc.core.translation import ugettext as _
 
 
 class ReportPendingLinks:
-    def __init__(self, ids, cache_key=None, ignore_profiles=None, filter_exists_link=False):
+    def __init__(self, ids, cache_key=None, ignore_profiles=None, filter_exists_link=False) -> None:
         self.ids = ids
         self.ignore_profiles = ignore_profiles
         self.filter_exists_link = filter_exists_link

--- a/services/web/apps/ip/reportoverview.py
+++ b/services/web/apps/ip/reportoverview.py
@@ -80,7 +80,7 @@ TABLE TR TD {
 
 
 class Node:
-    def __init__(self, app):
+    def __init__(self, app) -> None:
         self.app = app
         self.children = []
         self.height = 0
@@ -138,7 +138,7 @@ class Node:
 
 
 class VRFGroupNode(Node):
-    def __init__(self, app, vrf_group):
+    def __init__(self, app, vrf_group) -> None:
         self.vrf_group = vrf_group
         self.vrfs = list(vrf_group.vrf_set.all())
         super().__init__(app)
@@ -157,7 +157,7 @@ class VRFGroupNode(Node):
 
 
 class VRFNode(Node):
-    def __init__(self, app, vrf):
+    def __init__(self, app, vrf) -> None:
         self.vrf = vrf
         super().__init__(app)
 
@@ -173,7 +173,7 @@ class VRFNode(Node):
 class PrefixNode(Node):
     show_vrf = False
 
-    def __init__(self, app, prefix):
+    def __init__(self, app, prefix) -> None:
         self.prefix = prefix
         if self.prefix.afi == "4":
             self.size = 2 ** (32 - int(self.prefix.prefix.split("/")[1]))
@@ -240,7 +240,7 @@ class PrefixNode(Node):
 class GPrefixNode(PrefixNode):
     show_vrf = True
 
-    def __init__(self, app, prefix, vrfs):
+    def __init__(self, app, prefix, vrfs) -> None:
         self.vrfs = vrfs
         super().__init__(app, prefix)
 

--- a/services/web/apps/kb/macros/format.py
+++ b/services/web/apps/kb/macros/format.py
@@ -23,7 +23,7 @@ class NOCHtmlFormatter(HtmlFormatter):
 
     name = "NOC HTML"
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         kwargs["linenos"] = "table"
         super().__init__(**kwargs)
 

--- a/services/web/apps/kb/macros/rack.py
+++ b/services/web/apps/kb/macros/rack.py
@@ -33,7 +33,7 @@ def unroll_link(s):
 class RackSet:
     """RackSet representation"""
 
-    def __init__(self, id, label):
+    def __init__(self, id, label) -> None:
         self.id = id
         self.racks = []
         if label is None:
@@ -157,7 +157,7 @@ class RackSet:
 # Rack Representation
 #
 class Rack:
-    def __init__(self, rackset, id, height):
+    def __init__(self, rackset, id, height) -> None:
         self.rackset = rackset
         self.id = id
         self.height = height
@@ -282,7 +282,7 @@ class Slot:
 #                    `-> slot attrs: id, model, hostname, description, reserved, assetno, href, serial
 #
 class XMLParser:
-    def __init__(self, text):
+    def __init__(self, text) -> None:
         self.parser = xml.parsers.expat.ParserCreate()
         self.parser.StartElementHandler = self.start_element
         self.parser.EndElementHandler = self.end_element

--- a/services/web/apps/kb/parsers/mediawiki.py
+++ b/services/web/apps/kb/parsers/mediawiki.py
@@ -28,7 +28,7 @@ class MediaWikiParser(BaseParser):
     class NOCDB:
         rx_link = re.compile(r"<a href='(.+?)'>")
 
-        def __init__(self, kb_entry):
+        def __init__(self, kb_entry) -> None:
             self.kb_entry = kb_entry
 
         def getURL(self, title, revision=None):

--- a/services/web/apps/main/calculator/calculators/base.py
+++ b/services/web/apps/main/calculator/calculators/base.py
@@ -13,7 +13,7 @@ class BaseCalculator:
     form_class = None
     template = "calculator.html"
 
-    def __init__(self, app):
+    def __init__(self, app) -> None:
         self.app = app
 
     def render(self, request):

--- a/services/web/apps/main/desktop/views.py
+++ b/services/web/apps/main/desktop/views.py
@@ -28,7 +28,7 @@ class DesktopApplication(ExtApplication):
     main.desktop application
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         ExtApplication.__init__(self, *args, **kwargs)
         # Login restrictions
         self.restrict_to_group = self.get_group(config.login.restrict_to_group)

--- a/services/web/apps/main/ref.py
+++ b/services/web/apps/main/ref.py
@@ -53,7 +53,7 @@ class RefAppplication(ExtApplication):
     FA_CSS_PATH = "ui/pkg/fontawesome/css/font-awesome.min.css"
     NOC_SOUND_PATH = "ui/pkg/nocsound"
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         ExtApplication.__init__(self, *args, **kwargs)
         self.refs = {}  # Name -> [(key, value)]
         # Fill refs

--- a/services/web/apps/pm/ddash/dashboards/base.py
+++ b/services/web/apps/pm/ddash/dashboards/base.py
@@ -22,7 +22,7 @@ class BaseDashboard:
     class NotFound(Exception):
         pass
 
-    def __init__(self, object, extra_template=None, extra_vars=None):
+    def __init__(self, object, extra_template=None, extra_vars=None) -> None:
         self.object = self.resolve_object(object)
         self.extra_template = extra_template
         self.extra_vars = extra_vars

--- a/services/web/apps/sa/monitor.py
+++ b/services/web/apps/sa/monitor.py
@@ -112,7 +112,7 @@ class MonitorApplication(ObjectListApplication):
 
 
 class JobF:
-    def __init__(self, scheduler="discovery", pool="default"):
+    def __init__(self, scheduler="discovery", pool="default") -> None:
         self.scheduler = scheduler
         self.pool = pool
         self.mos_filter = None

--- a/services/web/apps/sa/reportdiscoveryproblem.py
+++ b/services/web/apps/sa/reportdiscoveryproblem.py
@@ -25,7 +25,7 @@ from noc.core.translation import ugettext as _
 class ReportDiscoveryProblem:
     """Report for MO links detail"""
 
-    def __init__(self, mos, avail_only=False, match=None):
+    def __init__(self, mos, avail_only=False, match=None) -> None:
         """
 
         :param mos:

--- a/services/web/base/access.py
+++ b/services/web/base/access.py
@@ -64,7 +64,7 @@ class LogicPermision(Permission):
     using logic condition
     """
 
-    def __init__(self, left, right):
+    def __init__(self, left, right) -> None:
         super().__init__()
         self.left = left
         self.right = right
@@ -137,7 +137,7 @@ class HasPerm(Permission):
     Permit if the user has permission _perm_
     """
 
-    def __init__(self, perm):
+    def __init__(self, perm) -> None:
         super().__init__()
         self.perm = perm
 

--- a/services/web/base/application.py
+++ b/services/web/base/application.py
@@ -98,7 +98,7 @@ class BoundView:
         __self__: Instance the original method is bound to.
     """
 
-    def __init__(self, func):
+    def __init__(self, func) -> None:
         self.func = func
         self.__self__ = func.__self__
         functools.update_wrapper(self, func)
@@ -149,7 +149,7 @@ class Application(metaclass=ApplicationBase):
 
     TZ = get_current_timezone()
 
-    def __init__(self, site):
+    def __init__(self, site) -> None:
         self.site = site
         self.service = None  # Set by web
         parts = self.__class__.__module__.split(".")

--- a/services/web/base/decorators/base.py
+++ b/services/web/base/decorators/base.py
@@ -11,7 +11,7 @@ class BaseAppDecorator:
     Basic application decorator to inject new methods via .add_view
     """
 
-    def __init__(self, cls):
+    def __init__(self, cls) -> None:
         self.cls = cls
         self.contribute_to_class()
 

--- a/services/web/base/docinline.py
+++ b/services/web/base/docinline.py
@@ -59,7 +59,7 @@ class DocInline:
     field_labels = {}  # field_name -> callable(field_value) -> result
     render_fields = {}  # field_name -> callable(field_value) -> result
 
-    def __init__(self, model):
+    def __init__(self, model) -> None:
         self.model = model
         self.app = None
         self.pk_field_name = "id"

--- a/services/web/base/extapplication.py
+++ b/services/web/base/extapplication.py
@@ -60,7 +60,7 @@ class ExtApplication(Application):
 
     rx_oper_splitter = re.compile(r"^(?P<field>\S+?)(?P<f_num>\d+)__in")
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.document_root = os.path.join("services", "web", "apps", self.module, self.app)
         self.row_limit = config.web.api_row_limit

--- a/services/web/base/extdocapplication.py
+++ b/services/web/base/extdocapplication.py
@@ -77,7 +77,7 @@ class ExtDocApplication(ExtApplication):
     # Add `__label` items
     field_labels = {}  # field_name -> callable(field_value) -> result
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.pk = "id"  # @todo: detect properly
         self.has_uuid = False

--- a/services/web/base/extmodelapplication.py
+++ b/services/web/base/extmodelapplication.py
@@ -78,7 +78,7 @@ class ExtModelApplication(ExtApplication):
     SECRET_MASK = "********"
     file_fields_mask = None
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.db_table = self.model._meta.db_table
         self.pk_field_name = self.model._meta.pk.name

--- a/services/web/base/modelinline.py
+++ b/services/web/base/modelinline.py
@@ -58,7 +58,7 @@ class ModelInline:
     clean_fields = {}  # field name -> Parameter instance
     custom_fields = {}  # name -> handler, populated automatically
 
-    def __init__(self, model):
+    def __init__(self, model) -> None:
         self.model = model
         self.app = None
         self.pk_field_name = self.model._meta.pk.name

--- a/services/web/base/repoinline.py
+++ b/services/web/base/repoinline.py
@@ -10,7 +10,7 @@ from django.http import Http404
 
 
 class RepoInline:
-    def __init__(self, field, access="read"):
+    def __init__(self, field, access="read") -> None:
         self.field = field
         self.app = None
         self.parent_model = None

--- a/services/web/base/reportapplication.py
+++ b/services/web/base/reportapplication.py
@@ -29,7 +29,7 @@ class ReportApplication(Application):
     inline_styles = ""
     ISO_DATE_MASK = "%Y-%m-%d"
 
-    def __init__(self, site):
+    def __init__(self, site) -> None:
         super().__init__(site)
         site.reports += [self]
 
@@ -114,7 +114,7 @@ class ReportByConfigApplication(Application):
     report_id: str = None
     report_config = None
 
-    def __init__(self, site):
+    def __init__(self, site) -> None:
         self.site = site
         self.service = None  # Set by web
         self.module = self.get_module()

--- a/services/web/base/reportdatasources/base.py
+++ b/services/web/base/reportdatasources/base.py
@@ -74,7 +74,7 @@ class BaseReportColumn:
     multiple_series = False  # Extract return dict columns dataseries
     # {"Series1_name": dataseries1, "Series2_name": dataseries2}
 
-    def __init__(self, sync_ids=None):
+    def __init__(self, sync_ids=None) -> None:
         """
 
         :param sync_ids:
@@ -199,7 +199,7 @@ class LongestIter:
     hostname = LongestIter(did)
     """
 
-    def __init__(self, it):
+    def __init__(self, it) -> None:
         self._iterator = it
         self._end_iterator = False
         self._id = 0

--- a/services/web/base/reportdatasources/report_metrics.py
+++ b/services/web/base/reportdatasources/report_metrics.py
@@ -24,7 +24,7 @@ class ReportMetrics(BaseReportColumn):
     CUSTOM_FILTER = {"having": [], "where": []}
     KEY_FIELDS = None
 
-    def __init__(self, mos_ids, f_date, to_date, columns=None):
+    def __init__(self, mos_ids, f_date, to_date, columns=None) -> None:
         super().__init__(mos_ids)
         self.from_date = f_date
         self.to_date = to_date

--- a/services/web/base/reportdatasources/report_objecthostname.py
+++ b/services/web/base/reportdatasources/report_objecthostname.py
@@ -50,7 +50,7 @@ class ReportObjectsHostname2(BaseReportColumn):
 # class ReportObjectsHostname(BaseReportDataSource):
 #     """MO hostname"""
 #
-#     def __init__(self, mo_ids=(), use_facts=False):
+#     def __init__(self, mo_ids=(), use_facts=False) -> None:
 #         self.load = self.load_discovery
 #         super(ReportObjectsHostname).__init__(mo_ids)
 #         if use_facts:

--- a/services/web/base/site.py
+++ b/services/web/base/site.py
@@ -50,7 +50,7 @@ class URL:
     URL Data wrapper
     """
 
-    def __init__(self, url, name=None, method=None):
+    def __init__(self, url, name=None, method=None) -> None:
         self.url = url
         self.name = name
         if method is None:

--- a/tests/cdag/node/util.py
+++ b/tests/cdag/node/util.py
@@ -23,7 +23,7 @@ from noc.core.service.stub import ServiceStub
 
 
 class NodeCDAG:
-    def __init__(self, node_type: str, config=None, state=None):
+    def __init__(self, node_type: str, config=None, state=None) -> None:
         self.cdag = CDAG("test", state or {})
         self.node = self.cdag.add_node("node", node_type, config=config)
         self.measure_node = self.cdag.add_node("measure", "none")
@@ -83,7 +83,7 @@ class PublishMsg:
 
 
 class PublishStub(ServiceStub):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.messages: list[PublishMsg] = []
 

--- a/tests/collections/test_sa_profilecheckrules.py
+++ b/tests/collections/test_sa_profilecheckrules.py
@@ -20,7 +20,7 @@ from noc.core.mib import mib
 
 
 class PCRHelper(CollectionTestHelper):
-    def __init__(self, model):
+    def __init__(self, model) -> None:
         super().__init__(model)
         self._oid_count = defaultdict(int)
 

--- a/tests/collections/utils.py
+++ b/tests/collections/utils.py
@@ -17,7 +17,7 @@ import pytest
 class CollectionTestHelper(object):
     COLLECTIONS = "collections"
 
-    def __init__(self, model):
+    def __init__(self, model) -> None:
         self.model = model
         self.collection = model._meta["json_collection"]
         self.cache = None

--- a/tests/confdb/collator/test_ifpath.py
+++ b/tests/confdb/collator/test_ifpath.py
@@ -336,7 +336,7 @@ PathItem = namedtuple("PathItem", ["object", "connection"])
 
 
 class MockObject:
-    def __init__(self, name, data):
+    def __init__(self, name, data) -> None:
         self.name = name
         self.data = data
 
@@ -346,13 +346,13 @@ class MockObject:
 
 
 class MockObjectConnection:
-    def __init__(self, name, protocols):
+    def __init__(self, name, protocols) -> None:
         self.name = name
         self.protocols = protocols
 
 
 class MockInterface:
-    def __init__(self, name, default_name, type):
+    def __init__(self, name, default_name, type) -> None:
         self.name = name
         self.default_name = default_name
         self.type = type

--- a/tests/confdb/test_profiles.py
+++ b/tests/confdb/test_profiles.py
@@ -36,7 +36,7 @@ def iter_test_paths():
 
 
 class MockProfile:
-    def __init__(self, profile_cls):
+    def __init__(self, profile_cls) -> None:
         self.profile = profile_cls()
 
     def get_profile(self):
@@ -44,7 +44,7 @@ class MockProfile:
 
 
 class MockManagedObject:
-    def __init__(self, profile):
+    def __init__(self, profile) -> None:
         self.profile = MockProfile(profile)
 
 

--- a/tests/core/test_password.py
+++ b/tests/core/test_password.py
@@ -55,7 +55,7 @@ def test_check_password(password: str, encoded: str) -> None:
 
 
 class ErrContext:
-    def __init__(self, msg: str | None = None):
+    def __init__(self, msg: str | None = None) -> None:
         self._msg = msg
 
     def __enter__(self) -> "ErrContext":

--- a/tests/docs/conftest.py
+++ b/tests/docs/conftest.py
@@ -25,7 +25,7 @@ T_NAV_ITEM = str | dict[str, "T_NAV_ITEM"] | list["T_NAV_ITEM"]
 
 
 class ToC:
-    def __init__(self, path: Path):
+    def __init__(self, path: Path) -> None:
         self.items: dict[tuple[str, ...], str] = {}
         for kv in self.iter_nav(path):
             self.add_item([], kv)

--- a/tests/models/test_capabilities.py
+++ b/tests/models/test_capabilities.py
@@ -16,7 +16,7 @@ from noc.core.caps.decorator import capabilities
 class MockManagedObject:
     name = "mock"
 
-    def __init__(self, caps=None):
+    def __init__(self, caps=None) -> None:
         self.caps = caps or []
 
     def save_caps(self, caps, **kwargs):

--- a/tests/models/test_remote_mappings.py
+++ b/tests/models/test_remote_mappings.py
@@ -20,7 +20,7 @@ class MockManagedObject:
     _is_document = True
     _created = True
 
-    def __init__(self, mappings=None):
+    def __init__(self, mappings=None) -> None:
         self.mappings = mappings or []
 
     def update(self, **kwargs):

--- a/tests/reporter/test_report_config.py
+++ b/tests/reporter/test_report_config.py
@@ -18,7 +18,7 @@ from noc.services.web.base.site import site
 
 
 class RequestStub:
-    def __init__(self, user):
+    def __init__(self, user) -> None:
         self.user = user
 
 

--- a/tests/runner/test_job.py
+++ b/tests/runner/test_job.py
@@ -176,7 +176,7 @@ def test_is_leader() -> None:
 
 
 class RunnerWrapper(Runner):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.last_state = {}
 

--- a/tests/scripts/test_cli.py
+++ b/tests/scripts/test_cli.py
@@ -31,11 +31,11 @@ BROKEN_PW = TEST_PW + "X"
 
 class ServiceStub:
     class ServiceConfig:
-        def __init__(self, pool, tos=None):
+        def __init__(self, pool, tos=None) -> None:
             self.pool = pool
             self.tos = tos
 
-    def __init__(self, pool="default"):
+    def __init__(self, pool="default") -> None:
         self.config = self.ServiceConfig(pool=pool)
 
 

--- a/tests/scripts/test_snmp.py
+++ b/tests/scripts/test_snmp.py
@@ -27,11 +27,11 @@ SNMP_COMMUNITY = "public"
 
 class ServiceStub:
     class ServiceConfig:
-        def __init__(self, pool, tos=None):
+        def __init__(self, pool, tos=None) -> None:
             self.pool = pool
             self.tos = tos
 
-    def __init__(self, pool="default"):
+    def __init__(self, pool="default") -> None:
         self.config = self.ServiceConfig(pool=pool)
 
 

--- a/tests/test_beef.py
+++ b/tests/test_beef.py
@@ -24,11 +24,11 @@ rx_tc = re.compile(r"^.+/\d\d\d\d\.\S+\.json\.bz2")
 
 class ServiceStub:
     class ServiceConfig:
-        def __init__(self, pool, tos=None):
+        def __init__(self, pool, tos=None) -> None:
             self.pool = pool
             self.tos = tos
 
-    def __init__(self, pool):
+    def __init__(self, pool) -> None:
         self.config = self.ServiceConfig(pool=pool)
         setup_asyncio()
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -44,7 +44,7 @@ _configs = {}  # mo -> config
 
 
 class ServiceStub:
-    def __init__(self, pool):
+    def __init__(self, pool) -> None:
         self.pool = pool
         self.metrics = defaultdict(list)
         self.service_id = "stub"
@@ -56,7 +56,7 @@ class ServiceStub:
 
 
 class BeefCallWrapper:
-    def __init__(self, obj, name):
+    def __init__(self, obj, name) -> None:
         self.name = name
         self.object = obj
 


### PR DESCRIPTION
Add explicit `-> None` return type annotations to all `__init__` methods in the codebase. This improves static analysis coverage and consistency with PEP 484 conventions, where constructors are required to return `None`.

### Notable Implementation Details
- No logic or behavior changes — this is a pure type annotation pass
- All inheritance chains preserved, including custom metaclasses (`Action(metaclass=ActionBase)`)
- Generic class constructors typed correctly (`Reference(Generic[T])`, `BaseResourceAPI(Generic[T], metaclass=ABCMeta)`)
- `__slots__` classes unaffected by annotations
