### PR TITLE
noc.core.hash: docstrings and typing

### DIFF
--- a/core/hash.py
+++ b/core/hash.py
@@ -1,42 +1,80 @@
 # ----------------------------------------------------------------------
 # Fast hash function
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
 # Python modules
 import struct
+from typing import Any
 
 # Third-party modules
 from siphash24 import siphash24
-from typing import Any
+from bson import ObjectId
+
 
 # NOC modules
-from noc.core.comp import smart_text, smart_bytes
+from noc.core.comp import smart_text
 
 SIPHASH_SEED = b"\x00" * 16
 hash_fmt = struct.Struct("!q")
 
 
-def hash_str(value: Any) -> str:
+def hash_str(value: str | ObjectId | int) -> bytes:
+    """Calculate SipHash digest for a value.
+
+    The value is converted to a string representation before hashing.
+    The function returns the raw 64-bit hash digest.
+
+    Args:
+        value: Value to calculate the hash for.
+
+    Returns:
+        Raw hash digest as bytes.
     """
-    Calculate integer hash of value
+    return siphash24(smart_text(value).encode(), key=SIPHASH_SEED).digest()
 
-    :param value: String
-    :return: Hashed string
+
+def hash_int(value: str | ObjectId | int) -> int:
+    """Calculate integer hash for a value.
+
+    The SipHash digest is converted into a signed 64-bit integer.
+
+    Args:
+        value: Value to calculate the hash for.
+
+    Returns:
+        Hash value as an integer.
     """
-    return siphash24(smart_bytes(smart_text(value)), key=SIPHASH_SEED).digest()
-
-
-def hash_int(value: Any) -> int:
     return hash_fmt.unpack(hash_str(value))[0]
 
 
 def dict_hash_int(d: dict[str, Any]) -> int:
-    r = ["%s=%s" % (k, d[k]) for k in sorted(d)]
+    """Calculate deterministic integer hash for a dictionary.
+
+    Dictionary keys are sorted before hashing to ensure that dictionaries
+    with the same content produce the same hash regardless of key order.
+
+    Args:
+        d: Dictionary to calculate the hash for.
+
+    Returns:
+        Hash value as an integer.
+    """
+    r = [f"{k}={d[k]}" for k in sorted(d)]
     return hash_int(",".join(r))
 
 
-def dict_hash_int_args(**kwargs):
+def dict_hash_int_args(**kwargs: Any) -> int:
+    """Calculate deterministic integer hash for keyword arguments.
+
+    This is a convenience wrapper around :func:`dict_hash_int`.
+
+    Args:
+        **kwargs: Values to include in the hash calculation.
+
+    Returns:
+        Hash value as an integer.
+    """
     return dict_hash_int(kwargs)


### PR DESCRIPTION
Add proper type annotations and Google-style docstrings to `noc.core.hash`, a module containing SipHash-based utility functions used across the codebase.

### Key Changes

- Narrow `hash_str` type signature from `Any -> str` to `str | ObjectId | int -> bytes` (previous return type was incorrect — `.digest()` always returns bytes)
- Add typed annotations for `hash_int`, `dict_hash_int`, and `dict_hash_int_args`
- Replace format-string with f-string (`f"{k}={d[k]}"`) per UP032 linting rule
- Replace `smart_bytes(smart_text(value))` with `smart_text(value).encode()` idiom
- Remove unused `smart_bytes` import; add explicit `bson.ObjectId` import
- Update copyright year to 2026

### Notable Implementation Details

- Return type of `hash_str` corrected from `str` (stale/wrong) to `bytes` — this is a documentation fix only, runtime behavior unchanged as `siphash24().digest()` always returned bytes
- Only external caller (`services/card/cards/interfacepath.py`) already treats the result as bytes via `codecs.encode()`
