### PR TITLE
migrations: Use .format() or f-strings

### DIFF
--- a/cm/migrations/0005_split_object_data.py
+++ b/cm/migrations/0005_split_object_data.py
@@ -53,4 +53,4 @@ class Migration(BaseMigration):
             elif handler_class_name == "prefix-list":
                 self.db.execute("INSERT INTO cm_prefixlist(repo_path) VALUES(%s)", [repo_path])
             else:
-                raise Exception("Unsupported handler_class_name='%s'" % handler_class_name)
+                raise Exception(f"Unsupported handler_class_name='{handler_class_name}'")

--- a/cm/migrations/0007_last_modified.py
+++ b/cm/migrations/0007_last_modified.py
@@ -25,16 +25,16 @@ class Migration(BaseMigration):
         repo_root = config.path.repo
         for ot in TYPES:
             self.db.add_column(
-                "cm_%s" % ot,
+                f"cm_{ot}",
                 "last_modified",
                 models.DateTimeField("Last Modified", blank=True, null=True),
             )
             if repo_root:
                 repo = os.path.join(repo_root, TYPES[ot])
-                for id, repo_path in self.db.execute("SELECT id,repo_path FROM cm_%s" % ot):
+                for id, repo_path in self.db.execute(f"SELECT id,repo_path FROM cm_{ot}"):
                     path = os.path.join(repo, repo_path)
                     if os.path.exists(path):
                         lm = datetime.datetime.fromtimestamp(os.stat(path)[stat.ST_MTIME])
                         self.db.execute(
-                            "UPDATE cm_%s SET last_modified=%%s WHERE id=%%s" % ot, [lm, id]
+                            f"UPDATE cm_{ot} SET last_modified=%s WHERE id=%s", [lm, id]
                         )

--- a/cm/migrations/0009_access_and_notify.py
+++ b/cm/migrations/0009_access_and_notify.py
@@ -46,12 +46,12 @@ class Migration(BaseMigration):
 
         for ot in OBJECT_TYPES:
             self.db.add_column(
-                "cm_%s" % ot,
+                f"cm_{ot}",
                 "location",
                 models.ForeignKey(ObjectLocation, null=True, blank=True, on_delete=models.CASCADE),
             )
-            self.db.execute("UPDATE cm_%s SET location_id=%%s" % ot, [loc_id])
-            self.db.execute("ALTER TABLE cm_%s ALTER location_id SET NOT NULL" % ot)
+            self.db.execute(f"UPDATE cm_{ot} SET location_id=%s", [loc_id])
+            self.db.execute(f"ALTER TABLE cm_{ot} ALTER location_id SET NOT NULL")
 
         # Mock Models
         ObjectCategory = self.db.mock_model(

--- a/cm/migrations/0011_clean_up_config.py
+++ b/cm/migrations/0011_clean_up_config.py
@@ -33,7 +33,7 @@ class Migration(BaseMigration):
             self.db.delete_column("cm_config", column)
         for table in ["cm_config", "cm_rpsl", "cm_dns", "cm_prefixlist"]:
             self.db.delete_column(table, "location_id")
-            self.db.delete_table("%s_categories" % table)
+            self.db.delete_table(f"{table}_categories")
         self.db.delete_table("cm_object_categories")
         self.db.delete_table("cm_objectaccess")
         self.db.execute("DELETE FROM cm_objectcategory")

--- a/dns/migrations/0003_dnszonerecordtype_initial_data.py
+++ b/dns/migrations/0003_dnszonerecordtype_initial_data.py
@@ -58,7 +58,7 @@ class Migration(BaseMigration):
                 continue
             rt += [(rtype, is_visible)]
         if rt:
-            print("Creating DNS Zone record types: %s" % ", ".join(sorted([x[0] for x in rt])))
+            print("Creating DNS Zone record types: {}".format(", ".join(sorted([x[0] for x in rt]))))
             for rtype, is_visible in rt:
                 self.db.execute(
                     "INSERT INTO dns_dnszonerecordtype(type, is_visible) VALUES(%s, %s)",

--- a/dns/migrations/0003_dnszonerecordtype_initial_data.py
+++ b/dns/migrations/0003_dnszonerecordtype_initial_data.py
@@ -58,7 +58,9 @@ class Migration(BaseMigration):
                 continue
             rt += [(rtype, is_visible)]
         if rt:
-            print("Creating DNS Zone record types: {}".format(", ".join(sorted([x[0] for x in rt]))))
+            print(
+                "Creating DNS Zone record types: {}".format(", ".join(sorted([x[0] for x in rt])))
+            )
             for rtype, is_visible in rt:
                 self.db.execute(
                     "INSERT INTO dns_dnszonerecordtype(type, is_visible) VALUES(%s, %s)",

--- a/dns/migrations/0033_migrate_tags.py
+++ b/dns/migrations/0033_migrate_tags.py
@@ -20,10 +20,9 @@ class Migration(BaseMigration):
         # Migrate data
         for m in self.TAG_MODELS:
             self.db.execute(
-                """
-            UPDATE %s
+                f"""
+            UPDATE {m}
             SET tmp_tags = string_to_array(regexp_replace(tags, ',$', ''), ',')
             WHERE tags != ''
             """
-                % m
             )

--- a/dns/migrations/0034_finish_tag_migration.py
+++ b/dns/migrations/0034_finish_tag_migration.py
@@ -21,4 +21,4 @@ class Migration(BaseMigration):
             self.db.rename_column(m, "tmp_tags", "tags")
         # Create indexes
         for m in self.TAG_MODELS:
-            self.db.execute('CREATE INDEX x_%s_tags ON "%s" USING GIN("tags")' % (m, m))
+            self.db.execute(f'CREATE INDEX x_{m}_tags ON "{m}" USING GIN("tags")')

--- a/dns/migrations/0042_labels.py
+++ b/dns/migrations/0042_labels.py
@@ -39,21 +39,19 @@ class Migration(BaseMigration):
         # Migrate data
         for table, setting in self.TAG_MODELS:
             self.db.execute(
-                """
-                UPDATE %s
+                f"""
+                UPDATE {table}
                 SET labels = tags
-                WHERE tags is not NULL and tags <> '{}'
+                WHERE tags is not NULL and tags <> '{{}}'
                 """
-                % table
             )
             # Fill labels
             for (ll,) in self.db.execute(
-                """
+                f"""
                 SELECT DISTINCT labels
-                FROM %s
-                WHERE labels <> '{}'
+                FROM {table}
+                WHERE labels <> '{{}}'
                 """
-                % table
             ):
                 for name in ll:
                     labels[name].add(f"enable_{setting}")

--- a/inv/migrations/0009_merge_partno.py
+++ b/inv/migrations/0009_merge_partno.py
@@ -24,10 +24,10 @@ class Migration(BaseMigration):
             for k in om["data"]["asset"]:
                 if k.startswith("part_no") and k != "part_no":
                     part_no += [om["data"]["asset"][k]]
-                    uso["data.asset.%s" % k] = ""
+                    uso[f"data.asset.{k}"] = ""
                 elif k.startswith("order_part_no") and k != "order_part_no":
                     order_part_no += [om["data"]["asset"][k]]
-                    uso["data.asset.%s" % k] = ""
+                    uso[f"data.asset.{k}"] = ""
             if not part_no and not order_part_no:
                 continue
             if part_no:

--- a/inv/migrations/0019_thresholdprofiles.py
+++ b/inv/migrations/0019_thresholdprofiles.py
@@ -43,7 +43,7 @@ class Migration(BaseMigration):
                     tp = {"_id": tp_id}
                 # Fill profile
                 tp["name"] = "ip-%05d-%03d" % (next(current), n)
-                tp["description"] = "Migrated for interface profile '%s' metric '%s'" % (
+                tp["description"] = "Migrated for interface profile '{}' metric '{}'".format(
                     doc["name"],
                     metric["metric_type"],
                 )

--- a/ip/migrations/0002_plpgsql_triggers_and_functions.py
+++ b/ip/migrations/0002_plpgsql_triggers_and_functions.py
@@ -30,21 +30,19 @@ class Migration(BaseMigration):
 
     def has_column(self, table, name):
         return self.db.execute(
-            """SELECT COUNT(*)>0
+            f"""SELECT COUNT(*)>0
             FROM pg_attribute a JOIN pg_class p ON (p.oid=a.attrelid)
-            WHERE p.relname='%s'
-              AND a.attname='%s'
+            WHERE p.relname='{table}'
+              AND a.attname='{name}'
             """
-            % (table, name)
         )[0][0]
 
     def has_trigger(self, table, name):
         return self.db.execute(
-            """SELECT COUNT(*)>0
+            f"""SELECT COUNT(*)>0
             FROM pg_trigger t JOIN pg_class p ON (p.oid=t.tgrelid)
-            WHERE p.relname='%s'
-              AND t.tgname='%s'"""
-            % (table, name)
+            WHERE p.relname='{table}'
+              AND t.tgname='{name}'"""
         )[0][0]
 
 

--- a/ip/migrations/0022_drop_project.py
+++ b/ip/migrations/0022_drop_project.py
@@ -12,11 +12,10 @@ from noc.core.migration.base import BaseMigration
 class Migration(BaseMigration):
     def migrate_project(self, table):
         r = self.db.execute(
-            """
+            f"""
             SELECT COUNT(*)
-            FROM %s
+            FROM {table}
             WHERE project IS NOT NULL AND project != ''"""
-            % table
         )[0][0]
         if r:
             # Create custom field
@@ -31,10 +30,9 @@ class Migration(BaseMigration):
 
             # Move data
             self.db.execute(
-                """
-                ALTER TABLE %s RENAME project TO cust_project
+                f"""
+                ALTER TABLE {table} RENAME project TO cust_project
             """
-                % table
             )
         else:
             # Drop column

--- a/ip/migrations/0023_migrate_tags.py
+++ b/ip/migrations/0023_migrate_tags.py
@@ -22,10 +22,9 @@ class Migration(BaseMigration):
         # Migrate data
         for m in self.TAG_MODELS:
             self.db.execute(
-                """
-            UPDATE %s
+                f"""
+            UPDATE {m}
             SET tmp_tags = string_to_array(regexp_replace(tags, ',$', ''), ',')
             WHERE tags != ''
             """
-                % m
             )

--- a/ip/migrations/0024_finish_tag_migration.py
+++ b/ip/migrations/0024_finish_tag_migration.py
@@ -21,4 +21,4 @@ class Migration(BaseMigration):
             self.db.rename_column(m, "tmp_tags", "tags")
         # Create indexes
         for m in self.TAG_MODELS:
-            self.db.execute('CREATE INDEX x_%s_tags ON "%s" USING GIN("tags")' % (m, m))
+            self.db.execute(f'CREATE INDEX x_{m}_tags ON "{m}" USING GIN("tags")')

--- a/ip/migrations/0031_prefixprofile.py
+++ b/ip/migrations/0031_prefixprofile.py
@@ -42,8 +42,8 @@ class Migration(BaseMigration):
             p_id = bson.ObjectId()
             p = {
                 "_id": p_id,
-                "name": "Style %s" % style_id,
-                "description": "Auto-converted for style %s" % style_id,
+                "name": f"Style {style_id}",
+                "description": f"Auto-converted for style {style_id}",
                 "workflow": wf,
                 "style": style_id,
                 "bi_id": bson.int64.Int64(bi_hash(p_id)),
@@ -61,11 +61,11 @@ class Migration(BaseMigration):
         # Migrate profile styles
         for style_id in style_profiles:
             if style_id:
-                cond = "style_id = %s" % style_id
+                cond = f"style_id = {style_id}"
             else:
                 cond = "style_id IS NULL"
             self.db.execute(
-                "UPDATE ip_prefix SET profile = %%s WHERE %s" % cond,
+                f"UPDATE ip_prefix SET profile = %s WHERE {cond}",
                 [str(style_profiles[style_id])],
             )
         # Make Prefix.profile not nullable

--- a/ip/migrations/0032_addressprofile.py
+++ b/ip/migrations/0032_addressprofile.py
@@ -42,8 +42,8 @@ class Migration(BaseMigration):
             p_id = bson.ObjectId()
             p = {
                 "_id": p_id,
-                "name": "Style %s" % style_id,
-                "description": "Auto-converted for style %s" % style_id,
+                "name": f"Style {style_id}",
+                "description": f"Auto-converted for style {style_id}",
                 "workflow": wf,
                 "style": style_id,
                 "bi_id": bson.int64.Int64(bi_hash(p_id)),
@@ -61,11 +61,11 @@ class Migration(BaseMigration):
         # Migrate profile styles
         for style_id in style_profiles:
             if style_id:
-                cond = "style_id = %s" % style_id
+                cond = f"style_id = {style_id}"
             else:
                 cond = "style_id IS NULL"
             self.db.execute(
-                "UPDATE ip_address SET profile = %%s WHERE %s" % cond,
+                f"UPDATE ip_address SET profile = %s WHERE {cond}",
                 [str(style_profiles[style_id])],
             )
         # Make Prefix.profile not nullable

--- a/ip/migrations/0033_vrf_profile.py
+++ b/ip/migrations/0033_vrf_profile.py
@@ -48,9 +48,9 @@ class Migration(BaseMigration):
             p_id = bson.ObjectId()
             p = {
                 "_id": p_id,
-                "name": "VRF Style %s" % style_id,
+                "name": f"VRF Style {style_id}",
                 "type": "vrf",
-                "description": "Auto-converted for VRF style %s" % style_id,
+                "description": f"Auto-converted for VRF style {style_id}",
                 "workflow": wf,
                 "style": style_id,
                 "default_prefix_profile": default_prefix_profile,
@@ -67,11 +67,11 @@ class Migration(BaseMigration):
         # Migrate profile styles
         for style_id in style_profiles:
             if style_id:
-                cond = "style_id = %s" % style_id
+                cond = f"style_id = {style_id}"
             else:
                 cond = "style_id IS NULL"
             self.db.execute(
-                "UPDATE ip_vrf SET profile = %%s WHERE %s" % cond, [str(style_profiles[style_id])]
+                f"UPDATE ip_vrf SET profile = %s WHERE {cond}", [str(style_profiles[style_id])]
             )
         # Make Prefix.profile not nullable
         self.db.execute("ALTER TABLE ip_vrf ALTER profile SET NOT NULL")

--- a/ip/migrations/0047_labels.py
+++ b/ip/migrations/0047_labels.py
@@ -49,21 +49,19 @@ class Migration(BaseMigration):
         # Migrate data
         for table, setting in self.TAG_MODELS:
             self.db.execute(
-                """
-                UPDATE %s
+                f"""
+                UPDATE {table}
                 SET labels = tags
-                WHERE tags is not NULL and tags <> '{}'
+                WHERE tags is not NULL and tags <> '{{}}'
                 """
-                % table
             )
             # Fill labels
             for (ll,) in self.db.execute(
-                """
+                f"""
                 SELECT DISTINCT labels
-                FROM %s
-                WHERE labels <> '{}'
+                FROM {table}
+                WHERE labels <> '{{}}'
                 """
-                % table
             ):
                 for name in ll:
                     labels[name].add(f"enable_{setting}")

--- a/ip/migrations/0049_ip_remote_system_integration.py
+++ b/ip/migrations/0049_ip_remote_system_integration.py
@@ -34,20 +34,19 @@ class Migration(BaseMigration):
             self.db.add_column(table, "bi_id", models.BigIntegerField(null=True, blank=True))
         # Set BI_ID
         for table in TABLES:
-            rows = self.db.execute("SELECT id FROM %s WHERE bi_id IS NULL" % table)
+            rows = self.db.execute(f"SELECT id FROM {table} WHERE bi_id IS NULL")
             values = ["(%d, %d)" % (r[0], bi_hash(r[0])) for r in rows]
             while values:
                 chunk, values = values[:PG_CHUNK], values[PG_CHUNK:]
                 self.db.execute(
                     """
-                    UPDATE %s AS t
+                    UPDATE {} AS t
                     SET
                       bi_id = c.bi_id
                     FROM (
                       VALUES
-                      %s
+                      {}
                     ) AS c(id, bi_id)
                     WHERE c.id = t.id
-                    """
-                    % (table, ",\n".join(chunk))
+                    """.format(table, ",\n".join(chunk))
                 )

--- a/kb/migrations/0010_labels.py
+++ b/kb/migrations/0010_labels.py
@@ -39,21 +39,19 @@ class Migration(BaseMigration):
         # Migrate data
         for table, setting in self.TAG_MODELS:
             self.db.execute(
-                """
-                UPDATE %s
+                f"""
+                UPDATE {table}
                 SET labels = tags
-                WHERE tags is not NULL and tags <> '{}'
+                WHERE tags is not NULL and tags <> '{{}}'
                 """
-                % table
             )
             # Fill labels
             for (ll,) in self.db.execute(
-                """
+                f"""
                 SELECT DISTINCT labels
-                FROM %s
-                WHERE labels <> '{}'
+                FROM {table}
+                WHERE labels <> '{{}}'
                 """
-                % table
             ):
                 for name in ll:
                     labels[name].add(f"enable_{setting}")

--- a/main/migrations/0048_drop_django_tagging.py
+++ b/main/migrations/0048_drop_django_tagging.py
@@ -12,5 +12,5 @@ from noc.core.migration.base import BaseMigration
 class Migration(BaseMigration):
     def migrate(self) -> None:
         for t in ["tagging_taggeditem", "tagging_tag"]:
-            if self.db.execute("SELECT COUNT(*) FROM pg_class WHERE relname='%s'" % t)[0][0] == 1:
+            if self.db.execute(f"SELECT COUNT(*) FROM pg_class WHERE relname='{t}'")[0][0] == 1:
                 self.db.delete_table(t)

--- a/main/migrations/0049_update_tags.py
+++ b/main/migrations/0049_update_tags.py
@@ -37,12 +37,11 @@ class Migration(BaseMigration):
             "peer_peer",
         ]:
             for tag, count in self.db.execute(
-                """
+                f"""
                     SELECT unnest(tags), COUNT(*)
-                    FROM %s
+                    FROM {m}
                     GROUP BY 1
                     """
-                % m
             ):
                 c.update_many(
                     {"tag": tag},

--- a/main/migrations/0052_audit_data.py
+++ b/main/migrations/0052_audit_data.py
@@ -72,7 +72,7 @@ class Migration(BaseMigration):
                 o = {
                     "timestamp": timestamp,
                     "user": user_cache[user_id],
-                    "model_id": "%s.%s" % (db_table.split("_")[0], model),
+                    "model_id": "{}.{}".format(db_table.split("_")[0], model),
                     "op": op,
                     "expires": timestamp + delta,
                 }
@@ -103,7 +103,7 @@ class Migration(BaseMigration):
                             continue
                         changes += [{"field": k, "old": None, "new": v}]
                 else:
-                    raise ValueError("Invalid op '%s'" % op)
+                    raise ValueError(f"Invalid op '{op}'")
                 o["changes"] = changes
                 bulk += [InsertOne(o)]
                 last_id = a_id

--- a/main/migrations/0054_migrate_pyrule.py
+++ b/main/migrations/0054_migrate_pyrule.py
@@ -25,7 +25,7 @@ class Migration(BaseMigration):
 
     def migrate(self) -> None:
         for name, iface in self.PMAP:
-            handler = "noc.solutions.noc.default.pyrules.%s.%s" % (name, name)
+            handler = f"noc.solutions.noc.default.pyrules.{name}.{name}"
             if self.db.execute("SELECT COUNT(*) FROM main_pyrule WHERE name = %s", [name])[0][0]:
                 # Pyrule exists, change handler
                 self.db.execute(
@@ -36,5 +36,5 @@ class Migration(BaseMigration):
                 self.db.execute(
                     """INSERT INTO main_pyrule(name, interface, handler, description, changed)
                     VALUES(%s, %s, %s, %s, now())""",
-                    [name, iface, handler, "%s solution" % handler],
+                    [name, iface, handler, f"{handler} solution"],
                 )

--- a/main/migrations/0060_create_default_labels.py
+++ b/main/migrations/0060_create_default_labels.py
@@ -84,11 +84,10 @@ class Migration(BaseMigration):
                 ]
             # Fill labels
             for (name,) in self.db.execute(
-                """
+                f"""
                 SELECT DISTINCT name
-                FROM %s
+                FROM {table}
                 """
-                % table
             ):
                 label = f"noc::{scope}::{name}::="
                 if label not in current_labels:

--- a/peer/migrations/0036_migrate_tags.py
+++ b/peer/migrations/0036_migrate_tags.py
@@ -20,10 +20,9 @@ class Migration(BaseMigration):
         # Migrate data
         for m in self.TAG_MODELS:
             self.db.execute(
-                """
-            UPDATE %s
+                f"""
+            UPDATE {m}
             SET tmp_tags = string_to_array(regexp_replace(tags, ',$', ''), ',')
             WHERE tags != ''
             """
-                % m
             )

--- a/peer/migrations/0037_finish_tag_migration.py
+++ b/peer/migrations/0037_finish_tag_migration.py
@@ -21,4 +21,4 @@ class Migration(BaseMigration):
             self.db.rename_column(m, "tmp_tags", "tags")
         # Create indexes
         for m in self.TAG_MODELS:
-            self.db.execute('CREATE INDEX x_%s_tags ON "%s" USING GIN("tags")' % (m, m))
+            self.db.execute(f'CREATE INDEX x_{m}_tags ON "{m}" USING GIN("tags")')

--- a/peer/migrations/0043_labels.py
+++ b/peer/migrations/0043_labels.py
@@ -39,21 +39,19 @@ class Migration(BaseMigration):
         # Migrate data
         for table, setting in self.TAG_MODELS:
             self.db.execute(
-                """
-                UPDATE %s
+                f"""
+                UPDATE {table}
                 SET labels = tags
-                WHERE tags is not NULL and tags <> '{}'
+                WHERE tags is not NULL and tags <> '{{}}'
                 """
-                % table
             )
             # Fill labels
             for (ll,) in self.db.execute(
-                """
+                f"""
                 SELECT DISTINCT labels
-                FROM %s
-                WHERE labels <> '{}'
+                FROM {table}
+                WHERE labels <> '{{}}'
                 """
-                % table
             ):
                 for name in ll:
                     labels[name].add(f"enable_{setting}")

--- a/pm/migrations/0008_set_probe_credentials.py
+++ b/pm/migrations/0008_set_probe_credentials.py
@@ -40,10 +40,10 @@ class Migration(BaseMigration):
         if not os.path.exists("etc/noc-probe.conf"):
             return
         # Create user and set config
-        os.system("./scripts/set-conf.py etc/noc-probe.conf autoconf user %s" % PROBEUSER)
+        os.system(f"./scripts/set-conf.py etc/noc-probe.conf autoconf user {PROBEUSER}")
         r = os.system(
-            "PW=`./noc user --add --username=%s --email=test@example.com --template=probe --pwgen` &&"
-            "./scripts/set-conf.py etc/noc-probe.conf autoconf passwd $PW" % PROBEUSER
+            f"PW=`./noc user --add --username={PROBEUSER} --email=test@example.com --template=probe --pwgen` &&"
+            "./scripts/set-conf.py etc/noc-probe.conf autoconf passwd $PW"
         )
         if r != 0:
             import sys

--- a/pm/migrations/0011_migrate_handlers.py
+++ b/pm/migrations/0011_migrate_handlers.py
@@ -49,7 +49,7 @@ class Migration(BaseMigration):
                     "_id": h_id,
                     "handler": handler,
                     "name": handler,
-                    "description": "Migrated %s %s" % ("thresholdprofiles", handler),
+                    "description": "Migrated {} {}".format("thresholdprofiles", handler),
                     HTYPE.get(h_type): True,
                 }
                 h_coll.insert_one(h_data)

--- a/project/migrations/0004_set_bi_id.py
+++ b/project/migrations/0004_set_bi_id.py
@@ -15,21 +15,20 @@ PG_CHUNK = 500
 class Migration(BaseMigration):
     def migrate(self) -> None:
         table = "project_project"
-        rows = self.db.execute("SELECT id FROM %s WHERE bi_id IS NULL" % table)
+        rows = self.db.execute(f"SELECT id FROM {table} WHERE bi_id IS NULL")
         values = ["(%d, %d)" % (r[0], bi_hash(r[0])) for r in rows]
         while values:
             chunk, values = values[:PG_CHUNK], values[PG_CHUNK:]
             self.db.execute(
                 """
-                UPDATE %s AS t
+                UPDATE {} AS t
                 SET
                   bi_id = c.bi_id
                 FROM (
                   VALUES
-                  %s
+                  {}
                 ) AS c(id, bi_id)
                 WHERE c.id = t.id
-                """
-                % (table, ",\n".join(chunk))
+                """.format(table, ",\n".join(chunk))
             )
-        self.db.execute("ALTER TABLE %s ALTER bi_id SET NOT NULL" % table)
+        self.db.execute(f"ALTER TABLE {table} ALTER bi_id SET NOT NULL")

--- a/sa/migrations/0020_save_useraccess.py
+++ b/sa/migrations/0020_save_useraccess.py
@@ -22,7 +22,7 @@ class Migration(BaseMigration):
                 VALUES(%s,%s,%s)""",
                 [
                     name,
-                    "Auto created from (%s,%s,%s)" % (user_id, administrative_domain_id, group_id),
+                    f"Auto created from ({user_id},{administrative_domain_id},{group_id})",
                     administrative_domain_id,
                 ],
             )

--- a/sa/migrations/0055_object_profile_topology_discovery.py
+++ b/sa/migrations/0055_object_profile_topology_discovery.py
@@ -19,16 +19,16 @@ class Migration(BaseMigration):
         for d in self.d_types:
             self.db.add_column(
                 "sa_managedobjectprofile",
-                "enable_%s_discovery" % d,
+                f"enable_{d}_discovery",
                 models.BooleanField("", default=True),
             )
             self.db.add_column(
                 "sa_managedobjectprofile",
-                "%s_discovery_min_interval" % d,
+                f"{d}_discovery_min_interval",
                 models.IntegerField("", default=600),
             )
             self.db.add_column(
                 "sa_managedobjectprofile",
-                "%s_discovery_max_interval" % d,
+                f"{d}_discovery_max_interval",
                 models.IntegerField("", default=86400),
             )

--- a/sa/migrations/0057_managed_object_profile_rep.py
+++ b/sa/migrations/0057_managed_object_profile_rep.py
@@ -19,16 +19,16 @@ class Migration(BaseMigration):
         for d in self.d_types:
             self.db.add_column(
                 "sa_managedobjectprofile",
-                "enable_%s_discovery" % d,
+                f"enable_{d}_discovery",
                 models.BooleanField("", default=True),
             )
             self.db.add_column(
                 "sa_managedobjectprofile",
-                "%s_discovery_min_interval" % d,
+                f"{d}_discovery_min_interval",
                 models.IntegerField("", default=600),
             )
             self.db.add_column(
                 "sa_managedobjectprofile",
-                "%s_discovery_max_interval" % d,
+                f"{d}_discovery_max_interval",
                 models.IntegerField("", default=86400),
             )

--- a/sa/migrations/0058_managed_object_profile_bfd.py
+++ b/sa/migrations/0058_managed_object_profile_bfd.py
@@ -19,16 +19,16 @@ class Migration(BaseMigration):
         for d in self.d_types:
             self.db.add_column(
                 "sa_managedobjectprofile",
-                "enable_%s_discovery" % d,
+                f"enable_{d}_discovery",
                 models.BooleanField("", default=True),
             )
             self.db.add_column(
                 "sa_managedobjectprofile",
-                "%s_discovery_min_interval" % d,
+                f"{d}_discovery_min_interval",
                 models.IntegerField("", default=600),
             )
             self.db.add_column(
                 "sa_managedobjectprofile",
-                "%s_discovery_max_interval" % d,
+                f"{d}_discovery_max_interval",
                 models.IntegerField("", default=86400),
             )

--- a/sa/migrations/0059_managed_object_profile_udld.py
+++ b/sa/migrations/0059_managed_object_profile_udld.py
@@ -19,16 +19,16 @@ class Migration(BaseMigration):
         for d in self.d_types:
             self.db.add_column(
                 "sa_managedobjectprofile",
-                "enable_%s_discovery" % d,
+                f"enable_{d}_discovery",
                 models.BooleanField("", default=True),
             )
             self.db.add_column(
                 "sa_managedobjectprofile",
-                "%s_discovery_min_interval" % d,
+                f"{d}_discovery_min_interval",
                 models.IntegerField("", default=600),
             )
             self.db.add_column(
                 "sa_managedobjectprofile",
-                "%s_discovery_max_interval" % d,
+                f"{d}_discovery_max_interval",
                 models.IntegerField("", default=86400),
             )

--- a/sa/migrations/0062_migrate_tags.py
+++ b/sa/migrations/0062_migrate_tags.py
@@ -20,10 +20,9 @@ class Migration(BaseMigration):
         # Migrate data
         for m in self.TAG_MODELS:
             self.db.execute(
-                """
-            UPDATE %s
+                f"""
+            UPDATE {m}
             SET tmp_tags = string_to_array(regexp_replace(tags, ',$', ''), ',')
             WHERE tags != ''
             """
-                % m
             )

--- a/sa/migrations/0063_finish_tag_migration.py
+++ b/sa/migrations/0063_finish_tag_migration.py
@@ -21,4 +21,4 @@ class Migration(BaseMigration):
             self.db.rename_column(m, "tmp_tags", "tags")
         # Create indexes
         for m in self.TAG_MODELS:
-            self.db.execute('CREATE INDEX x_%s_tags ON "%s" USING GIN("tags")' % (m, m))
+            self.db.execute(f'CREATE INDEX x_{m}_tags ON "{m}" USING GIN("tags")')

--- a/sa/migrations/0067_activator_prefixtable.py
+++ b/sa/migrations/0067_activator_prefixtable.py
@@ -31,7 +31,7 @@ class Migration(BaseMigration):
         )
         # Migrate data
         for id, name, ip, to_ip in self.db.execute("SELECT id, name, ip, to_ip FROM sa_activator"):
-            pt_name = "Activator::%s" % name
+            pt_name = f"Activator::{name}"
             self.db.execute(
                 """
                 INSERT INTO main_prefixtable(name)

--- a/sa/migrations/0070_managed_object_profile_vlan.py
+++ b/sa/migrations/0070_managed_object_profile_vlan.py
@@ -19,16 +19,16 @@ class Migration(BaseMigration):
         for d in self.d_types:
             self.db.add_column(
                 "sa_managedobjectprofile",
-                "enable_%s_discovery" % d,
+                f"enable_{d}_discovery",
                 models.BooleanField("", default=False),
             )
             self.db.add_column(
                 "sa_managedobjectprofile",
-                "%s_discovery_min_interval" % d,
+                f"{d}_discovery_min_interval",
                 models.IntegerField("", default=600),
             )
             self.db.add_column(
                 "sa_managedobjectprofile",
-                "%s_discovery_max_interval" % d,
+                f"{d}_discovery_max_interval",
                 models.IntegerField("", default=86400),
             )

--- a/sa/migrations/0074_migrate_notifications.py
+++ b/sa/migrations/0074_migrate_notifications.py
@@ -39,7 +39,7 @@ class Migration(BaseMigration):
                 domain_name = self.db.execute(
                     "SELECT name FROM sa_administrativedomain WHERE id = %s", [domain]
                 )[0][0]
-                s_name = "~~~ON~~~ %s" % domain_name
+                s_name = f"~~~ON~~~ {domain_name}"
                 self.db.execute(
                     """
                 INSERT INTO sa_managedobjectselector(
@@ -47,7 +47,7 @@ class Migration(BaseMigration):
                     is_enabled, filter_administrative_domain_id)
                 VALUES(%s, %s, %s, %s)
                 """,
-                    [s_name, "Auto-generated selector for %s domain" % domain_name, True, domain],
+                    [s_name, f"Auto-generated selector for {domain_name} domain", True, domain],
                 )
                 selector_id = self.db.execute(
                     "SELECT id FROM sa_managedobjectselector WHERE name = %s", [s_name]

--- a/sa/migrations/0075_managedobjectprofile_oam_discovery.py
+++ b/sa/migrations/0075_managedobjectprofile_oam_discovery.py
@@ -19,16 +19,16 @@ class Migration(BaseMigration):
         for d in self.d_types:
             self.db.add_column(
                 "sa_managedobjectprofile",
-                "enable_%s_discovery" % d,
+                f"enable_{d}_discovery",
                 models.BooleanField("", default=False),
             )
             self.db.add_column(
                 "sa_managedobjectprofile",
-                "%s_discovery_min_interval" % d,
+                f"{d}_discovery_min_interval",
                 models.IntegerField("", default=600),
             )
             self.db.add_column(
                 "sa_managedobjectprofile",
-                "%s_discovery_max_interval" % d,
+                f"{d}_discovery_max_interval",
                 models.IntegerField("", default=86400),
             )

--- a/sa/migrations/0078_managedobjectprofile_asset_discovery.py
+++ b/sa/migrations/0078_managedobjectprofile_asset_discovery.py
@@ -19,16 +19,16 @@ class Migration(BaseMigration):
         for d in self.d_types:
             self.db.add_column(
                 "sa_managedobjectprofile",
-                "enable_%s_discovery" % d,
+                f"enable_{d}_discovery",
                 models.BooleanField("", default=False),
             )
             self.db.add_column(
                 "sa_managedobjectprofile",
-                "%s_discovery_min_interval" % d,
+                f"{d}_discovery_min_interval",
                 models.IntegerField("", default=600),
             )
             self.db.add_column(
                 "sa_managedobjectprofile",
-                "%s_discovery_max_interval" % d,
+                f"{d}_discovery_max_interval",
                 models.IntegerField("", default=86400),
             )

--- a/sa/migrations/0125_access_administrative_domain.py
+++ b/sa/migrations/0125_access_administrative_domain.py
@@ -25,4 +25,4 @@ class Migration(BaseMigration):
                     AdministrativeDomain, null=True, blank=True, on_delete=models.CASCADE
                 ),
             )
-            self.db.execute("ALTER TABLE %s ALTER selector_id DROP NOT NULL" % t)
+            self.db.execute(f"ALTER TABLE {t} ALTER selector_id DROP NOT NULL")

--- a/sa/migrations/0141_managedobject_address_cust_index.py
+++ b/sa/migrations/0141_managedobject_address_cust_index.py
@@ -28,7 +28,7 @@ class Migration(BaseMigration):
                           WHERE tablename='sa_managedobject' AND indexname='x_managedobject_addressprefix'"""
         )
         if i:
-            self.db.execute("DROP INDEX %s" % "x_managedobject_addressprefix")
+            self.db.execute("DROP INDEX {}".format("x_managedobject_addressprefix"))
 
         self.db.execute(func)
         self.db.execute(

--- a/sa/migrations/0160_set_bi_id.py
+++ b/sa/migrations/0160_set_bi_id.py
@@ -28,22 +28,21 @@ class Migration(BaseMigration):
         ]
         # Update postgresql tables
         for table in MODELS:
-            rows = self.db.execute("SELECT id FROM %s WHERE bi_id IS NULL" % table)
+            rows = self.db.execute(f"SELECT id FROM {table} WHERE bi_id IS NULL")
             values = ["(%d, %d)" % (r[0], bi_hash(r[0])) for r in rows]
             while values:
                 chunk, values = values[:PG_CHUNK], values[PG_CHUNK:]
                 self.db.execute(
                     """
-                    UPDATE %s AS t
+                    UPDATE {} AS t
                     SET
                       bi_id = c.bi_id
                     FROM (
                       VALUES
-                      %s
+                      {}
                     ) AS c(id, bi_id)
                     WHERE c.id = t.id
-                    """
-                    % (table, ",\n".join(chunk))
+                    """.format(table, ",\n".join(chunk))
                 )
         # Update mongodb collections
         mdb = self.mongo_db
@@ -61,5 +60,5 @@ class Migration(BaseMigration):
                 coll.bulk_write(updates)
         # Alter bi_id fields and create indexes
         for table in MODELS:
-            self.db.execute("ALTER TABLE %s ALTER bi_id SET NOT NULL" % table)
+            self.db.execute(f"ALTER TABLE {table} ALTER bi_id SET NOT NULL")
             self.db.create_index(table, ["bi_id"], unique=True)

--- a/sa/migrations/0172_managedobject_config_handlers.py
+++ b/sa/migrations/0172_managedobject_config_handlers.py
@@ -45,10 +45,9 @@ class Migration(BaseMigration):
             ("config_validation_rule_id", "config_validation_handler"),
         ]:
             for row in self.db.execute(
-                """
-                    SELECT DISTINCT %s
-                    FROM sa_managedobject WHERE %s IS NOT NULL"""
-                % (old_field, old_field)
+                f"""
+                    SELECT DISTINCT {old_field}
+                    FROM sa_managedobject WHERE {old_field} IS NOT NULL"""
             ):
                 pyrule_id = row[0]
                 if not pyrule_id:
@@ -59,12 +58,11 @@ class Migration(BaseMigration):
                     handler = self.migrate_pyrule(new_coll, pyrule_id)
                     pmap[pyrule_id] = handler
                 self.db.execute(
-                    """
+                    f"""
                     UPDATE sa_managedobject
-                    SET %s = %%s
-                    WHERE %s = %%s
-                    """
-                    % (new_field, old_field),
+                    SET {new_field} = %s
+                    WHERE {old_field} = %s
+                    """,
                     [handler, pyrule_id],
                 )
             self.db.delete_column("sa_managedobject", old_field)
@@ -83,6 +81,6 @@ class Migration(BaseMigration):
         new_text = self.rx_strip_decorator.sub("", text)
         fn = match.group(1)
         new_name = "config.filter%d" % pyrule_id
-        handler = "noc.pyrules.%s.%s" % (new_name, fn)
+        handler = f"noc.pyrules.{new_name}.{fn}"
         coll.insert_one({"name": new_name, "source": new_text})
         return handler

--- a/sa/migrations/0189_managedobject_fill_fqdn.py
+++ b/sa/migrations/0189_managedobject_fill_fqdn.py
@@ -27,16 +27,14 @@ class Migration(BaseMigration):
                 """
                 UPDATE sa_managedobject
                 SET fqdn=address, address_resolution_policy='O'
-                WHERE id IN (%s)
-                """
-                % ",".join(fixes)
+                WHERE id IN ({})
+                """.format(",".join(fixes))
             )
         if dot_fixes:
             self.db.execute(
                 """
                 UPDATE sa_managedobject
                 SET fqdn=concat(address, '.'), address_resolution_policy='O'
-                WHERE id IN (%s)
-                """
-                % ",".join(dot_fixes)
+                WHERE id IN ({})
+                """.format(",".join(dot_fixes))
             )

--- a/sa/migrations/0192_thresholdprofiles.py
+++ b/sa/migrations/0192_thresholdprofiles.py
@@ -52,7 +52,7 @@ class Migration(BaseMigration):
                     tp = {"_id": tp_id}
                 # Fill profile
                 tp["name"] = "op14-%05d-%03d" % (next(current), n)
-                tp["description"] = "Migrated for interface profile '%s' metric '%s'" % (
+                tp["description"] = "Migrated for interface profile '{}' metric '{}'".format(
                     name,
                     metric["metric_type"],
                 )

--- a/sa/migrations/0198_migrate_handlers.py
+++ b/sa/migrations/0198_migrate_handlers.py
@@ -50,12 +50,11 @@ class Migration(BaseMigration):
     def migrate_handler(self, table, field, **kwargs):
         h_coll = self.mongo_db["handlers"]
         for mop_id, handler in self.db.execute(
+            f"""
+            SELECT id, {field}
+            FROM {table}
+            WHERE {field} IS NOT NULL
             """
-            SELECT id, %s
-            FROM %s
-            WHERE %s IS NOT NULL
-            """
-            % (field, table, field)
         ):
             # Create handler
             h_id = bson.ObjectId()
@@ -63,18 +62,17 @@ class Migration(BaseMigration):
                 "_id": h_id,
                 "handler": handler,
                 "name": handler,
-                "description": "Migrated %s's %s %s" % (table, field, handler),
+                "description": f"Migrated {table}'s {field} {handler}",
             }
             h_data.update(kwargs)
             h_coll.insert_one(h_data)
             # Migrate profile
             self.db.execute(
-                """
-                UPDATE %s
-                SET %s = %%s
-                WHERE %s = %%s
-                """
-                % (table, field, field),
+                f"""
+                UPDATE {table}
+                SET {field} = %s
+                WHERE {field} = %s
+                """,
                 [str(h_id), handler],
             )
-        self.db.execute("ALTER TABLE %s ALTER COLUMN %s TYPE CHAR(24)" % (table, field))
+        self.db.execute(f"ALTER TABLE {table} ALTER COLUMN {field} TYPE CHAR(24)")

--- a/sa/migrations/0213_labels.py
+++ b/sa/migrations/0213_labels.py
@@ -47,21 +47,19 @@ class Migration(BaseMigration):
         # Migrate data
         for table, setting in self.TAG_MODELS:
             self.db.execute(
-                """
-                UPDATE %s
+                f"""
+                UPDATE {table}
                 SET labels = tags
-                WHERE tags is not NULL and tags <> '{}'
+                WHERE tags is not NULL and tags <> '{{}}'
                 """
-                % table
             )
             # Fill labels
             for (ll,) in self.db.execute(
-                """
+                f"""
                 SELECT DISTINCT labels
-                FROM %s
-                WHERE labels <> '{}'
+                FROM {table}
+                WHERE labels <> '{{}}'
                 """
-                % table
             ):
                 for name in ll:
                     labels[name].add(f"enable_{setting}")

--- a/sa/migrations/0240_add_diagnostic_labels.py
+++ b/sa/migrations/0240_add_diagnostic_labels.py
@@ -66,7 +66,7 @@ class Migration(BaseMigration):
                  UPDATE sa_managedobject
                  SET diagnostics = diagnostics  #- %s  #- %s
                  """,
-            ["{%s}" % SNMPTRAP_DIAG, "{%s}" % SYSLOG_DIAG],
+            [f"{{{SNMPTRAP_DIAG}}}", f"{{{SYSLOG_DIAG}}}"],
         )
 
     def sync_labels(self, labels):

--- a/sla/migrations/0002_thresholdprofiles.py
+++ b/sla/migrations/0002_thresholdprofiles.py
@@ -49,7 +49,7 @@ class Migration(BaseMigration):
                     tp = {"_id": tp_id}
                 # Fill profile
                 tp["name"] = "sp-%05d-%03d" % (next(current), n)
-                tp["description"] = "Migrated for SLA profile '%s' metric '%s'" % (
+                tp["description"] = "Migrated for SLA profile '{}' metric '{}'".format(
                     doc["name"],
                     metric["metric_type"],
                 )

--- a/vc/migrations/0017_drop_project.py
+++ b/vc/migrations/0017_drop_project.py
@@ -12,11 +12,10 @@ from noc.core.migration.base import BaseMigration
 class Migration(BaseMigration):
     def migrate_project(self, table):
         r = self.db.execute(
-            """
+            f"""
             SELECT COUNT(*)
-            FROM %s
+            FROM {table}
             WHERE project IS NOT NULL AND project != ''"""
-            % table
         )[0][0]
         if r:
             # Create custom field
@@ -31,10 +30,9 @@ class Migration(BaseMigration):
 
             # Move data
             self.db.execute(
-                """
-                ALTER TABLE %s RENAME project TO cust_project
+                f"""
+                ALTER TABLE {table} RENAME project TO cust_project
             """
-                % table
             )
         else:
             # Drop column

--- a/vc/migrations/0021_migrate_tags.py
+++ b/vc/migrations/0021_migrate_tags.py
@@ -20,10 +20,9 @@ class Migration(BaseMigration):
         # Migrate data
         for m in self.TAG_MODELS:
             self.db.execute(
-                """
-            UPDATE %s
+                f"""
+            UPDATE {m}
             SET tmp_tags = string_to_array(regexp_replace(tags, ',$', ''), ',')
             WHERE tags != ''
             """
-                % m
             )

--- a/vc/migrations/0022_finish_tag_migration.py
+++ b/vc/migrations/0022_finish_tag_migration.py
@@ -21,4 +21,4 @@ class Migration(BaseMigration):
             self.db.rename_column(m, "tmp_tags", "tags")
         # Create indexes
         for m in self.TAG_MODELS:
-            self.db.execute('CREATE INDEX x_%s_tags ON "%s" USING GIN("tags")' % (m, m))
+            self.db.execute(f'CREATE INDEX x_{m}_tags ON "{m}" USING GIN("tags")')

--- a/vc/migrations/0025_labels.py
+++ b/vc/migrations/0025_labels.py
@@ -47,21 +47,19 @@ class Migration(BaseMigration):
         # Migrate data
         for table, setting in self.TAG_MODELS:
             self.db.execute(
-                """
-                UPDATE %s
+                f"""
+                UPDATE {table}
                 SET labels = tags
-                WHERE tags is not NULL and tags <> '{}'
+                WHERE tags is not NULL and tags <> '{{}}'
                 """
-                % table
             )
             # Fill labels
             for (ll,) in self.db.execute(
-                """
+                f"""
                 SELECT DISTINCT labels
-                FROM %s
-                WHERE labels <> '{}'
+                FROM {table}
+                WHERE labels <> '{{}}'
                 """
-                % table
             ):
                 for name in ll:
                     labels[name].add(f"enable_{setting}")


### PR DESCRIPTION
Large-scale refactoring: replace all `%` string formatting in migration modules with `.format()` or f-strings across 54 files in 10 apps (`+171/-203`)