### PR TITLE
Fix KeyError in Cisco.IOS confdb normalizer for encrypted SNMP community

### DIFF
--- a/sa/profiles/Cisco/IOS/confdb/normalizer.py
+++ b/sa/profiles/Cisco/IOS/confdb/normalizer.py
@@ -41,8 +41,15 @@ class CiscoIOSNormalizer(BaseNormalizer):
 
     @match("snmp-server", "community", ANY, ANY, ANY)
     def normalize_snmp_protocol(self, tokens):
+        if tokens[2] == "7":
+            community = tokens[3]
+            level = tokens[4]
+        else:
+            community = tokens[2]
+            level = tokens[3]
         yield self.make_snmp_community_level(
-            community=tokens[2], level={"RO": "read-only", "RW": "read-write"}[tokens[3]]
+            community=community,
+            level={"RO": "read-only", "RW": "read-write"}[level],
         )
 
     @match("vlan", "database", "vlan", REST)


### PR DESCRIPTION
normalize_snmp_protocol assumed tokens[2]/tokens[3] were always the community string and access level ("RO"/"RW"). This broke on devices using encrypted (type 7) SNMP communities, e.g.:

    snmp-server community 7 <encrypted-string> RO

where tokens[2] is the encryption type marker "7", tokens[3] is the encrypted community string, and tokens[4] is the actual access level. The old code tried to look up the encrypted string as a dict key, raising KeyError.

Now detects the "7" marker and shifts community/level accordingly.