### PR TITLE
Replace __import__ with importlib

### DIFF
--- a/commands/newapp.py
+++ b/commands/newapp.py
@@ -6,6 +6,7 @@
 # ---------------------------------------------------------------------
 
 # Python modules
+import importlib
 import argparse
 import os
 import datetime
@@ -197,11 +198,11 @@ class Command(BaseCommand):
             if tv["model"]:
                 tv["requires"] = ["NOC.%s.%s.Model" % (m, tv["model"].lower())]
                 tv["modelimport"] = "noc.%s.models.%s" % (m, a)
-                models = __import__(tv["modelimport"], {}, {}, tv["model"])
+                models = importlib.import_module(tv["modelimport"])
                 model = getattr(models, tv["model"])
                 if model is None:
                     tv["modelimport"] = "noc.%s.models" % m
-                    models = __import__(tv["modelimport"], {}, {}, "*")
+                    models = importlib.import_module(tv["modelimport"])
                     model = getattr(models, tv["model"])
                 if issubclass(model, Model):
                     # Model

--- a/commands/sync-refbooks.py
+++ b/commands/sync-refbooks.py
@@ -6,6 +6,7 @@
 # ---------------------------------------------------------------------
 
 # Python modules
+import importlib
 import os
 
 # NOC modules
@@ -33,7 +34,7 @@ class Command(BaseCommand):
                 for f in filenames
                 if f.endswith(".py") and f != "__init__.py" and not f.startswith(".")
             ]:
-                m = __import__(mb + f[:-3], {}, {}, "*")
+                m = importlib.import_module(mb + f[:-3])
                 for ec_name in dir(m):
                     ec = getattr(m, ec_name)
                     try:

--- a/core/clickhouse/dictionary.py
+++ b/core/clickhouse/dictionary.py
@@ -6,6 +6,7 @@
 # ----------------------------------------------------------------------
 
 # Python modules
+import importlib
 import os
 import operator
 
@@ -136,7 +137,7 @@ class Dictionary(metaclass=DictionaryBase):
         :param name:
         :return:
         """
-        m = __import__("noc.core.bi.dictionaries.%s" % name, {}, {}, "*")
+        m = importlib.import_module("noc.core.bi.dictionaries.%s" % name)
         for a in dir(m):
             o = getattr(m, a)
             if not hasattr(o, "_meta"):

--- a/core/config/base.py
+++ b/core/config/base.py
@@ -6,6 +6,7 @@
 # ----------------------------------------------------------------------
 
 # Python modules
+import importlib
 import inspect
 import re
 import os
@@ -274,7 +275,7 @@ class BaseConfig(metaclass=ConfigBase):
         if h:
             # NB: We cannot use get_handler, so use naive implementation
             module_name, handler_class = h.rsplit(".", 1)
-            module = __import__(module_name, {}, {}, [handler_class])
+            module = importlib.import_module(module_name)
             return getattr(module, handler_class)
         msg = f"Invalid protocol: {p}"
         raise ValueError(msg)

--- a/core/etl/loader/loader.py
+++ b/core/etl/loader/loader.py
@@ -6,6 +6,7 @@
 # ----------------------------------------------------------------------
 
 # Python modules
+import importlib
 import logging
 import inspect
 import threading
@@ -36,7 +37,7 @@ class LoaderLoader:
                     base = "noc.custom" if p else "noc.core"
                     module_name = "%s.etl.loader.%s" % (base, name)
                     try:
-                        sm = __import__(module_name, {}, {}, "*")
+                        sm = importlib.import_module(module_name)
                         for n in dir(sm):
                             o = getattr(sm, n)
                             if (

--- a/core/interface/loader.py
+++ b/core/interface/loader.py
@@ -59,7 +59,7 @@ class InterfaceLoader:
                 self.interfaces[name] = None
                 return None
             try:
-                sm = __import__(module_name, {}, {}, "*")
+                sm = importlib.import_module(module_name)
                 for n in dir(sm):
                     o = getattr(sm, n)
                     if (

--- a/core/loader/base.py
+++ b/core/loader/base.py
@@ -6,6 +6,7 @@
 # ----------------------------------------------------------------------
 
 # Python modules
+import importlib
 import logging
 import inspect
 import threading
@@ -40,7 +41,7 @@ class BaseLoader:
         :return: class reference or None
         """
         try:
-            sm = __import__(module_name, {}, {}, "*")
+            sm = importlib.import_module(module_name)
             for n in dir(sm):
                 o = getattr(sm, n)
                 if (

--- a/core/mib.py
+++ b/core/mib.py
@@ -6,6 +6,7 @@
 # ----------------------------------------------------------------------
 
 # Python modules
+import importlib
 import logging
 from threading import Lock
 
@@ -85,7 +86,7 @@ class MIBRegistry:
             logger.debug("Loading MIB: %s", name)
             mn = "%s.cmibs.%s" % (base_name, mod_name)
             try:
-                m = __import__(mn, {}, {}, ["MIB"])
+                m = importlib.import_module(mn)
             except ModuleNotFoundError:
                 continue
             self.mib.update(getattr(m, "MIB"))

--- a/core/migration/loader.py
+++ b/core/migration/loader.py
@@ -6,6 +6,7 @@
 # ----------------------------------------------------------------------
 
 # Python modules
+import importlib
 import operator
 from typing import Iterable
 from pathlib import Path
@@ -64,7 +65,7 @@ class MigrationLoader:
             mn = f"noc.custom.{app}.migrations.{mname}"
         else:
             mn = f"noc.{app}.migrations.{mname}"
-        m = __import__(mn, {}, {}, "Migration")
+        m = importlib.import_module(mn)
         return m.Migration()
 
     @classmethod

--- a/core/service/paths/loader.py
+++ b/core/service/paths/loader.py
@@ -5,6 +5,9 @@
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
+# Python modules
+import importlib
+
 # Third-party modules
 from fastapi import APIRouter
 
@@ -27,7 +30,7 @@ class PathLoader(BaseLoader):
         :return: class reference or None
         """
         try:
-            sm = __import__(module_name, {}, {}, "router")
+            sm = importlib.import_module(module_name)
             if hasattr(sm, "router") and isinstance(sm.router, APIRouter):
                 return sm.router
         except ImportError as e:

--- a/gis/models/overlay.py
+++ b/gis/models/overlay.py
@@ -6,6 +6,7 @@
 # ----------------------------------------------------------------------
 
 # Python modules
+import importlib
 import inspect
 
 # Third-party modules
@@ -32,7 +33,7 @@ class Overlay(Document):
         if self.overlay not in self._overlay_cache:
             from noc.gis.overlays.base import OverlayHandler
 
-            m = __import__("noc.gis.overlays.%s" % self.overlay, {}, {}, "*")
+            m = importlib.import_module("noc.gis.overlays.%s" % self.overlay)
             for n in dir(m):
                 o = getattr(m, n)
                 if inspect.isclass(o) and o != OverlayHandler and issubclass(o, OverlayHandler):

--- a/services/card/paths/card.py
+++ b/services/card/paths/card.py
@@ -6,6 +6,7 @@
 # ----------------------------------------------------------------------
 
 # Python modules
+import importlib
 import os
 import inspect
 from threading import Lock
@@ -114,7 +115,7 @@ class CardAPI(BaseAPI):
                 if not f.endswith(".py"):
                     continue
                 mn = "%s.%s.%s" % (basename, cls.CARDS_PREFIX.replace(os.path.sep, "."), f[:-3])
-                m = __import__(mn, {}, {}, "*")
+                m = importlib.import_module(mn)
                 for d in dir(m):
                     c = getattr(m, d)
                     if (

--- a/services/web/apps/fm/alarm/views.py
+++ b/services/web/apps/fm/alarm/views.py
@@ -6,6 +6,7 @@
 # ---------------------------------------------------------------------
 
 # Python modules
+import importlib
 import os
 import inspect
 import datetime
@@ -120,7 +121,7 @@ class AlarmApplication(ExtApplication):
             if not f.endswith(".py") or f == "base.py" or f.startswith("_"):
                 continue
             mn = "noc.services.web.apps.fm.alarm.plugins.%s" % f[:-3]
-            m = __import__(mn, {}, {}, "*")
+            m = importlib.import_module(mn)
             for on in dir(m):
                 o = getattr(m, on)
                 if (

--- a/services/web/apps/inv/inv/views.py
+++ b/services/web/apps/inv/inv/views.py
@@ -6,6 +6,7 @@
 # ---------------------------------------------------------------------
 
 # Python modules
+import importlib
 import inspect
 import operator
 import os
@@ -89,7 +90,7 @@ class InvApplication(ExtApplication):
             if not f.endswith(".py") or f == "base.py" or f.startswith("_"):
                 continue
             mn = "noc.services.web.apps.inv.inv.plugins.%s" % f[:-3]
-            m = __import__(mn, {}, {}, "*")
+            m = importlib.import_module(mn)
             for on in dir(m):
                 o = getattr(m, on)
                 if inspect.isclass(o) and issubclass(o, InvPlugin) and o.__module__.startswith(mn):

--- a/services/web/apps/main/reportloc.py
+++ b/services/web/apps/main/reportloc.py
@@ -6,6 +6,7 @@
 # ---------------------------------------------------------------------
 
 # Python modules
+import importlib
 import os
 import glob
 
@@ -50,7 +51,7 @@ class ReportLOC(SimpleReport):
         # Scan modules
         for m in [m for m in settings.INSTALLED_APPS if m.startswith("noc.")]:
             m = m[4:]
-            module_name = __import__("noc.%s" % m, {}, {}, ["MODULE_NAME"]).MODULE_NAME
+            module_name = importlib.import_module("noc.%s" % m).MODULE_NAME
             data += [SectionRow(module_name)]
             # Scan models
             models_path = os.path.join(m, "models.py")

--- a/services/web/apps/main/reporttaggedmodels.py
+++ b/services/web/apps/main/reporttaggedmodels.py
@@ -5,6 +5,9 @@
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
+# Python modules
+import importlib
+
 # Third-party modules
 from django.db import models as django_models
 
@@ -22,7 +25,7 @@ class ReportTaggedModels(SimpleReport):
         for app in INSTALLED_APPS:
             if app.startswith("noc."):
                 models = app + ".models"
-                module = __import__(models, {}, {}, "*")
+                module = importlib.import_module(models)
                 for n in dir(module):
                     obj = getattr(module, n)
                     try:

--- a/services/web/base/application.py
+++ b/services/web/base/application.py
@@ -6,6 +6,7 @@
 # ---------------------------------------------------------------------
 
 # Python modules
+import importlib
 import logging
 import os
 import datetime
@@ -159,8 +160,8 @@ class Application(metaclass=ApplicationBase):
         else:
             self.module = parts[4]
             self.app = parts[5]
-        self.module_title = __import__(
-            "noc.services.web.apps.%s" % self.module, {}, {}, ["MODULE_NAME"]
+        self.module_title = importlib.import_module(
+            "noc.services.web.apps.%s" % self.module
         ).MODULE_NAME
         self.app_id = "%s.%s" % (self.module, self.app)
         self.menu_url = None  # Set by site.autodiscover()

--- a/services/web/base/site.py
+++ b/services/web/base/site.py
@@ -445,7 +445,7 @@ class Site:
 
     def add_module_menu(self, m):
         mn = "noc.services.web.apps.%s" % m[4:]  # Strip noc.
-        mod_name = __import__(mn, {}, {}, ["MODULE_NAME"]).MODULE_NAME
+        mod_name = importlib.import_module(mn).MODULE_NAME
         r = {"id": self.get_menu_id([m]), "title": mod_name, "children": []}
         self.menu += [r]
         return r
@@ -606,7 +606,7 @@ class Site:
         apps = list(self.apps)
         for module in [m for m in settings.INSTALLED_APPS if m.startswith("noc.")]:
             mod = module[4:]
-            m = __import__(f"noc.services.web.apps.{mod}", {}, {}, "MODULE_NAME")
+            m = importlib.import_module(f"noc.services.web.apps.{mod}")
             module_name = m.MODULE_NAME
             for app in [app for app in apps if app.startswith(mod + ".")]:
                 app_perms = sorted([p for p in perms if p.startswith(app.replace(".", ":") + ":")])

--- a/tests/test_mib.py
+++ b/tests/test_mib.py
@@ -6,6 +6,7 @@
 # ----------------------------------------------------------------------
 
 # Python modules
+import importlib
 import os
 
 # Third-party modules
@@ -47,7 +48,7 @@ def test_mib_lookup(input, expected):
 def test_compiled_mib(name):
     mod_name = name[:-3]
     mn = "noc.cmibs.%s" % mod_name
-    m = __import__(mn, {}, {}, "*")
+    m = importlib.import_module(mn)
     assert hasattr(m, "NAME")
     assert mib.mib_to_modname(m.NAME) == mod_name
     assert hasattr(m, "MIB")

--- a/tests/test_py_module.py
+++ b/tests/test_py_module.py
@@ -6,6 +6,7 @@
 # ---------------------------------------------------------------------
 
 # Python modules
+import importlib
 import os
 import ast
 from typing import Iterable
@@ -72,7 +73,7 @@ def iter_init() -> Iterable[Path]:
 @pytest.mark.parametrize("module", iter_py_modules())
 def test_import(module: str) -> None:
     try:
-        m = __import__(module, {}, {}, "*")
+        m = importlib.import_module(module)
         assert m
     except (ImportError, ModuleNotFoundError, NotImplementedError) as e:
         if _allow_xfail(module):


### PR DESCRIPTION
Sweep the remaining `__import__()` calls across 20 files and replace them with the modern `importlib.import_module()` equivalent.

### Key changes
- Add `import importlib` to each affected module
- Replace all 23 `__import__(X, {}, {}, fromlist)` patterns with `importlib.import_module(X)`
- No behavioral change — `fromlist` parameter was only used to ensure leaf-module returns for dotted paths, which `importlib.import_module()` does unconditionally