### PR TITLE
Ruff: Enforce UP032 checks, replace str.format() with f-strings

### DIFF
--- a/commands/job.py
+++ b/commands/job.py
@@ -46,7 +46,7 @@ class Command(BaseCommand):
         try:
             return datetime.strptime(s, "%Y-%m-%d %H:%M")
         except ValueError:
-            msg = "Not a valid date: '{0}'.".format(s)
+            msg = f"Not a valid date: '{s}'."
             raise argparse.ArgumentTypeError(msg)
 
     @staticmethod

--- a/commands/liftbridge.py
+++ b/commands/liftbridge.py
@@ -36,7 +36,7 @@ class Command(BaseCommand):
         try:
             return int(parse(s).timestamp())
         except ValueError:
-            msg = "Not a valid date: '{0}'.".format(s)
+            msg = f"Not a valid date: '{s}'."
             raise argparse.ArgumentTypeError(msg)
 
     def add_arguments(self, parser):

--- a/commands/msgstream.py
+++ b/commands/msgstream.py
@@ -33,7 +33,7 @@ class Command(BaseCommand):
         try:
             return int(parse(s).timestamp())
         except ValueError:
-            msg = "Not a valid date: '{0}'.".format(s)
+            msg = f"Not a valid date: '{s}'."
             raise argparse.ArgumentTypeError(msg)
 
     def add_arguments(self, parser):

--- a/core/datasources/loadmetricsmaxds.py
+++ b/core/datasources/loadmetricsmaxds.py
@@ -176,7 +176,7 @@ class LoadMetricsMaxDS(BaseDataSource):
         **kwargs,
     ) -> AsyncIterable[tuple[str, str]]:
         def str_to_float(str):
-            return float("{0:.3f}".format(float(str)))
+            return float(f"{float(str):.3f}")
 
         diff = end - start
         q_filter = cls.get_filter(kwargs)
@@ -231,8 +231,8 @@ class LoadMetricsMaxDS(BaseDataSource):
                     "max_load_out_time": max_load_out_time,
                     "avg_load_in": avg_in,
                     "avg_load_out": avg_out,
-                    "total_in": float("{0:.1f}".format(total_in)),
-                    "total_out": float("{0:.1f}".format(total_out)),
+                    "total_in": float(f"{total_in:.1f}"),
+                    "total_out": float(f"{total_out:.1f}"),
                 }
         # Yielding data
         num = 1

--- a/pm/models/scale.py
+++ b/pm/models/scale.py
@@ -121,7 +121,7 @@ class Scale(Document):
                 seconds -= value * count
                 if value == 1:
                     name = name.rstrip("s")
-                result.append("{}{}".format(value, name))
+                result.append(f"{value}{name}")
         return ", ".join(result[:-1])
 
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,7 +212,6 @@ ignore = [
   "UP017", # Use `datetime.UTC` alias
   "UP030", # Use implicit references for positional format fields
   "UP031", # Use format specifiers instead of percent format
-  "UP032", # Use f-string instead of `format` call
   "UP035", # `typing.Dict` is deprecated, use `dict` instead
   "UP041", # Replace aliased errors with `TimeoutError`
   "UP042", # Class Interaction inherits from both `str` and `enum.Enum`

--- a/sa/profiles/Cisco/ASA/get_capabilities.py
+++ b/sa/profiles/Cisco/ASA/get_capabilities.py
@@ -24,5 +24,5 @@ class Script(BaseScript):
         if "Invalid input detected at" not in v:
             match = self.re_search(self.sec_mode, v)
             sec_mode = match.group("mode")
-            self.logger.debug("Mode {0}".format(sec_mode))
+            self.logger.debug(f"Mode {sec_mode}")
             caps["Cisco | ASA | Security | Context | Mode"] = sec_mode

--- a/sa/profiles/Cisco/IOS/get_interfaces.py
+++ b/sa/profiles/Cisco/IOS/get_interfaces.py
@@ -339,10 +339,7 @@ class Script(BaseScript):
             result[int(ifindex)]["tagged_vlans"] += list(
                 compress(
                     range(4096),
-                    [
-                        int(x)
-                        for x in chain.from_iterable(f"{mask:08b}" for mask in vlans_bank)
-                    ],
+                    [int(x) for x in chain.from_iterable(f"{mask:08b}" for mask in vlans_bank)],
                 )
             )
         time.sleep(2)

--- a/sa/profiles/Cisco/IOS/get_interfaces.py
+++ b/sa/profiles/Cisco/IOS/get_interfaces.py
@@ -341,7 +341,7 @@ class Script(BaseScript):
                     range(4096),
                     [
                         int(x)
-                        for x in chain.from_iterable("{0:08b}".format(mask) for mask in vlans_bank)
+                        for x in chain.from_iterable(f"{mask:08b}" for mask in vlans_bank)
                     ],
                 )
             )

--- a/sa/profiles/Cisco/IOS/get_switchport.py
+++ b/sa/profiles/Cisco/IOS/get_switchport.py
@@ -63,7 +63,7 @@ class Script(BaseScript):
         for line in vlans.splitlines():
             for vlan_pack in line.split()[0]:
                 # for is_v in bin(int(vlan_pack, 16)):
-                for is_v in "{0:04b}".format(vlan_pack):
+                for is_v in f"{vlan_pack:04b}":
                     yield int(is_v)
 
     def execute_snmp(self, **kwargs):

--- a/sa/profiles/Cisco/NXOS/get_portchannel.py
+++ b/sa/profiles/Cisco/NXOS/get_portchannel.py
@@ -31,7 +31,7 @@ class Script(BaseScript):
             for l in s.splitlines():
                 pc, rest = l.split(" ", 1)
                 pc = pc[2:]
-                v = self.cli("show interface port-channel {0} | i Member_[0-9]+".format(pc))
+                v = self.cli(f"show interface port-channel {pc} | i Member_[0-9]+")
                 out_if = {
                     "interface": "Po %s" % pc,
                     "members": [],

--- a/sa/profiles/Generic/get_interfaces.py
+++ b/sa/profiles/Generic/get_interfaces.py
@@ -115,7 +115,7 @@ class Script(BaseScript):
             vlan_num = int(oid.split(".")[-1])
             # Getting port as mask,  convert to vlan: Iface list
             for port, is_egress in enumerate(
-                chain.from_iterable("{0:08b}".format(mask) for mask in ports_mask), start=1
+                chain.from_iterable(f"{mask:08b}" for mask in ports_mask), start=1
             ):
                 if is_egress == "0":
                     continue

--- a/sa/profiles/Generic/get_switchport.py
+++ b/sa/profiles/Generic/get_switchport.py
@@ -36,7 +36,7 @@ class Script(BaseScript):
         for line in vlans.splitlines():
             for vlan_pack in line.split()[0]:
                 # for is_v in bin(int(vlan_pack, 16)):
-                for is_v in "{0:08b}".format(vlan_pack):
+                for is_v in f"{vlan_pack:08b}":
                     yield int(is_v)
 
     def execute_snmp(self, **kwargs):

--- a/sa/profiles/Huawei/VRP/get_interfaces.py
+++ b/sa/profiles/Huawei/VRP/get_interfaces.py
@@ -232,10 +232,7 @@ class Script(BaseScript):
             result[pid_ifindex_mappings[port_num]]["tagged_vlans"] += list(
                 compress(
                     vlans,
-                    [
-                        int(x)
-                        for x in chain.from_iterable(f"{mask:08b}" for mask in vlans_bank)
-                    ],
+                    [int(x) for x in chain.from_iterable(f"{mask:08b}" for mask in vlans_bank)],
                 )
             )
         return result

--- a/sa/profiles/Huawei/VRP/get_interfaces.py
+++ b/sa/profiles/Huawei/VRP/get_interfaces.py
@@ -234,7 +234,7 @@ class Script(BaseScript):
                     vlans,
                     [
                         int(x)
-                        for x in chain.from_iterable("{0:08b}".format(mask) for mask in vlans_bank)
+                        for x in chain.from_iterable(f"{mask:08b}" for mask in vlans_bank)
                     ],
                 )
             )

--- a/sa/profiles/Huawei/VRP/get_switchport.py
+++ b/sa/profiles/Huawei/VRP/get_switchport.py
@@ -59,7 +59,7 @@ class Script(BaseScript):
         """
         for line in vlans.splitlines():
             for vlan_pack in line.split()[0]:
-                for is_v in "{0:08b}".format(vlan_pack):
+                for is_v in f"{vlan_pack:08b}":
                     yield int(is_v)
 
     def execute_snmp(self, **kwargs):

--- a/sa/profiles/VMWare/connection.py
+++ b/sa/profiles/VMWare/connection.py
@@ -92,9 +92,9 @@ def connect(host=None, alias=DEFAULT_CONNECTION_NAME, **kwargs):
 
         if new_conn_settings != prev_conn_setting:
             err_msg = (
-                "A different connection with alias `{}` was already "
+                f"A different connection with alias `{alias}` was already "
                 "registered. Use disconnect() first"
-            ).format(alias)
+            )
             raise ConnectionFailure(err_msg)
     else:
         register_connection(alias, host, **kwargs)

--- a/services/web/apps/inv/reportmaxmetrics.py
+++ b/services/web/apps/inv/reportmaxmetrics.py
@@ -156,7 +156,7 @@ class ReportMaxMetricsmaxDetailApplication(ExtApplication):
             return [row[i] for i in cmap]
 
         def str_to_float(str):
-            return float("{0:.3f}".format(float(str)))
+            return float(f"{float(str):.3f}")
 
         cols = [
             "object_id",
@@ -343,8 +343,8 @@ class ReportMaxMetricsmaxDetailApplication(ExtApplication):
                 "max_load_out_time": row[8],
                 "avg_load_in": avg_in,
                 "avg_load_out": avg_out,
-                "total_in": float("{0:.1f}".format(total_in)),
-                "total_out": float("{0:.1f}".format(total_out)),
+                "total_in": float(f"{total_in:.1f}"),
+                "total_out": float(f"{total_out:.1f}"),
             }
 
         # find uplinks


### PR DESCRIPTION
Enable Ruff's UP032 rule (use f-strings instead of `.format()`) and apply it across the codebase for consistency with Python 3.12+ standards.

**Key changes:**
- Removed `UP032` from the ignore list in `pyproject.toml`
- Replaced all remaining `str.format()` calls with equivalent f-strings across 16 files