### PR TITLE
services/web: Use .format() and f-strings

### DIFF
--- a/services/web/apps/aaa/modelprotectionprofile.py
+++ b/services/web/apps/aaa/modelprotectionprofile.py
@@ -35,7 +35,7 @@ class ModelProtectionProfileApplication(ExtDocApplication):
             model = get_model(model_id=model_id)
         except AssertionError:
             return self.render_json(
-                {"status": False, "message": "Not found model by id: %s" % model_id},
+                {"status": False, "message": f"Not found model by id: {model_id}"},
                 status=self.NOT_FOUND,
             )
         # Get links

--- a/services/web/apps/cm/reportlatestchanges.py
+++ b/services/web/apps/cm/reportlatestchanges.py
@@ -49,7 +49,7 @@ class ReportLatestChangesApplication(SimpleReport):
         self, request, repo="config", days=1, adm_domain=None, managed_object=None, **kwargs
     ):
         baseline = datetime.datetime.now() - datetime.timedelta(days=days)
-        coll = get_db()["noc.gridvcs.%s.files" % repo].with_options(
+        coll = get_db()[f"noc.gridvcs.{repo}.files"].with_options(
             read_preference=ReadPreference.SECONDARY_PREFERRED
         )
         pipeline = [

--- a/services/web/apps/dns/reportmissedreverse.py
+++ b/services/web/apps/dns/reportmissedreverse.py
@@ -19,7 +19,7 @@ class Reportreportmissedreverse(SimpleReport):
             n, m = p.split("/")
             n = n.split(".")[:-1]
             n.reverse()
-            return "%s.%s.%s.in-addr.arpa" % (n[0], n[1], n[2])
+            return f"{n[0]}.{n[1]}.{n[2]}.in-addr.arpa"
 
         vrf_id = VRF.get_global().id
         return self.from_query(

--- a/services/web/apps/fm/alarm/views.py
+++ b/services/web/apps/fm/alarm/views.py
@@ -120,7 +120,7 @@ class AlarmApplication(ExtApplication):
         for f in os.listdir("services/web/apps/fm/alarm/plugins/"):
             if not f.endswith(".py") or f == "base.py" or f.startswith("_"):
                 continue
-            mn = "noc.services.web.apps.fm.alarm.plugins.%s" % f[:-3]
+            mn = f"noc.services.web.apps.fm.alarm.plugins.{f[:-3]}"
             m = importlib.import_module(mn)
             for on in dir(m):
                 o = getattr(m, on)
@@ -319,9 +319,9 @@ class AlarmApplication(ExtApplication):
                         field: {"$elemMatch": {"profile": c_id, "summary": {"$regex": c_query}}}
                     }
         if c_in:
-            q["%s__profile__in" % field] = c_in
+            q[f"{field}__profile__in"] = c_in
         if c_nin:
-            q["%s__profile__nin" % field] = c_nin
+            q[f"{field}__profile__nin"] = c_nin
 
         return q
 
@@ -720,7 +720,7 @@ class AlarmApplication(ExtApplication):
         if alarm.status != "A":
             return self.response_not_found()
         if alarm.ack_ts:
-            return {"status": False, "message": "Already acknowledged by %s" % alarm.ack_user}
+            return {"status": False, "message": f"Already acknowledged by {alarm.ack_user}"}
         alarm.acknowledge(request.user, msg)
         return {"status": True}
 
@@ -841,7 +841,7 @@ class AlarmApplication(ExtApplication):
             if r:
                 s = AlarmSeverity.get_severity(r[0]["severity"])
                 if s and s.sound and s.volume:
-                    sound = "/ui/pkg/nocsound/%s.mp3" % s.sound
+                    sound = f"/ui/pkg/nocsound/{s.sound}.mp3"
                     volume = float(s.volume) / 100.0
         return {"new_alarms": n, "sound": sound, "volume": volume}
 
@@ -865,16 +865,16 @@ class AlarmApplication(ExtApplication):
                     if collapse and c < 2:
                         badge = ""
                     else:
-                        badge = '<span class="x-display-tag">%s</span>' % c
+                        badge = f'<span class="x-display-tag">{c}</span>'
                     order = getattr(pv, "display_order", 100)
                     v += [
                         (
                             (order, -c),
-                            '<i class="%s" title="%s"></i>%s' % (pv.glyph, pv.name, badge),
+                            f'<i class="{pv.glyph}" title="{pv.name}"></i>{badge}',
                         )
                     ]
-            return "<span class='x-summary'>%s</span>" % "".join(
-                i[1] for i in sorted(v, key=operator.itemgetter(0))
+            return "<span class='x-summary'>{}</span>".format(
+                "".join(i[1] for i in sorted(v, key=operator.itemgetter(0)))
             )
 
         if not isinstance(s, dict):
@@ -908,7 +908,7 @@ class AlarmApplication(ExtApplication):
                 continue
             if alarm.escalation_tt:
                 alarm.log_message(
-                    "Already escalated with TT #%s" % alarm.escalation_tt,
+                    f"Already escalated with TT #{alarm.escalation_tt}",
                     source=request.user.username,
                 )
             elif alarm.root:
@@ -918,7 +918,7 @@ class AlarmApplication(ExtApplication):
                 )
             else:
                 alarm.log_message(
-                    "Alarm has been escalated by %s" % request.user.username,
+                    f"Alarm has been escalated by {request.user.username}",
                     source=request.user.username,
                 )
                 AlarmEscalation.watch_escalations(alarm, force=True)

--- a/services/web/apps/fm/classificationrule.py
+++ b/services/web/apps/fm/classificationrule.py
@@ -59,7 +59,7 @@ class EventClassificationRuleApplication(ExtDocApplication):
                     data["profile"] = event.managed_object.profile.name
                     data["source"] = event.source
                 else:
-                    errors += ["Event not found: %s" % q["data"]]
+                    errors += ["Event not found: {}".format(q["data"])]
             else:
                 # Decode json
                 try:
@@ -97,13 +97,15 @@ class EventClassificationRuleApplication(ExtDocApplication):
                         k = re.compile(p["key_re"])
                     except re.error as why:
                         errors += [
-                            "Invalid key regular expression <<<%s>>>: %s" % (p["key_re"], why)
+                            "Invalid key regular expression <<<{}>>>: {}".format(p["key_re"], why)
                         ]
                     try:
                         v = re.compile(p["value_re"])
                     except re.error as why:
                         errors += [
-                            "Invalid value regular expression <<<%s>>>: %s" % (p["value_re"], why)
+                            "Invalid value regular expression <<<{}>>>: {}".format(
+                                p["value_re"], why
+                            )
                         ]
                     if k and v:
                         patterns += [(k, v)]
@@ -170,13 +172,13 @@ class EventClassificationRuleApplication(ExtDocApplication):
                     try:
                         vars[v["name"]] = eval(v["value"][1:], {}, vars)
                     except Exception as why:
-                        errors += ["Error when evaluating '%s': %s" % (v["name"], why)]
+                        errors += ["Error when evaluating '{}': {}".format(v["name"], why)]
                 else:
                     vars[v["name"]] = v["value"]
         # Check required variables
         for rvars in required_vars:
             if rvars not in vars:
-                errors += ["Missed required variable: %s" % rvars]
+                errors += [f"Missed required variable: {rvars}"]
         # Fill event class template
         if event_class:
             # lang = "en"

--- a/services/web/apps/fm/event/views.py
+++ b/services/web/apps/fm/event/views.py
@@ -159,7 +159,7 @@ class EventApplication(ExtApplication):
             event_class,
         )
         if filter_x:
-            sql += ["WHERE %s" % " AND ".join(filter_x)]
+            sql += ["WHERE {}".format(" AND ".join(filter_x))]
         sql += ["ORDER BY ts DESC"]
         if limit and offset:
             sql += [f"LIMIT {offset}, {limit}"]

--- a/services/web/apps/fm/mib.py
+++ b/services/web/apps/fm/mib.py
@@ -136,11 +136,11 @@ class MIBApplication(ExtDocApplication):
             s = []
             s += [syntax["base_type"]]
             if "display_hint" in syntax:
-                s += ["display-hint: %s" % syntax["display_hint"]]
+                s += ["display-hint: {}".format(syntax["display_hint"])]
             if syntax["base_type"] in ("Enumeration", "Bits") and "enum_map" in syntax:
                 # Display enumeration
                 for k in sorted(syntax["enum_map"], key=lambda x: int(x)):
-                    s += ["%s -> %s" % (k, syntax["enum_map"][k])]
+                    s += ["{} -> {}".format(k, syntax["enum_map"][k])]
             return s
 
         s = []

--- a/services/web/apps/fm/outage.py
+++ b/services/web/apps/fm/outage.py
@@ -16,4 +16,4 @@ class OutageApplication(ExtApplication):
     title = _("Outages")
     menu = _("Outages")
     glyph = "bolt"
-    link = "/api/card/view/outage/1/?refresh=%s" % config.fm.outage_refresh
+    link = f"/api/card/view/outage/1/?refresh={config.fm.outage_refresh}"

--- a/services/web/apps/fm/reportalarmcomments.py
+++ b/services/web/apps/fm/reportalarmcomments.py
@@ -261,7 +261,7 @@ class ReportAlarmCommentsApplication(ExtApplication):
         filename = "alarm_comments.csv"
         if o_format == "csv":
             response = HttpResponse(content_type="text/csv")
-            response["Content-Disposition"] = 'attachment; filename="%s"' % filename
+            response["Content-Disposition"] = f'attachment; filename="{filename}"'
             writer = csv.writer(response)
             writer.writerows(r)
             return response
@@ -274,11 +274,11 @@ class ReportAlarmCommentsApplication(ExtApplication):
             f.seek(0)
             with ZipFile(response, "w", compression=ZIP_DEFLATED) as zf:
                 zf.writestr(filename, f.read())
-                zf.filename = "%s.zip" % filename
+                zf.filename = f"{filename}.zip"
             # response = HttpResponse(content_type="text/csv")
             response.seek(0)
             response = HttpResponse(response.getvalue(), content_type="application/zip")
-            response["Content-Disposition"] = 'attachment; filename="%s.zip"' % filename
+            response["Content-Disposition"] = f'attachment; filename="{filename}.zip"'
             return response
         if o_format == "xlsx":
             response = BytesIO()

--- a/services/web/apps/fm/reportavailability.py
+++ b/services/web/apps/fm/reportavailability.py
@@ -150,7 +150,7 @@ class ReportAvailabilityApplication(SimpleReport):
             start_date=from_date, stop_date=to_date, skip_zero_avail=skip_zero_avail
         )
         rb = self.get_reboots(start_date=from_date, stop_date=to_date)
-        r = [SectionRow("Report from %s to %s" % (from_date, to_date))]
+        r = [SectionRow(f"Report from {from_date} to {to_date}")]
         mos = ManagedObject.objects.filter(is_managed=True)
 
         if not request.user.is_superuser:

--- a/services/web/apps/fm/reportclassificationrule.py
+++ b/services/web/apps/fm/reportclassificationrule.py
@@ -39,7 +39,7 @@ class ReportClassificationRules(SimpleReport):
             if p_re and not re.search(p_re, profile):
                 # Skip
                 continue
-            data += [SectionRow("%s (%s)" % (r.name, r.preference))]
+            data += [SectionRow(f"{r.name} ({r.preference})")]
             data += [["Event Class", r.event_class.name]]
             for p in r.patterns:
                 data += [[p.key_re, p.value_re]]

--- a/services/web/apps/fm/reportreboots.py
+++ b/services/web/apps/fm/reportreboots.py
@@ -84,8 +84,7 @@ class ReportRebootsApplication(SimpleReport):
                 """
                 SELECT id, address, name
                 FROM sa_managedobject
-                WHERE id IN (%s)"""
-                % ", ".join(chunk)
+                WHERE id IN ({})""".format(", ".join(chunk))
             )
             mo_names.update({c[0]: c[1:3] for c in cursor})
         if not request.user.is_superuser:

--- a/services/web/apps/fm/reportttsystemstat.py
+++ b/services/web/apps/fm/reportttsystemstat.py
@@ -114,7 +114,7 @@ class ReportTTSystemStatApplication(SimpleReport):
                 where service IN ('create_massive_damage_outer', 'change_massive_damage_outer_close') and
                       error_code <> 0 and %s"""
 
-        q_where = ["server IN ('%s')" % "', '".join(tt_systems)]
+        q_where = ["server IN ('{}')".format("', '".join(tt_systems))]
         # q_where = ["managed_object IN (%s)" % ", ".join(mo_bi_dict.keys())]
         q_where += [
             "(date >= toDate(%d)) AND (ts >= toDateTime(%d) AND ts <= toDateTime(%d))"
@@ -167,8 +167,9 @@ class ReportTTSystemStatApplication(SimpleReport):
 
             r += [
                 SectionRow(
-                    name="Report from %s to %s"
-                    % (from_date.strftime("%d.%m.%Y %H:%M"), to_date.strftime("%d.%m.%Y %H:%M"))
+                    name="Report from {} to {}".format(
+                        from_date.strftime("%d.%m.%Y %H:%M"), to_date.strftime("%d.%m.%Y %H:%M")
+                    )
                 )
             ]
             for line in sorted(tt_s, key=lambda x: x[0]):

--- a/services/web/apps/fm/totaloutage.py
+++ b/services/web/apps/fm/totaloutage.py
@@ -15,4 +15,4 @@ class TotalOutageApplication(ExtApplication):
     title = _("Total Outages")
     menu = _("Total Outages")
     glyph = "bolt"
-    link = "/api/card/view/totaloutage/1/?refresh=%s" % config.fm.total_outage_refresh
+    link = f"/api/card/view/totaloutage/1/?refresh={config.fm.total_outage_refresh}"

--- a/services/web/apps/inv/capability.py
+++ b/services/web/apps/inv/capability.py
@@ -70,7 +70,7 @@ class CapabilityApplication(ExtDocApplication):
                 for f in caps_d[e]
             ]
             if not e:
-                self.logger.warning("Not e: %s, children: %s" % (caps_d[e], children))
+                self.logger.warning(f"Not e: {caps_d[e]}, children: {children}")
                 # @todo Update inside list
                 context[children[0]["text"]] += children
             for b in reversed(e):

--- a/services/web/apps/inv/connectiontype.py
+++ b/services/web/apps/inv/connectiontype.py
@@ -44,7 +44,7 @@ class ConnectionTypeApplication(ExtDocApplication):
         def cp(c1, c2):
             """Inheritance path"""
             chain = c1.get_inheritance_path(c2)
-            return " --- ".join("[%s]" % x.name for x in chain)
+            return " --- ".join(f"[{x.name}]" for x in chain)
 
         o = self.get_object_or_404(ConnectionType, id=id)
         r = []
@@ -55,12 +55,18 @@ class ConnectionTypeApplication(ExtDocApplication):
                 rr += [fn(o, "f", "Same type")]
             # Superclassess
             for ct in o.get_superclasses():
-                rr += [fn(ct, "f", "Superclass %s" % cp(o, ct))]
+                rr += [fn(ct, "f", f"Superclass {cp(o, ct)}")]
             # c_groups
             if o.c_group:
                 so = set(o.c_group)
                 for ct in o.get_by_c_group():
-                    rr += [fn(ct, "f", "Share common groups: %s" % ", ".join(so & set(ct.c_group)))]
+                    rr += [
+                        fn(
+                            ct,
+                            "f",
+                            "Share common groups: {}".format(", ".join(so & set(ct.c_group))),
+                        )
+                    ]
             r += [{"gender": "m", "records": rr}]
         if "f" in o.genders:
             # Type f
@@ -69,27 +75,39 @@ class ConnectionTypeApplication(ExtDocApplication):
                 rr += [fn(o, "m", "Same type")]
             # Superclassess
             for ct in o.get_subclasses():
-                rr += [fn(ct, "m", "Subclass %s" % cp(ct, o))]
+                rr += [fn(ct, "m", f"Subclass {cp(ct, o)}")]
             # c_group
             if o.c_group:
                 so = set(o.c_group)
                 for ct in o.get_by_c_group():
-                    rr += [fn(ct, "m", "Share common groups: %s" % ", ".join(so & set(ct.c_group)))]
+                    rr += [
+                        fn(
+                            ct,
+                            "m",
+                            "Share common groups: {}".format(", ".join(so & set(ct.c_group))),
+                        )
+                    ]
             r += [{"gender": "f", "records": rr}]
         if "s" in o.genders:
             # Type s
             rr = [fn(o, "s", "Same type")]
             # Superclassess
             for ct in o.get_superclasses():
-                rr += [fn(ct, "s", "Superclass %s" % cp(o, ct))]
+                rr += [fn(ct, "s", f"Superclass {cp(o, ct)}")]
             # Subclasses
             for ct in o.get_subclasses():
-                rr += [fn(ct, "s", "Subclass %s" % cp(ct, o))]
+                rr += [fn(ct, "s", f"Subclass {cp(ct, o)}")]
             # c_group
             if o.c_group:
                 so = set(o.c_group)
                 for ct in o.get_by_c_group():
-                    rr += [fn(ct, "s", "Share common groups: %s" % ", ".join(so & set(ct.c_group)))]
+                    rr += [
+                        fn(
+                            ct,
+                            "s",
+                            "Share common groups: {}".format(", ".join(so & set(ct.c_group))),
+                        )
+                    ]
 
             r += [{"gender": "s", "records": rr}]
         return r

--- a/services/web/apps/inv/interface.py
+++ b/services/web/apps/inv/interface.py
@@ -276,7 +276,7 @@ class InterfaceApplication(ExtDocApplication):
     def api_unlinked(self, request, object_id):
         def get_label(i):
             if i.description:
-                return "%s (%s)" % (i.name, i.description)
+                return f"{i.name} ({i.description})"
             return i.name
 
         o = self.get_object_or_404(ManagedObject, id=int(object_id))

--- a/services/web/apps/inv/inv/plugins/base.py
+++ b/services/web/apps/inv/inv/plugins/base.py
@@ -21,7 +21,7 @@ class InvPlugin:
 
     def __init__(self, app: InvApplication) -> None:
         self.app = app
-        self.logger = logging.getLogger("%s.%s" % (__name__.rsplit(".", 1)[0], self.name))
+        self.logger = logging.getLogger("{}.{}".format(__name__.rsplit(".", 1)[0], self.name))
         self.init_plugin()
 
     def set_app(self, app: InvApplication):

--- a/services/web/apps/inv/inv/plugins/comment.py
+++ b/services/web/apps/inv/inv/plugins/comment.py
@@ -18,9 +18,9 @@ class CommentPlugin(InvPlugin):
     def init_plugin(self):
         super().init_plugin()
         self.add_view(
-            "api_plugin_%s_set_comment" % self.name,
+            f"api_plugin_{self.name}_set_comment",
             self.api_set_comment,
-            url="^(?P<id>[0-9a-f]{24})/plugin/%s/$" % self.name,
+            url=f"^(?P<id>[0-9a-f]{{24}})/plugin/{self.name}/$",
             method=["POST"],
             validate={"comment": UnicodeParameter()},
         )

--- a/services/web/apps/inv/inv/plugins/conduits.py
+++ b/services/web/apps/inv/inv/plugins/conduits.py
@@ -35,15 +35,15 @@ class ConduitsPlugin(InvPlugin):
     def init_plugin(self):
         super().init_plugin()
         self.add_view(
-            "api_plugin_%s_get_neighbors" % self.name,
+            f"api_plugin_{self.name}_get_neighbors",
             self.api_get_neighbors,
-            url="^(?P<id>[0-9a-f]{24})/plugin/%s/get_neighbors/$" % self.name,
+            url=f"^(?P<id>[0-9a-f]{{24}})/plugin/{self.name}/get_neighbors/$",
             method=["GET"],
         )
         self.add_view(
-            "api_plugin_%s_create_ducts" % self.name,
+            f"api_plugin_{self.name}_create_ducts",
             self.api_create_ducts,
-            url="^(?P<id>[0-9a-f]{24})/plugin/%s/$" % self.name,
+            url=f"^(?P<id>[0-9a-f]{{24}})/plugin/{self.name}/$",
             method=["POST"],
             validate={
                 "ducts": DictListParameter(

--- a/services/web/apps/inv/inv/plugins/contacts.py
+++ b/services/web/apps/inv/inv/plugins/contacts.py
@@ -18,9 +18,9 @@ class ContactsPlugin(InvPlugin):
     def init_plugin(self):
         super().init_plugin()
         self.add_view(
-            "api_plugin_%s_set_contacts" % self.name,
+            f"api_plugin_{self.name}_set_contacts",
             self.api_set_contacts,
-            url="^(?P<id>[0-9a-f]{24})/plugin/%s/$" % self.name,
+            url=f"^(?P<id>[0-9a-f]{{24}})/plugin/{self.name}/$",
             method=["POST"],
             validate={
                 "administrative": UnicodeParameter(),

--- a/services/web/apps/inv/inv/plugins/data.py
+++ b/services/web/apps/inv/inv/plugins/data.py
@@ -327,7 +327,7 @@ class DataPlugin(InvPlugin):
                             m = self.app.get_object_or_404(ObjectModel, id=value)
                             o.model = m
                             o.log(
-                                message="Changing model to %s" % m.name,
+                                message=f"Changing model to {m.name}",
                                 user=request.user,
                                 system="WEB",
                             )

--- a/services/web/apps/inv/inv/plugins/facade.py
+++ b/services/web/apps/inv/inv/plugins/facade.py
@@ -22,7 +22,7 @@ class FacadePlugin(InvPlugin):
     def init_plugin(self):
         super().init_plugin()
         self.add_view(
-            "api_plugin_%s_facade" % self.name,
+            f"api_plugin_{self.name}_facade",
             self.api_facade_svg,
             url="^(?P<id>[0-9a-f]{24})/plugin/facade/(?P<name>front|rear).svg$",
             method=["GET"],

--- a/services/web/apps/inv/inv/plugins/file.py
+++ b/services/web/apps/inv/inv/plugins/file.py
@@ -22,21 +22,21 @@ class FilePlugin(InvPlugin):
     def init_plugin(self):
         super().init_plugin()
         self.add_view(
-            "api_plugin_%s_upload" % self.name,
+            f"api_plugin_{self.name}_upload",
             self.api_upload,
-            url="^(?P<id>[0-9a-f]{24})/plugin/%s/upload/$" % self.name,
+            url=f"^(?P<id>[0-9a-f]{{24}})/plugin/{self.name}/upload/$",
             method=["POST"],
         )
         self.add_view(
-            "api_plugin_%s_download" % self.name,
+            f"api_plugin_{self.name}_download",
             self.api_download,
-            url="^(?P<id>[0-9a-f]{24})/plugin/%s/(?P<file_id>[0-9a-f]{24})/$" % self.name,
+            url=f"^(?P<id>[0-9a-f]{{24}})/plugin/{self.name}/(?P<file_id>[0-9a-f]{{24}})/$",
             method=["GET"],
         )
         self.add_view(
-            "api_plugin_%s_delete" % self.name,
+            f"api_plugin_{self.name}_delete",
             self.api_delete,
-            url="^(?P<id>[0-9a-f]{24})/plugin/%s/(?P<file_id>[0-9a-f]{24})/$" % self.name,
+            url=f"^(?P<id>[0-9a-f]{{24}})/plugin/{self.name}/(?P<file_id>[0-9a-f]{{24}})/$",
             method=["DELETE"],
         )
 
@@ -64,7 +64,7 @@ class FilePlugin(InvPlugin):
         failed = False
         for name in left:
             # file_XXX -> description_XXX
-            dn = "description_%s" % name[5:]
+            dn = f"description_{name[5:]}"
             f = left[name]
             of = ObjectFile(
                 object=o.id,

--- a/services/web/apps/inv/inv/plugins/map.py
+++ b/services/web/apps/inv/inv/plugins/map.py
@@ -30,36 +30,36 @@ class MapPlugin(InvPlugin):
     def init_plugin(self):
         super().init_plugin()
         self.add_view(
-            "api_plugin_%s_get_layer" % self.name,
+            f"api_plugin_{self.name}_get_layer",
             self.api_get_layer,
-            url=r"^plugin/%s/layers/(?P<layer>\S+)/$" % self.name,
+            url=rf"^plugin/{self.name}/layers/(?P<layer>\S+)/$",
             method=["GET"],
         )
         self.add_view(
-            "api_plugin_%s_object_data" % self.name,
+            f"api_plugin_{self.name}_object_data",
             self.api_object_data,
-            url="^(?P<id>[0-9a-f]{24})/plugin/%s/object_data/$" % self.name,
+            url=f"^(?P<id>[0-9a-f]{{24}})/plugin/{self.name}/object_data/$",
             method=["GET"],
         )
         self.add_view(
-            "api_plugin_%s_set_geopoint" % self.name,
+            f"api_plugin_{self.name}_set_geopoint",
             self.api_set_geopoint,
-            url="^(?P<id>[0-9a-f]{24})/plugin/%s/set_geopoint/$" % self.name,
+            url=f"^(?P<id>[0-9a-f]{{24}})/plugin/{self.name}/set_geopoint/$",
             method=["POST"],
             validate={"srid": StringParameter(), "x": FloatParameter(), "y": FloatParameter()},
         )
         self.add_view(
-            "api_plugin_%s_set_layer_visibility" % self.name,
+            f"api_plugin_{self.name}_set_layer_visibility",
             self.api_set_layer_visibility,
-            url="^plugin/%s/layer_visibility/$" % self.name,
+            url=f"^plugin/{self.name}/layer_visibility/$",
             method=["POST"],
             validate={"layer": StringParameter(), "status": BooleanParameter()},
         )
 
         self.add_view(
-            "api_plugin_%s_create" % self.name,
+            f"api_plugin_{self.name}_create",
             self.api_create,
-            url="^plugin/%s/$" % self.name,
+            url=f"^plugin/{self.name}/$",
             method=["POST"],
             validate={
                 "model": DocumentParameter(ObjectModel),
@@ -87,8 +87,8 @@ class MapPlugin(InvPlugin):
                 "code": layer.code,
                 "min_zoom": layer.min_zoom,
                 "max_zoom": layer.max_zoom,
-                "stroke_color": "#%06x" % layer.stroke_color,
-                "fill_color": "#%06x" % layer.fill_color,
+                "stroke_color": f"#{layer.stroke_color:06x}",
+                "fill_color": f"#{layer.fill_color:06x}",
                 "stroke_width": layer.stroke_width,
                 "point_radius": layer.point_radius,
                 "show_labels": layer.show_labels,

--- a/services/web/apps/inv/inv/plugins/metric.py
+++ b/services/web/apps/inv/inv/plugins/metric.py
@@ -240,9 +240,9 @@ class MetricPlugin(InvPlugin):
     def init_plugin(self):
         super().init_plugin()
         self.add_view(
-            "api_plugin_%s_set_metric_threshold" % self.name,
+            f"api_plugin_{self.name}_set_metric_threshold",
             self.api_set_metric_threshold,
-            url="^(?P<id>[0-9a-f]{24})/plugin/%s/(?P<sid>[0-9a-f]{24})/set_threshold/$" % self.name,
+            url=f"^(?P<id>[0-9a-f]{{24}})/plugin/{self.name}/(?P<sid>[0-9a-f]{{24}})/set_threshold/$",
             method=["POST"],
             validate={
                 "thresholds": DictListParameter(

--- a/services/web/apps/inv/inv/plugins/param.py
+++ b/services/web/apps/inv/inv/plugins/param.py
@@ -22,7 +22,7 @@ class ParamPlugin(InvPlugin):
     def init_plugin(self):
         super().init_plugin()
         self.add_view(
-            "api_plugin_%s_save_data" % self.name,
+            f"api_plugin_{self.name}_save_data",
             self.api_save_data,
             url="^(?P<id>[0-9a-f]{24})/plugin/param/$",
             method=["PUT"],
@@ -35,7 +35,7 @@ class ParamPlugin(InvPlugin):
             ),
         )
         self.add_view(
-            "api_plugin_%s_schema" % self.name,
+            f"api_plugin_{self.name}_schema",
             self.api_save_data,
             url="^(?P<id>[0-9a-f]{24})/plugin/param/schema/$",
             method=["GET"],
@@ -45,7 +45,7 @@ class ParamPlugin(InvPlugin):
             },
         )
         self.add_view(
-            "api_plugin_%s_scopes" % self.name,
+            f"api_plugin_{self.name}_scopes",
             self.api_scopes,
             url="^(?P<id>[0-9a-f]{24})/plugin/param/scopes/$",
             method=["GET"],

--- a/services/web/apps/inv/inv/plugins/rack.py
+++ b/services/web/apps/inv/inv/plugins/rack.py
@@ -21,7 +21,7 @@ class RackPlugin(InvPlugin):
     def init_plugin(self):
         super().init_plugin()
         self.add_view(
-            "api_plugin_%s_set_rackload" % self.name,
+            f"api_plugin_{self.name}_set_rackload",
             self.api_set_rack_load,
             url=f"^(?P<id>[0-9a-f]{{24}})/plugin/{self.name}/rackload/$",
             method=["POST"],

--- a/services/web/apps/inv/inv/plugins/sensor.py
+++ b/services/web/apps/inv/inv/plugins/sensor.py
@@ -44,9 +44,9 @@ class SensorPlugin(InvPlugin):
     def init_plugin(self):
         super().init_plugin()
         self.add_view(
-            "api_plugin_%s_set_sensor" % self.name,
+            f"api_plugin_{self.name}_set_sensor",
             self.api_set_sensor,
-            url="^(?P<id>[0-9a-f]{24})/plugin/%s/$" % self.name,
+            url=f"^(?P<id>[0-9a-f]{{24}})/plugin/{self.name}/$",
             method=["POST"],
             validate={
                 "profile": ObjectIdParameter(required=False),

--- a/services/web/apps/inv/inv/views.py
+++ b/services/web/apps/inv/inv/views.py
@@ -89,7 +89,7 @@ class InvApplication(ExtApplication):
         for f in os.listdir("services/web/apps/inv/inv/plugins/"):
             if not f.endswith(".py") or f == "base.py" or f.startswith("_"):
                 continue
-            mn = "noc.services.web.apps.inv.inv.plugins.%s" % f[:-3]
+            mn = f"noc.services.web.apps.inv.inv.plugins.{f[:-3]}"
             m = importlib.import_module(mn)
             for on in dir(m):
                 o = getattr(m, on)

--- a/services/web/apps/inv/macdb.py
+++ b/services/web/apps/inv/macdb.py
@@ -101,7 +101,7 @@ class MACApplication(ExtApplication):
         ]
         filter_x = self.get_filter(mac_query, managed_object, segment, interface_profile, is_uni)
         if filter_x:
-            sql += ["WHERE %s" % " AND ".join(filter_x)]
+            sql += ["WHERE {}".format(" AND ".join(filter_x))]
         sql += ["ORDER BY mac"]
         if limit and offset:
             sql += [f"LIMIT {offset}, {limit}"]
@@ -239,7 +239,7 @@ class MACApplication(ExtApplication):
         ]
         filter_x = cls.get_filter(mac_query, managed_object, segment, interface_profile, is_uni)
         if filter_x:
-            sql += ["WHERE %s" % " AND ".join(filter_x)]
+            sql += ["WHERE {}".format(" AND ".join(filter_x))]
         sql += ["ORDER BY ts DESC"]
         if limit and offset:
             sql += [f"LIMIT {offset}, {limit}"]

--- a/services/web/apps/inv/map/views.py
+++ b/services/web/apps/inv/map/views.py
@@ -623,7 +623,7 @@ class MapApplication(ExtApplication):
             return s
 
         def qt(t):
-            return "|".join(["%s=%s" % (v, t[v]) for v in sorted(t)])
+            return "|".join([f"{v}={t[v]}" for v in sorted(t)])
 
         # Filter misformated metrics
         filtered_metrics = [

--- a/services/web/apps/inv/reportcompare.py
+++ b/services/web/apps/inv/reportcompare.py
@@ -25,7 +25,7 @@ class ReportCompareApplication(SimpleReport):
             ).order_by("name"):
                 ru = m.get_data("rackmount", "units")
                 if ru:
-                    ru = "%sU" % ru
+                    ru = f"{ru}U"
                 else:
                     ru = ""
                 weight = m.get_data("weight", "weight")

--- a/services/web/apps/inv/reportdiscoverypoison.py
+++ b/services/web/apps/inv/reportdiscoverypoison.py
@@ -69,10 +69,10 @@ class ReportDiscoveryIDPoisonApplication(SimpleReport):
                 if filter_dup_macs:
                     continue
                 data += [
-                    SectionRow(name="%s %s (%s)" % (MAC(f["macs"][0]), reason, "On duplicated"))
+                    SectionRow(name="{} {} ({})".format(MAC(f["macs"][0]), reason, "On duplicated"))
                 ]
             else:
-                data += [SectionRow(name="%s %s" % (MAC(f["macs"][0]), reason))]
+                data += [SectionRow(name="{} {}".format(MAC(f["macs"][0]), reason))]
             data += data_c
 
         return self.from_dataset(

--- a/services/web/apps/inv/reportifacestatus.py
+++ b/services/web/apps/inv/reportifacestatus.py
@@ -133,7 +133,7 @@ class ReportInterfaceStatusApplication(ExtApplication):
                 if speed >= t:
                     if speed // t * t == speed:
                         return "%d%s" % (speed // t, n)
-                    return "%.2f%s" % (float(speed) / t, n)
+                    return f"{float(speed) / t:.2f}{n}"
             return str(speed)
 
         def row(row):
@@ -246,8 +246,7 @@ class ReportInterfaceStatusApplication(ExtApplication):
                         [
                             mo[i["managed_object"]]["name"],
                             mo[i["managed_object"]]["address"],
-                            "%s %s"
-                            % (
+                            "{} {}".format(
                                 smart_text(mo[i["managed_object"]]["vendor"]),
                                 smart_text(mo[i["managed_object"]]["platform"]),
                             ),
@@ -270,10 +269,10 @@ class ReportInterfaceStatusApplication(ExtApplication):
                 )
             ]
 
-        filename = "interface_status_report_%s" % datetime.datetime.now().strftime("%Y%m%d")
+        filename = "interface_status_report_{}".format(datetime.datetime.now().strftime("%Y%m%d"))
         if o_format == "csv":
             response = HttpResponse(content_type="text/csv")
-            response["Content-Disposition"] = 'attachment; filename="%s.csv"' % filename
+            response["Content-Disposition"] = f'attachment; filename="{filename}.csv"'
             writer = csv.writer(response, dialect="excel", delimiter=";")
             writer.writerows(r)
             return response
@@ -284,12 +283,12 @@ class ReportInterfaceStatusApplication(ExtApplication):
             writer.writerows(r)
             f.seek(0)
             with ZipFile(response, "w", compression=ZIP_DEFLATED) as zf:
-                zf.writestr("%s.csv" % filename, f.read())
-                zf.filename = "%s.csv.zip" % filename
+                zf.writestr(f"{filename}.csv", f.read())
+                zf.filename = f"{filename}.csv.zip"
             # response = HttpResponse(content_type="text/csv")
             response.seek(0)
             response = HttpResponse(response.getvalue(), content_type="application/zip")
-            response["Content-Disposition"] = 'attachment; filename="%s.csv.zip"' % filename
+            response["Content-Disposition"] = f'attachment; filename="{filename}.csv.zip"'
             return response
         if o_format == "xlsx":
             response = BytesIO()
@@ -318,6 +317,6 @@ class ReportInterfaceStatusApplication(ExtApplication):
             response = HttpResponse(response.getvalue(), content_type="application/vnd.ms-excel")
             # response = HttpResponse(
             #     content_type="application/x-ms-excel")
-            response["Content-Disposition"] = 'attachment; filename="%s.xlsx"' % filename
+            response["Content-Disposition"] = f'attachment; filename="{filename}.xlsx"'
             response.close()
             return response

--- a/services/web/apps/inv/reportlinkdetail.py
+++ b/services/web/apps/inv/reportlinkdetail.py
@@ -306,10 +306,10 @@ class ReportLinkDetailApplication(ExtApplication):
                     cmap,
                 )
             ]
-        filename = "links_detail_report_%s" % datetime.datetime.now().strftime("%Y%m%d")
+        filename = "links_detail_report_{}".format(datetime.datetime.now().strftime("%Y%m%d"))
         if o_format == "csv":
             response = HttpResponse(content_type="text/csv")
-            response["Content-Disposition"] = 'attachment; filename="%s.csv"' % filename
+            response["Content-Disposition"] = f'attachment; filename="{filename}.csv"'
             writer = csv.writer(response, dialect="excel", delimiter=",", quoting=csv.QUOTE_MINIMAL)
             writer.writerows(r)
             return response
@@ -320,12 +320,12 @@ class ReportLinkDetailApplication(ExtApplication):
             writer.writerows(r)
             f.seek(0)
             with ZipFile(response, "w", compression=ZIP_DEFLATED) as zf:
-                zf.writestr("%s.csv" % filename, f.read())
-                zf.filename = "%s.csv.zip" % filename
+                zf.writestr(f"{filename}.csv", f.read())
+                zf.filename = f"{filename}.csv.zip"
             # response = HttpResponse(content_type="text/csv")
             response.seek(0)
             response = HttpResponse(response.getvalue(), content_type="application/zip")
-            response["Content-Disposition"] = 'attachment; filename="%s.csv.zip"' % filename
+            response["Content-Disposition"] = f'attachment; filename="{filename}.csv.zip"'
             return response
         if o_format == "xlsx":
             response = BytesIO()
@@ -354,6 +354,6 @@ class ReportLinkDetailApplication(ExtApplication):
             response = HttpResponse(response.getvalue(), content_type="application/vnd.ms-excel")
             # response = HttpResponse(
             #     content_type="application/x-ms-excel")
-            response["Content-Disposition"] = 'attachment; filename="%s.xlsx"' % filename
+            response["Content-Disposition"] = f'attachment; filename="{filename}.xlsx"'
             response.close()
             return response

--- a/services/web/apps/inv/reportmaxmetrics.py
+++ b/services/web/apps/inv/reportmaxmetrics.py
@@ -434,10 +434,10 @@ class ReportMaxMetricsmaxDetailApplication(ExtApplication):
                 if ss:
                     r += [translate_row(row2, cmap)]
 
-        filename = "metrics_detail_report_%s" % datetime.datetime.now().strftime("%Y%m%d")
+        filename = "metrics_detail_report_{}".format(datetime.datetime.now().strftime("%Y%m%d"))
         if o_format == "csv":
             response = HttpResponse(content_type="text/csv")
-            response["Content-Disposition"] = 'attachment; filename="%s.csv"' % filename
+            response["Content-Disposition"] = f'attachment; filename="{filename}.csv"'
             writer = csv.writer(response, dialect="excel", delimiter=",", quoting=csv.QUOTE_MINIMAL)
             writer.writerows(r)
             return response
@@ -448,12 +448,12 @@ class ReportMaxMetricsmaxDetailApplication(ExtApplication):
             writer.writerows(r)
             f.seek(0)
             with ZipFile(response, "w", compression=ZIP_DEFLATED) as zf:
-                zf.writestr("%s.csv" % filename, f.read())
-                zf.filename = "%s.csv.zip" % filename
+                zf.writestr(f"{filename}.csv", f.read())
+                zf.filename = f"{filename}.csv.zip"
             # response = HttpResponse(content_type="text/csv")
             response.seek(0)
             response = HttpResponse(response.getvalue(), content_type="application/zip")
-            response["Content-Disposition"] = 'attachment; filename="%s.csv.zip"' % filename
+            response["Content-Disposition"] = f'attachment; filename="{filename}.csv.zip"'
             return response
         if o_format == "xlsx":
             response = BytesIO()
@@ -480,6 +480,6 @@ class ReportMaxMetricsmaxDetailApplication(ExtApplication):
             wb.close()
             response.seek(0)
             response = HttpResponse(response.getvalue(), content_type="application/vnd.ms-excel")
-            response["Content-Disposition"] = 'attachment; filename="%s.xlsx"' % filename
+            response["Content-Disposition"] = f'attachment; filename="{filename}.xlsx"'
             response.close()
             return response

--- a/services/web/apps/inv/reportmetrics.py
+++ b/services/web/apps/inv/reportmetrics.py
@@ -268,10 +268,10 @@ class ReportMetricsDetailApplication(ExtApplication):
                 res.append(row.get(y, ""))
             r.append(res)
 
-        filename = "metrics_detail_report_%s" % datetime.datetime.now().strftime("%Y%m%d")
+        filename = "metrics_detail_report_{}".format(datetime.datetime.now().strftime("%Y%m%d"))
         if o_format == "csv":
             response = HttpResponse(content_type="text/csv")
-            response["Content-Disposition"] = 'attachment; filename="%s.csv"' % filename
+            response["Content-Disposition"] = f'attachment; filename="{filename}.csv"'
             writer = csv.writer(response, dialect="excel", delimiter=",", quoting=csv.QUOTE_MINIMAL)
             writer.writerows(r)
             return response
@@ -282,12 +282,12 @@ class ReportMetricsDetailApplication(ExtApplication):
             writer.writerows(r)
             f.seek(0)
             with ZipFile(response, "w", compression=ZIP_DEFLATED) as zf:
-                zf.writestr("%s.csv" % filename, f.read())
-                zf.filename = "%s.csv.zip" % filename
+                zf.writestr(f"{filename}.csv", f.read())
+                zf.filename = f"{filename}.csv.zip"
             # response = HttpResponse(content_type="text/csv")
             response.seek(0)
             response = HttpResponse(response.getvalue(), content_type="application/zip")
-            response["Content-Disposition"] = 'attachment; filename="%s.csv.zip"' % filename
+            response["Content-Disposition"] = f'attachment; filename="{filename}.csv.zip"'
             return response
         if o_format == "xlsx":
             response = BytesIO()
@@ -314,6 +314,6 @@ class ReportMetricsDetailApplication(ExtApplication):
             wb.close()
             response.seek(0)
             response = HttpResponse(response.getvalue(), content_type="application/vnd.ms-excel")
-            response["Content-Disposition"] = 'attachment; filename="%s.xlsx"' % filename
+            response["Content-Disposition"] = f'attachment; filename="{filename}.xlsx"'
             response.close()
             return response

--- a/services/web/apps/inv/reportmovedmac.py
+++ b/services/web/apps/inv/reportmovedmac.py
@@ -92,7 +92,7 @@ FROM (
      HAVING iface_count > 1
 )
     """ % " AND ".join(
-    "(mac < %s or mac > %s)" % (int(MAC(x[0])), int(MAC(x[1]))) for x in MULTICAST_MACS
+    f"(mac < {int(MAC(x[0]))} or mac > {int(MAC(x[1]))})" for x in MULTICAST_MACS
 )
 
 DEVICE_MOVED_QUERY = """SELECT
@@ -307,10 +307,10 @@ class ReportMovedMacApplication(ExtApplication):
                 )
             ]
 
-        filename = "macs_move_report_%s" % datetime.datetime.now().strftime("%Y%m%d")
+        filename = "macs_move_report_{}".format(datetime.datetime.now().strftime("%Y%m%d"))
         if o_format == "csv":
             response = HttpResponse(content_type="text/csv")
-            response["Content-Disposition"] = 'attachment; filename="%s.csv"' % filename
+            response["Content-Disposition"] = f'attachment; filename="{filename}.csv"'
             writer = csv.writer(response, dialect="excel", delimiter=",", quoting=csv.QUOTE_MINIMAL)
             writer.writerows(r)
             return response
@@ -321,12 +321,12 @@ class ReportMovedMacApplication(ExtApplication):
             writer.writerows(r)
             f.seek(0)
             with ZipFile(response, "w", compression=ZIP_DEFLATED) as zf:
-                zf.writestr("%s.csv" % filename, f.read())
-                zf.filename = "%s.csv.zip" % filename
+                zf.writestr(f"{filename}.csv", f.read())
+                zf.filename = f"{filename}.csv.zip"
             # response = HttpResponse(content_type="text/csv")
             response.seek(0)
             response = HttpResponse(response.getvalue(), content_type="application/zip")
-            response["Content-Disposition"] = 'attachment; filename="%s.csv.zip"' % filename
+            response["Content-Disposition"] = f'attachment; filename="{filename}.csv.zip"'
             return response
         if o_format == "xlsx":
             response = BytesIO()
@@ -353,6 +353,6 @@ class ReportMovedMacApplication(ExtApplication):
             wb.close()
             response.seek(0)
             response = HttpResponse(response.getvalue(), content_type="application/vnd.ms-excel")
-            response["Content-Disposition"] = 'attachment; filename="%s.xlsx"' % filename
+            response["Content-Disposition"] = f'attachment; filename="{filename}.xlsx"'
             response.close()
             return response

--- a/services/web/apps/inv/reportpendinglinks.py
+++ b/services/web/apps/inv/reportpendinglinks.py
@@ -147,13 +147,13 @@ class ReportPendingLinks:
                         problems[mo.id][iface] = {
                             "problem": "Not found iface on remote",
                             "detail": detail,
-                            "remote_id": "%s::: %s" % (rmo.name, rmo.profile.name),
+                            "remote_id": f"{rmo.name}::: {rmo.profile.name}",
                             "remote_iface": pend_str.group("remote_iface"),
                         }
                         problems[rmo.id][pend_str.group("remote_iface")] = {
                             "problem": "Not found local iface on remote",
                             "detail": detail,
-                            "remote_id": "%s::: %s" % (mo.name, mo.profile.name),
+                            "remote_id": f"{mo.name}::: {mo.profile.name}",
                             "remote_iface": iface,
                         }
                         # print(discovery["problems"]["lldp"])

--- a/services/web/apps/ip/addressrange.py
+++ b/services/web/apps/ip/addressrange.py
@@ -32,9 +32,9 @@ class AddressRangeApplication(ExtModelApplication):
         # Check AFI
         address_validator = is_ipv4 if afi == "4" else is_ipv6
         if not address_validator(from_address):
-            raise ValueError("Invalid IPv%(afi)s 'From Address'" % {"afi": afi})
+            raise ValueError(f"Invalid IPv{afi} 'From Address'")
         if not address_validator(to_address):
-            raise ValueError("Invalid IPv%(afi)s 'To Address'" % {"afi": afi})
+            raise ValueError(f"Invalid IPv{afi} 'To Address'")
         # Check from address not greater than to address
         if IP.prefix(from_address) > IP.prefix(to_address):
             raise ValueError("'To Address' must be greater or equal than 'From Address'")
@@ -53,7 +53,7 @@ class AddressRangeApplication(ExtModelApplication):
             for ns in reverse_nses.split(","):
                 ns = ns.strip()
                 if not is_ipv4(ns) and not is_ipv6(ns) and not is_fqdn(ns):
-                    raise ValueError("%s is invalid nameserver" % ns)
+                    raise ValueError(f"{ns} is invalid nameserver")
         # Check no locked range overlaps another locked range
         if data["is_locked"]:
             r = [
@@ -65,6 +65,6 @@ class AddressRangeApplication(ExtModelApplication):
             ]
             if r:
                 raise ValueError(
-                    "Locked range overlaps with ahother locked range: %s" % smart_text(r[0])
+                    f"Locked range overlaps with ahother locked range: {smart_text(r[0])}"
                 )
         return data

--- a/services/web/apps/ip/ipam.py
+++ b/services/web/apps/ip/ipam.py
@@ -372,13 +372,13 @@ class IPAMApplication(ExtApplication):
         # Prefix discovery
         dmap = {"E": "Enabled", "D": "Disabled"}
         if prefix.prefix_discovery_policy == "P":
-            t = "Profile (%s)" % dmap[prefix.profile.prefix_discovery_policy]
+            t = f"Profile ({dmap[prefix.profile.prefix_discovery_policy]})"
         else:
             t = dmap[prefix.prefix_discovery_policy]
         prefix_info += [("Prefix Discovery", t)]
         # Address discovery
         if prefix.address_discovery_policy == "P":
-            t = "Profile (%s)" % dmap[prefix.profile.address_discovery_policy]
+            t = f"Profile ({dmap[prefix.profile.address_discovery_policy]})"
         else:
             t = dmap[prefix.address_discovery_policy]
         prefix_info += [("Address Discovery", t)]

--- a/services/web/apps/ip/prefix.py
+++ b/services/web/apps/ip/prefix.py
@@ -107,7 +107,7 @@ class PrefixApplication(ExtModelApplication):
             o.delete_recursive()
         except ValueError as e:
             return self.render_json(
-                {"success": False, "message": "ERROR: %s" % e}, status=self.CONFLICT
+                {"success": False, "message": f"ERROR: {e}"}, status=self.CONFLICT
             )
         return HttpResponse(status=self.DELETED)
 

--- a/services/web/apps/ip/reportallocated.py
+++ b/services/web/apps/ip/reportallocated.py
@@ -76,10 +76,7 @@ class ReportAllocated(SimpleReport):
             if k in cfn and v is not None and v != "":
                 q &= Q(**{str(k): v})
         return self.from_dataset(
-            title=_(
-                "Allocated blocks in VRF %(vrf)s (IPv%(afi)s), %(prefix)s"
-                % {"vrf": vrf.name, "afi": afi, "prefix": prefix.prefix}
-            ),
+            title=_(f"Allocated blocks in VRF {vrf.name} (IPv{afi}), {prefix.prefix}"),
             columns=columns,
             data=[get_row(p) for p in prefix.children_set.filter(q).order_by("prefix")],
             enumerate=True,

--- a/services/web/apps/ip/reportexpanded.py
+++ b/services/web/apps/ip/reportexpanded.py
@@ -71,10 +71,7 @@ class ExpandedReport(SimpleReport):
         columns += ["Description", TableColumn(_("Tags"), format="tags")]
         data = get_info(prefix)
         return self.from_dataset(
-            title=_(
-                "All allocated blocks in VRF %(vrf)s (IPv%(afi)s), %(prefix)s"
-                % {"vrf": vrf.name, "afi": afi, "prefix": prefix.prefix}
-            ),
+            title=_(f"All allocated blocks in VRF {vrf.name} (IPv{afi}), {prefix.prefix}"),
             columns=columns,
             data=data,
             enumerate=True,

--- a/services/web/apps/ip/reportfree.py
+++ b/services/web/apps/ip/reportfree.py
@@ -46,10 +46,7 @@ class FreeBlocksReport(SimpleReport):
     def get_data(self, vrf, afi, prefix, **kwargs):
         p = IP.prefix(prefix.prefix)
         return self.from_dataset(
-            title=_(
-                "Free blocks in VRF %(vrf)s (IPv%(afi)s), %(prefix)s"
-                % {"vrf": vrf.name, "afi": afi, "prefix": prefix.prefix}
-            ),
+            title=_(f"Free blocks in VRF {vrf.name} (IPv{afi}), {prefix.prefix}"),
             columns=["Free Blocks"],
             data=[
                 [smart_text(f)]

--- a/services/web/apps/ip/reporthistory.py
+++ b/services/web/apps/ip/reporthistory.py
@@ -54,8 +54,7 @@ class ReportHistoryApplication(SimpleReport):
     def format_detail(self, o):
         r = [m.groups() for m in self.rx_detail.finditer(o)]
         s = "<br/>".join(
-            "<b>%s</b>: %s &rArr; %s"
-            % (self.html_escape(g[0]), self.html_escape(g[1]), self.html_escape(g[2]))
+            f"<b>{self.html_escape(g[0])}</b>: {self.html_escape(g[1])} &rArr; {self.html_escape(g[2])}"
             for g in r
         )
         return SafeString(s)
@@ -123,7 +122,7 @@ class ReportHistoryApplication(SimpleReport):
             for c in ll.changes:
                 if c.old is None and c.new is None:
                     continue
-                chg += ["%s: %s -> %s" % (c.field, c.old, c.new)]
+                chg += [f"{c.field}: {c.old} -> {c.new}"]
             r += [
                 (
                     self.to_json(ll.timestamp),

--- a/services/web/apps/ip/reportipusage.py
+++ b/services/web/apps/ip/reportipusage.py
@@ -30,7 +30,7 @@ class ReportIPUsageApplication(SimpleReport):
         c.execute(self.QUERY)
         for vrf, rd, afi, prefix, description, used in c:
             if last_vrf != vrf:
-                data += [SectionRow("%s (%s)" % (vrf, rd))]
+                data += [SectionRow(f"{vrf} ({rd})")]
                 last_vrf = vrf
             p = IP.prefix(prefix)
             if afi == "4":

--- a/services/web/apps/ip/reportoverview.py
+++ b/services/web/apps/ip/reportoverview.py
@@ -110,7 +110,7 @@ class Node:
 
     def update_report(self, r, current_level, max_level):
         if self.height > 1:
-            r += ["<td rowspan='%s' class='block'>" % self.height]
+            r += [f"<td rowspan='{self.height}' class='block'>"]
         else:
             r += ["<td class='block'>"]
         r += [self.get_html(), "</td>"]
@@ -145,14 +145,14 @@ class VRFGroupNode(Node):
 
     def populate(self):
         if self.vrfs:
-            vid = "{%s}" % ",".join([str(v.id) for v in self.vrfs])
+            vid = "{{{}}}".format(",".join([str(v.id) for v in self.vrfs]))
             root = Prefix.objects.get(vrf=self.vrfs[0], prefix="0.0.0.0/0")
             c = GPrefixNode(self.app, root, vid)
             self.children = c.children  # Relink
 
     def get_html(self):
-        r = ["<b>VRF Group: %s</b>" % self.vrf_group.name]
-        r += ["&nbsp;&nbsp;<b>%s</b> (RD: %s)" % (v.name, v.rd) for v in self.vrfs]
+        r = [f"<b>VRF Group: {self.vrf_group.name}</b>"]
+        r += [f"&nbsp;&nbsp;<b>{v.name}</b> (RD: {v.rd})" for v in self.vrfs]
         return "<br>".join(r)
 
 
@@ -167,7 +167,7 @@ class VRFNode(Node):
             self.children += [PrefixNode(self.app, p)]
 
     def get_html(self):
-        return "<b>VRF %s</b><br/>RD: %s" % (self.vrf.name, self.vrf.rd)
+        return f"<b>VRF {self.vrf.name}</b><br/>RD: {self.vrf.rd}"
 
 
 class PrefixNode(Node):
@@ -187,7 +187,7 @@ class PrefixNode(Node):
         return self.prefix
 
     def __repr__(self):
-        return "<%s %s>" % (self.__class__.__name__, self.prefix)
+        return f"<{self.__class__.__name__} {self.prefix}>"
 
     def populate(self):
         if not self.app.prefix_children.get(self.prefix.id):
@@ -196,13 +196,13 @@ class PrefixNode(Node):
             self.children += [PrefixNode(self.app, p)]
 
     def get_html(self):
-        r = ["<b><u>%s</u></b>" % self.prefix.prefix]
+        r = [f"<b><u>{self.prefix.prefix}</u></b>"]
         if self.prefix.description:
-            r += ["<br/>%s" % self.prefix.description]
+            r += [f"<br/>{self.prefix.description}"]
         if self.show_vrf:
-            r += ["<br/>VRF: %s" % self.prefix.vrf.name]
+            r += [f"<br/>VRF: {self.prefix.vrf.name}"]
         if self.used is not None:
-            r += ["<br/>%s" % self.get_bar(self.used)]
+            r += [f"<br/>{self.get_bar(self.used)}"]
         # Show custom fields
         for f in prefix_fields:
             v = getattr(self.prefix, f.name)
@@ -210,10 +210,10 @@ class PrefixNode(Node):
                 continue
             if f.type == "bool":
                 t = "check" if f else "times"
-                icon = "<i class='fa fa-%s'></i>" % t
-                r += ["<br/>%s: %s" % (f.label, icon)]
+                icon = f"<i class='fa fa-{t}'></i>"
+                r += [f"<br/>{f.label}: {icon}"]
             else:
-                r += ["<br/>%s: %s" % (f.label, v)]
+                r += [f"<br/>{f.label}: {v}"]
         return "".join(r)
 
     def update_usage(self):

--- a/services/web/apps/ip/reportvpnstatus.py
+++ b/services/web/apps/ip/reportvpnstatus.py
@@ -33,9 +33,7 @@ class ReportVPNStatusApplication(SimpleReport):
                 if si:
                     d += [[fi.managed_object.name, ", ".join(si)]]
             if d:
-                data += [
-                    SectionRow(name="VRF %s, RD: %s [%s]" % (vrf.name, vrf.rd, vrf.state.name))
-                ]
+                data += [SectionRow(name=f"VRF {vrf.name}, RD: {vrf.rd} [{vrf.state.name}]")]
                 data += d
         return self.from_dataset(
             title=self.title, columns=[_("Managed Object"), _("Interfaces")], data=data

--- a/services/web/apps/ip/tools/views.py
+++ b/services/web/apps/ip/tools/views.py
@@ -168,7 +168,7 @@ class ToolsAppplication(Application):
                         profile=ap,
                         fqdn=fqdn,
                         name=fqdn,
-                        description="Imported from %s zone" % zone,
+                        description=f"Imported from {zone} zone",
                     )
                     a.save()
                     create += 1

--- a/services/web/apps/kb/kbentry.py
+++ b/services/web/apps/kb/kbentry.py
@@ -81,7 +81,7 @@ class KBEntryApplication(ExtModelApplication):
         attach = self.get_object_or_404(KBEntryAttachment, kb_entry=o, name=name)
         file_mime = mimetypes.guess_type(attach.file.name)
         response = HttpResponse(attach.file, content_type=file_mime or "application/octet-stream")
-        response["Content-Disposition"] = 'attachment; filename="%s"' % attach.file.name
+        response["Content-Disposition"] = f'attachment; filename="{attach.file.name}"'
         return response
 
     @view(r"^(?P<id>\d+)/attachment/(?P<name>.+)/$", access="delete", api=True, method=["DELETE"])

--- a/services/web/apps/kb/macros/rack.py
+++ b/services/web/apps/kb/macros/rack.py
@@ -23,7 +23,7 @@ rx_link = re.compile(r"^(.*)\|(https?://.+)$")
 def unroll_link(s):
     match = rx_link.match(s)
     if match:
-        return "<a href='%s'>%s</a>" % (
+        return "<a href='{}'>{}</a>".format(
             match.group(2),
             escape(match.group(1)).replace(r"\n", "<br/>"),
         )
@@ -121,14 +121,14 @@ class RackSet:
         rack_labels = ["<tr>"]
         for r in self.racks:
             if r.id:
-                rack_labels += ["<td colspan='2' class='racklabel'>%s</td>" % escape(r.id)]
+                rack_labels += [f"<td colspan='2' class='racklabel'>{escape(r.id)}</td>"]
             else:
                 rack_labels += ["<td colspan='2' class='racklabel'></td>"]
         rack_labels += ["</tr>"]
         # Render the matrix
         out = ["<table class='rackset'>"]
         if self.id:
-            out += ["<caption>%s</caption>" % escape(self.id)]
+            out += [f"<caption>{escape(self.id)}</caption>"]
         if self.label in ["both", "top"]:
             out += rack_labels
         for i in range(self.height, 0, -1):
@@ -139,7 +139,7 @@ class RackSet:
                     td = "<td "
                     for attr in ["colspan", "rowspan", "class"]:
                         if attr in v:
-                            td += "%s='%s' " % (attr, v[attr])
+                            td += f"{attr}='{v[attr]}' "
                     td += ">"
                     # Render allocation
                     if v.get("text"):
@@ -199,7 +199,7 @@ class Allocation:
         self.slots = []
 
     def __repr__(self):
-        return "Allocation: id=%s position=%s height=%s" % (self.id, self.position, self.height)
+        return f"Allocation: id={self.id} position={self.position} height={self.height}"
 
     def to_html(self):
         """
@@ -208,25 +208,25 @@ class Allocation:
         """
         r = []
         if self.id:
-            r += ["<b>%s</b>" % unroll_link(self.id)]
+            r += [f"<b>{unroll_link(self.id)}</b>"]
         if self.hostname:
-            r += ["<u>%s</u>" % unroll_link(self.hostname)]
+            r += [f"<u>{unroll_link(self.hostname)}</u>"]
         if self.model:
             r += [unroll_link(self.model)]
         if self.serial:
-            r += ["S/N: %s" % unroll_link(self.serial)]
+            r += [f"S/N: {unroll_link(self.serial)}"]
         if self.asset_no:
-            r += ["#%s" % unroll_link(self.asset_no)]
+            r += [f"#{unroll_link(self.asset_no)}"]
         if self.description:
-            r += ["<i>%s</i>" % unroll_link(self.description)]
+            r += [f"<i>{unroll_link(self.description)}</i>"]
         if self.href:
-            r += ["<a href='%s'>Link...</a>" % self.href]
+            r += [f"<a href='{self.href}'>Link...</a>"]
         if self.slots:
             rr = ["<table border='1'>"]
             for s in self.slots:
-                rr += ["<tr><td><b>%s</b></td>" % s.id]
+                rr += [f"<tr><td><b>{s.id}</b></td>"]
                 a = " class='reserved'" if s.reserved else ""
-                rr += ["<td%s>%s</td></tr>" % (a, s.to_html())]
+                rr += [f"<td{a}>{s.to_html()}</td></tr>"]
             rr += ["</table>"]
             r += ["".join(rr)]
         return "<br/>".join(r)
@@ -259,17 +259,17 @@ class Slot:
     def to_html(self):
         r = []
         if self.hostname:
-            r += ["<u>%s</u>" % unroll_link(self.hostname)]
+            r += [f"<u>{unroll_link(self.hostname)}</u>"]
         if self.model:
             r += [unroll_link(self.model)]
         if self.serial:
-            r += ["S/N: %s" % unroll_link(self.serial)]
+            r += [f"S/N: {unroll_link(self.serial)}"]
         if self.asset_no:
-            r += ["#%s" % unroll_link(self.asset_no)]
+            r += [f"#{unroll_link(self.asset_no)}"]
         if self.description:
-            r += ["<i>%s</i>" % unroll_link(self.description)]
+            r += [f"<i>{unroll_link(self.description)}</i>"]
         if self.href:
-            r += ["<a href='%s'>Link...</a>" % self.href]
+            r += [f"<a href='{self.href}'>Link...</a>"]
         return "<br/>".join(r)
 
 

--- a/services/web/apps/kb/macros/search.py
+++ b/services/web/apps/kb/macros/search.py
@@ -55,22 +55,22 @@ class SearchMacro(BaseMacro):
             for f in args["display_list"].split(","):
                 f = f.strip()
                 if f not in ("id", "subject"):
-                    raise Exception("Invalid field %s" % f)
+                    raise Exception(f"Invalid field {f}")
                 display_list.append(f)
         else:
             display_list = ["id", "subject"]
         # Render
         out = ["<table border='0'>"]
         if "title" in args:
-            out += ["<tr><th>%s</th></tr>" % args["title"]]
+            out += ["<tr><th>{}</th></tr>".format(args["title"])]
         for a in q:
             link = "/api/card/view/kb/%d/" % a.id
             out += ["<tr>"]
             for f in display_list:
                 if f == "id":
-                    out += ["<td><a href='%s'>KB%s</a></td>" % (link, getattr(a, f))]
+                    out += [f"<td><a href='{link}'>KB{getattr(a, f)}</a></td>"]
                 else:
-                    out += ["<td><a href='%s'>%s</a></td>" % (link, getattr(a, f))]
+                    out += [f"<td><a href='{link}'>{getattr(a, f)}</a></td>"]
             out += ["</tr>"]
         out += ["</table>"]
         return "\n".join(out)

--- a/services/web/apps/kb/parsers/base.py
+++ b/services/web/apps/kb/parsers/base.py
@@ -51,7 +51,7 @@ class BaseParser:
         if text is None:
             text = link
         if link.startswith("KB") and is_int(link[2:]):
-            return "<a href='%s/%s/'>%s</a>" % (BASE_PATH, link[2:], text)
+            return f"<a href='{BASE_PATH}/{link[2:]}/'>{text}</a>"
         if link.startswith("TT"):
             return link[2:]
         if link.startswith("attach:"):
@@ -66,9 +66,9 @@ class BaseParser:
             return "<a href='/kb/kbentry/%d/attachment/%s/'>%s</a>" % (kb_entry.id, link, text)
         try:
             le = kb_entry.__class__.objects.get(subject=link)
-            return "<a href='%s/%s/'>%s</a>" % (BASE_PATH, le.id, text)
+            return f"<a href='{BASE_PATH}/{le.id}/'>{text}</a>"
         except kb_entry.__class__.DoesNotExist:
-            return "<a href='%s'>%s</a>" % (link, text)
+            return f"<a href='{link}'>{text}</a>"
 
     @classmethod
     def convert_attach(cls, kb_entry, href):

--- a/services/web/apps/kb/parsers/creole.py
+++ b/services/web/apps/kb/parsers/creole.py
@@ -39,10 +39,7 @@ class CreoleParser(BaseParser):
         def custom_image_emit(node):
             target = cls.convert_attach(kb_entry, node.content)
             text = html_emitter.get_text(node)
-            return '<img src="%s" alt="%s" />' % (
-                html_emitter.attr_escape(target),
-                html_emitter.attr_escape(text),
-            )
+            return f'<img src="{html_emitter.attr_escape(target)}" alt="{html_emitter.attr_escape(text)}" />'
 
         parser = creole.Parser(smart_text(kb_entry.body))
         html_emitter = creole.HtmlEmitter(parser.parse(), macros=cls.get_macro_wrapper())

--- a/services/web/apps/kb/parsers/csv.py
+++ b/services/web/apps/kb/parsers/csv.py
@@ -20,10 +20,10 @@ class CSVParser(BaseParser):
     def to_html(cls, kb_entry):
         reader = csv.reader(list(kb_entry.body.splitlines()))
         r = ["<TABLE BORDER='1' ID='csvtable' class='tablesorter'>", "<thead>"]
-        r += ["<TR>"] + ["<TH>%s</TH>" % smart_text(c) for c in next(reader)] + ["</TR>"]
+        r += ["<TR>"] + [f"<TH>{smart_text(c)}</TH>" for c in next(reader)] + ["</TR>"]
         r += ["</thead>", "<tbody>"]
         for row in reader:
-            r += ["<TR>"] + ["<TD>%s</TD>" % smart_text(c) for c in row] + ["</TR>"]
+            r += ["<TR>"] + [f"<TD>{smart_text(c)}</TD>" for c in row] + ["</TR>"]
         r += ["</tbody></TABLE>"]
         r += [
             "<script type='text/javascript'>",

--- a/services/web/apps/kb/parsers/plain.py
+++ b/services/web/apps/kb/parsers/plain.py
@@ -17,4 +17,4 @@ class PlainTextParser(BaseParser):
 
     @classmethod
     def to_html(cls, kb_entry):
-        return "<pre>%s</pre>" % kb_entry.body
+        return f"<pre>{kb_entry.body}</pre>"

--- a/services/web/apps/main/audittrail.py
+++ b/services/web/apps/main/audittrail.py
@@ -80,9 +80,9 @@ class AuditTrailApplication(ExtApplication):
 
         queries = []
         if _query:
-            queries.append("object_name = '%s'\n" % (_query))
+            queries.append(f"object_name = '{_query}'\n")
         if _op:
-            queries.append("op = '%s'\n" % (_op))
+            queries.append(f"op = '{_op}'\n")
 
         if queries:
             ch_query += "WHERE\n" + " AND ".join(queries)

--- a/services/web/apps/main/calculator/calculators/cir2cbr.py
+++ b/services/web/apps/main/calculator/calculators/cir2cbr.py
@@ -88,7 +88,7 @@ class Calculator(BaseCalculator):
 
     def escape(self, s):
         """Escape result"""
-        return mark_safe("<pre>%s</pre>" % s)
+        return mark_safe(f"<pre>{s}</pre>")
 
     def calculate_ios_policy(self, value, v):
         """Calculate IOS policy"""
@@ -125,4 +125,4 @@ class Calculator(BaseCalculator):
     def calculate(self, value, Tc, calculation):
         """Calculator"""
         v = int(value * Tc / 8)
-        return getattr(self, "calculate_%s" % calculation)(value, v)
+        return getattr(self, f"calculate_{calculation}")(value, v)

--- a/services/web/apps/main/calculator/calculators/multicast.py
+++ b/services/web/apps/main/calculator/calculators/multicast.py
@@ -56,7 +56,7 @@ class Calculator(BaseCalculator):
         if ip:
             p = [int(x) for x in ip.split(".")]
             mac = [0x1, 0x0, 0x5E, p[1] & 0x7F, p[2], p[3]]
-            mac = ":".join(["%02X" % x for x in mac])
+            mac = ":".join([f"{x:02X}" for x in mac])
             r = [("IP", ip), ("MAC", mac), *mac_ips(mac)]
         elif mac:
             r = [("MAC", mac), *mac_ips(mac)]

--- a/services/web/apps/main/csv/views.py
+++ b/services/web/apps/main/csv/views.py
@@ -48,7 +48,9 @@ class CSVApplication(Application):
                     return self.render_plain_text(
                         csv_export(model), content_type="text/csv; encoding=utf-8"
                     )
-                return self.response_redirect("/main/csv/import/%s/" % form.cleaned_data["model"])
+                return self.response_redirect(
+                    "/main/csv/import/{}/".format(form.cleaned_data["model"])
+                )
         else:
             form = ModelForm()
         return self.render(request, "index.html", form=form)
@@ -66,9 +68,9 @@ class CSVApplication(Application):
 
     def address_in_network(self, ip, net):
         """Is an address in a network"""
-        ipaddr = int("".join(["%02x" % int(x) for x in ip.split(".")]), 16)
+        ipaddr = int("".join([f"{int(x):02x}" for x in ip.split(".")]), 16)
         netstr, bits = net.split("/")
-        netaddr = int("".join(["%02x" % int(x) for x in netstr.split(".")]), 16)
+        netaddr = int("".join([f"{int(x):02x}" for x in netstr.split(".")]), 16)
         mask = (0xFFFFFFFF << (32 - int(bits))) & 0xFFFFFFFF
         return (ipaddr & mask) == (netaddr & mask)
 
@@ -148,12 +150,12 @@ class CSVApplication(Application):
         for name, required, rel, rname in get_model_fields(m):
             if rel:
                 if isinstance(rel._meta, dict):
-                    r = ["%s.%s" % (rel._meta["collection"], rname)]
+                    r = ["{}.{}".format(rel._meta["collection"], rname)]
                 else:
                     db_table = rel._meta.db_table
-                    r = ['%s."id"' % db_table]
+                    r = [f'{db_table}."id"']
                     if rname != "id":
-                        r = ['%s."%s"' % (db_table, rname), *r]
+                        r = [f'{db_table}."{rname}"', *r]
             else:
                 r = []
             fields += [(name, required, " or ".join(r))]

--- a/services/web/apps/main/desktop/views.py
+++ b/services/web/apps/main/desktop/views.py
@@ -46,7 +46,7 @@ class DesktopApplication(ExtApplication):
         try:
             return Group.objects.get(name=name)
         except Group.DoesNotExist:
-            self.error("Group '%s' is not found" % name)
+            self.error(f"Group '{name}' is not found")
             return None
 
     def get_language(self, request):

--- a/services/web/apps/main/jsonimport.py
+++ b/services/web/apps/main/jsonimport.py
@@ -34,7 +34,7 @@ class JSONImportApplication(ExtApplication):
         try:
             jdata = orjson.loads(json)
         except Exception as e:
-            return {"status": False, "error": "Invalid JSON: %s" % e}
+            return {"status": False, "error": f"Invalid JSON: {e}"}
         try:
             if isinstance(jdata, list):
                 for d in jdata:

--- a/services/web/apps/main/label.py
+++ b/services/web/apps/main/label.py
@@ -179,10 +179,10 @@ class LabelApplication(ExtDocApplication):
                     "scope": ll.scope,
                     "value": ll.value,
                     "badges": ll.badges,
-                    "bg_color1": "#%x" % ll.bg_color1,
-                    "fg_color1": "#%x" % ll.fg_color1,
-                    "bg_color2": "#%x" % ll.bg_color2,
-                    "fg_color2": "#%x" % ll.fg_color2,
+                    "bg_color1": f"#{ll.bg_color1:x}",
+                    "fg_color1": f"#{ll.fg_color1:x}",
+                    "bg_color2": f"#{ll.bg_color2:x}",
+                    "fg_color2": f"#{ll.fg_color2:x}",
                     # "checked": False,
                 }
             )

--- a/services/web/apps/main/ref.py
+++ b/services/web/apps/main/ref.py
@@ -102,7 +102,7 @@ class RefAppplication(ExtApplication):
         r += [
             {
                 "id": m._meta.db_table,
-                "label": "%s.%s" % (m._meta.app_label, m.__name__),
+                "label": f"{m._meta.app_label}.{m.__name__}",
                 "table": m._meta.db_table,
             }
             for m in apps.get_models()
@@ -111,7 +111,7 @@ class RefAppplication(ExtApplication):
         r += [
             {
                 "id": c._get_collection_name(),
-                "label": "%s.%s" % (c.__module__.split(".")[1], n),
+                "label": "{}.{}".format(c.__module__.split(".")[1], n),
                 "collection": c._get_collection_name(),
             }
             for n, c in _document_registry.items()

--- a/services/web/apps/main/refbook/views.py
+++ b/services/web/apps/main/refbook/views.py
@@ -74,8 +74,8 @@ class RefBookAppplication(Application):
                     continue
                 w += x["where"]
                 p += x["params"]
-            w = " OR ".join(["(%s)" % xx for xx in w])
-            queryset = queryset.extra(where=["(%s)" % w], params=p)
+            w = " OR ".join([f"({xx})" for xx in w])
+            queryset = queryset.extra(where=[f"({w})"], params=p)
         else:
             query = ""
         # Use generic view for final result

--- a/services/web/apps/main/reportloc.py
+++ b/services/web/apps/main/reportloc.py
@@ -51,7 +51,7 @@ class ReportLOC(SimpleReport):
         # Scan modules
         for m in [m for m in settings.INSTALLED_APPS if m.startswith("noc.")]:
             m = m[4:]
-            module_name = importlib.import_module("noc.%s" % m).MODULE_NAME
+            module_name = importlib.import_module(f"noc.{m}").MODULE_NAME
             data += [SectionRow(module_name)]
             # Scan models
             models_path = os.path.join(m, "models.py")
@@ -97,7 +97,7 @@ class ReportLOC(SimpleReport):
                             py_loc += lines(os.path.join(dirpath, f))
                         for f in [f for f in filenames if f.endswith(".html")]:
                             html_loc += lines(os.path.join(dirpath, f))
-                data += [["Application", "%s.%s" % (m, app), py_loc, html_loc, tests_loc]]
+                data += [["Application", f"{m}.{app}", py_loc, html_loc, tests_loc]]
                 # Scan Profiles
             if m == "sa":
                 for d in glob.glob("sa/profiles/*/*"):

--- a/services/web/apps/main/timepattern.py
+++ b/services/web/apps/main/timepattern.py
@@ -41,7 +41,7 @@ class TimePatternApplication(ExtModelApplication):
         },
     )
     def api_action_test(self, request, ids, date=None, time=None):
-        d = "%sT%s" % (date, time)
+        d = f"{date}T{time}"
         dt = datetime.datetime.strptime(d, "%Y-%m-%dT%H:%M")
         return {
             "ts": dt.isoformat(),

--- a/services/web/apps/pm/ddash/dashboards/base.py
+++ b/services/web/apps/pm/ddash/dashboards/base.py
@@ -26,7 +26,7 @@ class BaseDashboard:
         self.object = self.resolve_object(object)
         self.extra_template = extra_template
         self.extra_vars = extra_vars
-        self.logger = logging.getLogger("dashboard.%s" % self.name)
+        self.logger = logging.getLogger(f"dashboard.{self.name}")
         self.object_data = self.resolve_object_data(object)
         self.templates_path = ""
         self.templates = self.load_templates()

--- a/services/web/apps/pm/ddash/dashboards/jinja.py
+++ b/services/web/apps/pm/ddash/dashboards/jinja.py
@@ -29,7 +29,7 @@ class JinjaDashboard(BaseDashboard):
 
     def render(self):
         context = self.get_context()
-        self.logger.info("Context with data: %s" % context)
+        self.logger.info(f"Context with data: {context}")
         pm_template_path = []
         for p in config.get_customized_paths("", prefer_custom=True):
             if p:

--- a/services/web/apps/pm/ddash/dashboards/sensor_controller.py
+++ b/services/web/apps/pm/ddash/dashboards/sensor_controller.py
@@ -135,6 +135,5 @@ class SensorControllerDashboard(MODashboard):
             "extra_vars": self.extra_vars,
             "selected_types": self.object_data["selected_types"],
             "ping_interval": self.object.object_profile.ping_interval,
-            "discovery_interval": "%ss"
-            % int(self.object.object_profile.periodic_discovery_interval / 2),
+            "discovery_interval": f"{int(self.object.object_profile.periodic_discovery_interval / 2)}s",
         }

--- a/services/web/apps/sa/discoveredobject.py
+++ b/services/web/apps/sa/discoveredobject.py
@@ -123,8 +123,9 @@ class DiscoveredObjectApplication(ExtDocApplication):
         if synced != len(req["ids"]):
             return {
                 "status": False,
-                "error": "Synced %s/%s. Set default_template on Object Discovery Rule"
-                % (synced, len(req["ids"])),
+                "error": "Synced {}/{}. Set default_template on Object Discovery Rule".format(
+                    synced, len(req["ids"])
+                ),
             }
         return {"status": True}
 

--- a/services/web/apps/sa/managedobject.py
+++ b/services/web/apps/sa/managedobject.py
@@ -105,53 +105,65 @@ class ManagedObjectApplication(ExtModelApplication):
     order_map = {
         "link_count": " cardinality(links) ",
         "-link_count": " cardinality(links) ",
-        "profile": "CASE %s END"
-        % " ".join(
-            [
-                "WHEN %s='%s' THEN %s" % ("profile", pk, i)
-                for i, pk in enumerate(Profile.objects.filter().order_by("name").values_list("id"))
-            ]
+        "profile": "CASE {} END".format(
+            " ".join(
+                [
+                    "WHEN {}='{}' THEN {}".format("profile", pk, i)
+                    for i, pk in enumerate(
+                        Profile.objects.filter().order_by("name").values_list("id")
+                    )
+                ]
+            )
         ),
-        "-profile": "CASE %s END"
-        % " ".join(
-            [
-                "WHEN %s='%s' THEN %s" % ("profile", pk, i)
-                for i, pk in enumerate(Profile.objects.filter().order_by("-name").values_list("id"))
-            ]
+        "-profile": "CASE {} END".format(
+            " ".join(
+                [
+                    "WHEN {}='{}' THEN {}".format("profile", pk, i)
+                    for i, pk in enumerate(
+                        Profile.objects.filter().order_by("-name").values_list("id")
+                    )
+                ]
+            )
         ),
-        "platform": "CASE %s END"
-        % " ".join(
-            [
-                "WHEN %s='%s' THEN %s" % ("platform", pk, i)
-                for i, pk in enumerate(Platform.objects.filter().order_by("name").values_list("id"))
-            ]
+        "platform": "CASE {} END".format(
+            " ".join(
+                [
+                    "WHEN {}='{}' THEN {}".format("platform", pk, i)
+                    for i, pk in enumerate(
+                        Platform.objects.filter().order_by("name").values_list("id")
+                    )
+                ]
+            )
         ),
-        "-platform": "CASE %s END"
-        % " ".join(
-            [
-                "WHEN %s='%s' THEN %s" % ("platform", pk, i)
-                for i, pk in enumerate(
-                    Platform.objects.filter().order_by("-name").values_list("id")
-                )
-            ]
+        "-platform": "CASE {} END".format(
+            " ".join(
+                [
+                    "WHEN {}='{}' THEN {}".format("platform", pk, i)
+                    for i, pk in enumerate(
+                        Platform.objects.filter().order_by("-name").values_list("id")
+                    )
+                ]
+            )
         ),
-        "version": "CASE %s END"
-        % " ".join(
-            [
-                "WHEN %s='%s' THEN %s" % ("version", pk, i)
-                for i, pk in enumerate(
-                    Firmware.objects.filter().order_by("version").values_list("id")
-                )
-            ]
+        "version": "CASE {} END".format(
+            " ".join(
+                [
+                    "WHEN {}='{}' THEN {}".format("version", pk, i)
+                    for i, pk in enumerate(
+                        Firmware.objects.filter().order_by("version").values_list("id")
+                    )
+                ]
+            )
         ),
-        "-version": "CASE %s END"
-        % " ".join(
-            [
-                "WHEN %s='%s' THEN %s" % ("version", pk, i)
-                for i, pk in enumerate(
-                    Firmware.objects.filter().order_by("-version").values_list("id")
-                )
-            ]
+        "-version": "CASE {} END".format(
+            " ".join(
+                [
+                    "WHEN {}='{}' THEN {}".format("version", pk, i)
+                    for i, pk in enumerate(
+                        Firmware.objects.filter().order_by("-version").values_list("id")
+                    )
+                ]
+            )
         ),
     }
     resource_group_fields = [
@@ -685,16 +697,16 @@ class ManagedObjectApplication(ExtModelApplication):
             if link.is_ptp:
                 # ptp
                 o = link.other_ptp(i)
-                label = "%s:%s" % (o.managed_object.name, o.name)
+                label = f"{o.managed_object.name}:{o.name}"
             elif link.is_lag:
                 # unresolved LAG
                 o = [ii for ii in link.other(i) if ii.managed_object.id != i.managed_object.id]
-                label = "LAG %s: %s" % (o[0].managed_object.name, ", ".join(ii.name for ii in o))
+                label = "LAG {}: {}".format(
+                    o[0].managed_object.name, ", ".join(ii.name for ii in o)
+                )
             else:
                 # Broadcast
-                label = ", ".join(
-                    "%s:%s" % (ii.managed_object.name, ii.name) for ii in link.other(i)
-                )
+                label = ", ".join(f"{ii.managed_object.name}:{ii.name}" for ii in link.other(i))
             return {"id": str(link.id), "label": label}
 
         # Get object
@@ -712,9 +724,9 @@ class ManagedObjectApplication(ExtModelApplication):
                 load_out = r[o.bi_id][iface]["load_out"]
 
                 if load_in is not None:
-                    ctx["load_in"] = "%.2f%s" % Scale.humanize(int(load_in))
+                    ctx["load_in"] = "{:.2f}{}".format(*Scale.humanize(int(load_in)))
                 if load_out is not None:
-                    ctx["load_out"] = "%.2f%s" % Scale.humanize(int(load_out))
+                    ctx["load_out"] = "{:.2f}{}".format(*Scale.humanize(int(load_out)))
 
                 metrics[iface] = self.iface_metric_template.render(**ctx)
         # Physical interfaces
@@ -1018,7 +1030,7 @@ class ManagedObjectApplication(ExtModelApplication):
         if not o.has_access(request.user):
             return self.response_forbidden("Access denied")
         # fs = gridfs.GridFS(get_db(), "noc.joblog")
-        key = "discovery-%s-%s" % (job, o.id)
+        key = f"discovery-{job}-{o.id}"
         d = get_db()["noc.joblog"].find_one({"_id": key})
         if d and d["log"]:
             return self.render_plain_text(zlib.decompress(smart_bytes(d["log"])))
@@ -1063,7 +1075,7 @@ class ManagedObjectApplication(ExtModelApplication):
         if not o.has_access(request.user):
             return {"error": "Access denied"}
         if name not in o.scripts:
-            return {"error": "Script not found: %s" % name}
+            return {"error": f"Script not found: {name}"}
         params = self.deserialize(request.body)
         try:
             result = o.scripts[name](**params)

--- a/services/web/apps/sa/monitor.py
+++ b/services/web/apps/sa/monitor.py
@@ -84,12 +84,12 @@ class MonitorApplication(ObjectListApplication):
             prefix = self.job_map[job["jcls"]]
             result.update(
                 {
-                    "%s_time_start" % prefix: self.to_json(job[Job.ATTR_TS]),
-                    "%s_last_success" % prefix: self.to_json(job.get(Job.ATTR_LAST)),
-                    "%s_status" % prefix: job.get(Job.ATTR_STATUS, "--"),
-                    "%s_time" % prefix: job.get(Job.ATTR_LAST_DURATION, 0),
-                    "%s_duration" % prefix: job.get(Job.ATTR_LAST_DURATION, 0),
-                    "%s_last_status" % prefix: job.get(Job.ATTR_LAST_STATUS),
+                    f"{prefix}_time_start": self.to_json(job[Job.ATTR_TS]),
+                    f"{prefix}_last_success": self.to_json(job.get(Job.ATTR_LAST)),
+                    f"{prefix}_status": job.get(Job.ATTR_STATUS, "--"),
+                    f"{prefix}_time": job.get(Job.ATTR_LAST_DURATION, 0),
+                    f"{prefix}_duration": job.get(Job.ATTR_LAST_DURATION, 0),
+                    f"{prefix}_last_status": job.get(Job.ATTR_LAST_STATUS),
                 }
             )
         return result
@@ -101,7 +101,7 @@ class MonitorApplication(ObjectListApplication):
             return self.response_forbidden("Access denied")
         r = []
         for job in self.job_map:
-            key = "discovery-%s-%s" % (job, o.id)
+            key = f"discovery-{job}-{o.id}"
             d = get_db()["noc.joblog"].find_one({"_id": key})
             if d and d["log"]:
                 r += [b"\n", smart_bytes(job), b"\n"]

--- a/services/web/apps/sa/objectlist.py
+++ b/services/web/apps/sa/objectlist.py
@@ -33,7 +33,7 @@ class ObjectListApplication(ExtApplication):
         """
         Filter records for lookup
         """
-        self.logger.info("Queryset %s" % query)
+        self.logger.info(f"Queryset {query}")
         if self.managed_filter:
             q = d_Q(is_managed=True)
         else:
@@ -128,7 +128,7 @@ class ObjectListApplication(ExtApplication):
         for k in q:
             if not k.startswith("_") and "__" not in k:
                 nq[k] = q[k]
-        self.logger.debug("Cleaned query: %s" % nq)
+        self.logger.debug(f"Cleaned query: {nq}")
         if "ids" in nq:
             nq["id__in"] = list({int(nid) for nid in nq["ids"]})
             del nq["ids"]
@@ -153,7 +153,7 @@ class ObjectListApplication(ExtApplication):
         for x in xf:
             if x in ["address__in", "id__in", "administrative_domain__in"]:
                 continue
-            self.logger.warning("Remove element not in model: %s" % x)
+            self.logger.warning(f"Remove element not in model: {x}")
             del nq[x]
         return nq
 
@@ -166,7 +166,7 @@ class ObjectListApplication(ExtApplication):
             extra["select"]["ex_address"] = " address "
             extra["order_by"] = ["-ex_address", "-address"]
 
-        self.logger.info("Extra: %s" % extra)
+        self.logger.info(f"Extra: {extra}")
         return extra, [] if "order_by" in extra else order
 
     @view(method=["GET", "POST"], url="^$", access="read", api=True)

--- a/services/web/apps/sa/reportdiscoveryproblem.py
+++ b/services/web/apps/sa/reportdiscoveryproblem.py
@@ -153,7 +153,7 @@ class ReportFilterApplication(SimpleReport):
             pool = Pool.get_by_id(pool)
         else:
             pool = Pool.objects.filter()[0]
-        data += [SectionRow(name="Report by %s" % pool.name)]
+        data += [SectionRow(name=f"Report by {pool.name}")]
         if resource_group:
             resource_group = ResourceGroup.get_by_id(resource_group)
             mos = ManagedObject.objects.filter(

--- a/services/web/apps/sa/reportobjectdetail.py
+++ b/services/web/apps/sa/reportobjectdetail.py
@@ -474,10 +474,10 @@ class ReportObjectDetailApplication(ExtApplication):
             icount += 1
             # r.append(x)
         self.logger.debug("[%s|reportobjectdetail] End mail loop", request.user)
-        filename = "mo_detail_report_%s" % datetime.datetime.now().strftime("%Y%m%d")
+        filename = "mo_detail_report_{}".format(datetime.datetime.now().strftime("%Y%m%d"))
         if o_format == "csv":
             response = HttpResponse(content_type="text/csv")
-            response["Content-Disposition"] = 'attachment; filename="%s.csv"' % filename
+            response["Content-Disposition"] = f'attachment; filename="{filename}.csv"'
             writer = csv.writer(response, dialect="excel", delimiter=";", quotechar='"')
             writer.writerows(r)
             return response
@@ -488,12 +488,12 @@ class ReportObjectDetailApplication(ExtApplication):
             writer.writerows(r)
             f.seek(0)
             with ZipFile(response, "w", compression=ZIP_DEFLATED) as zf:
-                zf.writestr("%s.csv" % filename, f.read())
-                zf.filename = "%s.csv.zip" % filename
+                zf.writestr(f"{filename}.csv", f.read())
+                zf.filename = f"{filename}.csv.zip"
             # response = HttpResponse(content_type="text/csv")
             response.seek(0)
             response = HttpResponse(response.getvalue(), content_type="application/zip")
-            response["Content-Disposition"] = 'attachment; filename="%s.csv.zip"' % filename
+            response["Content-Disposition"] = f'attachment; filename="{filename}.csv.zip"'
             return response
         if o_format == "xlsx":
             response = BytesIO()
@@ -523,6 +523,6 @@ class ReportObjectDetailApplication(ExtApplication):
             response = HttpResponse(response.getvalue(), content_type="application/vnd.ms-excel")
             # response = HttpResponse(
             #     content_type="application/x-ms-excel")
-            response["Content-Disposition"] = 'attachment; filename="%s.xlsx"' % filename
+            response["Content-Disposition"] = f'attachment; filename="{filename}.xlsx"'
             response.close()
             return response

--- a/services/web/apps/sa/reportobjectsummary.py
+++ b/services/web/apps/sa/reportobjectsummary.py
@@ -80,76 +80,62 @@ class ReportObjectsSummary(SimpleReport):
             # wr_and = ("AND sam.administrative_domain_id in ", ad)
             wr_and2 = ("AND administrative_domain_id in ", ad)
             if len(ad) == 1:
-                wr = ("WHERE administrative_domain_id in (%s)" % ad, "")
+                wr = (f"WHERE administrative_domain_id in ({ad})", "")
                 # wr_and = ("AND sam.administrative_domain_id in (%s)" % ad, "")
-                wr_and2 = ("AND administrative_domain_id in (%s)" % ad, "")
+                wr_and2 = (f"AND administrative_domain_id in ({ad})", "")
         # By Profile
         if report_type == "profile":
             columns = [_("Profile")]
-            query = (
-                """SELECT profile,COUNT(*) FROM sa_managedobject
-                    %s%s GROUP BY 1 ORDER BY 2 DESC"""
-                % wr
-            )
+            query = """SELECT profile,COUNT(*) FROM sa_managedobject
+                    {}{} GROUP BY 1 ORDER BY 2 DESC""".format(*wr)
         # By Administrative Domain
         elif report_type == "domain":
             columns = [_("Administrative Domain")]
-            query = (
-                """SELECT a.name,COUNT(*)
+            query = """SELECT a.name,COUNT(*)
                   FROM sa_managedobject o JOIN sa_administrativedomain a ON (o.administrative_domain_id=a.id)
-                  %s%s
+                  {}{}
                   GROUP BY 1
-                  ORDER BY 2 DESC"""
-                % wr
-            )
+                  ORDER BY 2 DESC""".format(*wr)
         # By Profile and Administrative Domains
         elif report_type == "domain-profile":
             columns = [_("Administrative Domain"), _("Profile")]
-            query = (
-                """SELECT d.name,profile,COUNT(*)
+            query = """SELECT d.name,profile,COUNT(*)
                     FROM sa_managedobject o JOIN sa_administrativedomain d ON (o.administrative_domain_id=d.id)
-                    %s%s
+                    {}{}
                     GROUP BY 1,2
-                    """
-                % wr
-            )
+                    """.format(*wr)
         # By Labels
         elif report_type == "label":
             columns = [_("Label")]
-            query = (
-                """
+            query = """
               SELECT t.label, COUNT(*)
               FROM (
                 SELECT unnest(labels) AS label
                 FROM sa_managedobject
                 WHERE
                   labels IS NOT NULL
-                  %s%s
+                  {}{}
                   AND array_length(labels, 1) > 0
                 ) t
               GROUP BY 1
               ORDER BY 2 DESC;
-            """
-                % wr_and2
-            )
+            """.format(*wr_and2)
         elif report_type == "platform":
             columns = [_("Platform"), _("Profile")]
-            query = (
-                """select sam.profile, sam.platform, COUNT(platform)
-                    from sa_managedobject sam %s%s group by 1,2 order by count(platform) desc;"""
-                % wr
+            query = """select sam.profile, sam.platform, COUNT(platform)
+                    from sa_managedobject sam {}{} group by 1,2 order by count(platform) desc;""".format(
+                *wr
             )
 
         elif report_type == "version":
             columns = [_("Profile"), _("Version"), _("Firmware Policy")]
-            query = (
-                """select sam.profile, sam.version, COUNT(version)
-                    from sa_managedobject sam %s%s group by 1,2 order by count(version) desc;"""
-                % wr
+            query = """select sam.profile, sam.version, COUNT(version)
+                    from sa_managedobject sam {}{} group by 1,2 order by count(version) desc;""".format(
+                *wr
             )
 
         else:
-            raise Exception("Invalid report type: %s" % report_type)
+            raise Exception(f"Invalid report type: {report_type}")
         for r, t in report_types:
             if r == report_type:
                 title = self.title + ": " + t

--- a/services/web/apps/sa/reportstalediscovery.py
+++ b/services/web/apps/sa/reportstalediscovery.py
@@ -40,7 +40,7 @@ class ReportStaleDiscoveryJob(SimpleReport):
                     if "text" in tb and "code" in tb:
                         if tb["text"].endswith("END OF TRACEBACK"):
                             tb["text"] = "Job crashed"
-                        msg = "(%s) %s" % (tb["text"], tb["code"])
+                        msg = "({}) {}".format(tb["text"], tb["code"])
                 data += [
                     [
                         mo.administrative_domain.name,

--- a/services/web/apps/support/account.py
+++ b/services/web/apps/support/account.py
@@ -27,7 +27,7 @@ class AccountApplication(ExtApplication):
         if c.has_account():
             data["account"] = c.account_info()
             for i in data["account"].get("industries", []):
-                data["account"]["ind_%s" % i] = True
+                data["account"][f"ind_{i}"] = True
         if c.has_system():
             data["system"] = c.system_info()
         return data

--- a/services/web/apps/vc/vlanfilter.py
+++ b/services/web/apps/vc/vlanfilter.py
@@ -67,7 +67,7 @@ class VLANFilterApplication(ExtDocApplication):
         value = IntParameter().clean(value)
         filters = [str(f.id) for f in VLANFilter.objects.filters(include_vlans__in=[value])]
         if filters:
-            x = "(id IN (%s))" % ", ".join(filters)
+            x = "(id IN ({}))".format(", ".join(filters))
         else:
             x = "FALSE"
         try:

--- a/services/web/apps/wf/workflow.py
+++ b/services/web/apps/wf/workflow.py
@@ -178,7 +178,7 @@ class WorkflowApplication(ExtDocApplication):
             try:
                 get_model(am)
             except ImportError:
-                raise ValueError("Bad Model: %s" % am)
+                raise ValueError(f"Bad Model: {am}")
             wf.allowed_models += [am]
         wf.save()
         # Get current state
@@ -257,7 +257,7 @@ class WorkflowApplication(ExtDocApplication):
         # Get all clone names
         m = 0
         for d in Workflow._get_collection().find(
-            {"name": {"$regex": re.compile(r"^%s\(Copy #\d+\)$" % re.escape(wf.name))}},
+            {"name": {"$regex": re.compile(rf"^{re.escape(wf.name)}\(Copy #\d+\)$")}},
             {"_id": 0, "name": 1},
         ):
             match = self.rx_clone_name.search(d["name"])

--- a/services/web/base/access.py
+++ b/services/web/base/access.py
@@ -143,13 +143,13 @@ class HasPerm(Permission):
 
     def __repr__(self):
         if hasattr(self, "perm_id"):
-            return "<HasPerm '%s' object at 0x%x>" % (self.perm_id, id(self))
-        return "<HasPerm object at 0x%x>" % id(self)
+            return f"<HasPerm '{self.perm_id}' object at 0x{id(self):x}>"
+        return f"<HasPerm object at 0x{id(self):x}>"
 
     def get_permission(self, app):
         if ":" in self.perm:
             return self.perm
-        return "%s:%s:%s" % (app.module, app.app, self.perm)
+        return f"{app.module}:{app.app}:{self.perm}"
 
     def check(self, app, user, obj=None):
         return DBPermission.has_perm(user, self.get_permission(app))

--- a/services/web/base/application.py
+++ b/services/web/base/application.py
@@ -161,9 +161,9 @@ class Application(metaclass=ApplicationBase):
             self.module = parts[4]
             self.app = parts[5]
         self.module_title = importlib.import_module(
-            "noc.services.web.apps.%s" % self.module
+            f"noc.services.web.apps.{self.module}"
         ).MODULE_NAME
-        self.app_id = "%s.%s" % (self.module, self.app)
+        self.app_id = f"{self.module}.{self.app}"
         self.menu_url = None  # Set by site.autodiscover()
         self.logger = logging.getLogger(self.app_id)
         self.j2_env = None
@@ -244,15 +244,15 @@ class Application(metaclass=ApplicationBase):
         """
         parts = cls.__module__.split(".")
         if parts[1] == "custom":
-            return "%s.%s" % (parts[5], parts[6])
-        return "%s.%s" % (parts[4], parts[5])
+            return f"{parts[5]}.{parts[6]}"
+        return f"{parts[4]}.{parts[5]}"
 
     @property
     def base_url(self):
         """
         Application's base URL
         """
-        return "/%s/%s/" % (self.module, self.app)
+        return f"/{self.module}/{self.app}/"
 
     def reverse(self, url, *args, **kwargs):
         """
@@ -458,7 +458,7 @@ class Application(metaclass=ApplicationBase):
         Return a set of permissions, used by application
         """
         prefix = self.get_app_id().replace(".", ":")
-        p = {"%s:launch" % prefix}
+        p = {f"{prefix}:launch"}
         # View permissions from HasPerm
         for view in self.iter_views():
             if isinstance(view.access, HasPerm):
@@ -470,7 +470,7 @@ class Application(metaclass=ApplicationBase):
                 if isinstance(c["access"], HasPerm):
                     p.add(c["access"].get_permission(self))
                 elif isinstance(c["access"], str):
-                    p.add("%s:%s" % (prefix, c["access"]))
+                    p.add("{}:{}".format(prefix, c["access"]))
         # extra_permissions
         if callable(self.extra_permissions):
             extra = self.extra_permissions()
@@ -535,7 +535,7 @@ class Application(metaclass=ApplicationBase):
             elif f.type == "datetime":
                 ff = forms.DateTimeField(required=False, label=f.label)
             else:
-                raise ValueError("Invalid field type: '%s'" % f.type)
+                raise ValueError(f"Invalid field type: '{f.type}'")
             fields += [(str(f.name), ff)]
         form.base_fields.update(OrderedDict(fields))
         return form

--- a/services/web/base/docinline.py
+++ b/services/web/base/docinline.py
@@ -74,7 +74,7 @@ class DocInline:
                 self.clean_fields[name] = DocumentParameter(f.document_type)
         if not self.query_fields:
             self.query_fields = [
-                "%s__%s" % (n, self.query_condition)
+                f"{n}__{self.query_condition}"
                 for n, f in self.model._fields.items()
                 if f.unique and isinstance(f, StringField)
             ]
@@ -88,46 +88,46 @@ class DocInline:
     def contribute_to_class(self, app, name):
         # Add List handler
         app.add_view(
-            "api_%s_list" % name,
+            f"api_{name}_list",
             self.api_list,
             method=["GET"],
-            url="^(?P<parent>[^/]+)/%s/$" % name,
+            url=f"^(?P<parent>[^/]+)/{name}/$",
             access="read",
             api=True,
         )
         # Add Create handler
         app.add_view(
-            "api_%s_create" % name,
+            f"api_{name}_create",
             self.api_create,
             method=["POST"],
-            url="^(?P<parent>[^/]+)/%s/$" % name,
+            url=f"^(?P<parent>[^/]+)/{name}/$",
             access="create",
             api=True,
         )
         # Add Read Handler
         app.add_view(
-            "api_%s_read" % name,
+            f"api_{name}_read",
             self.api_read,
             method=["GET"],
-            url="^(?P<parent>[^/]+)/%s/(?P<id>[^/]+)/?$" % name,
+            url=f"^(?P<parent>[^/]+)/{name}/(?P<id>[^/]+)/?$",
             access="read",
             api=True,
         )
         # Add Update Handler
         app.add_view(
-            "api_%s_update" % name,
+            f"api_{name}_update",
             self.api_update,
             method=["PUT"],
-            url="^(?P<parent>[^/]+)/%s/(?P<id>[^/]+)/?$" % name,
+            url=f"^(?P<parent>[^/]+)/{name}/(?P<id>[^/]+)/?$",
             access="update",
             api=True,
         )
         # Add Delete Handler
         app.add_view(
-            "api_%s_delete" % name,
+            f"api_{name}_delete",
             self.api_delete,
             method=["DELETE"],
-            url="^(?P<parent>[^/]+)/%s/(?P<id>[^/]+)/?$" % name,
+            url=f"^(?P<parent>[^/]+)/{name}/(?P<id>[^/]+)/?$",
             access="delete",
             api=True,
         )
@@ -157,7 +157,7 @@ class DocInline:
 
         def get_q(f):
             if "__" not in f:
-                return "%s__%s" % (f, self.query_condition)
+                return f"{f}__{self.query_condition}"
             return f
 
         q = reduce(
@@ -228,20 +228,15 @@ class DocInline:
                 # Unroll __referred
                 app, fn = v.split("__", 1)
                 model = self.app.site.apps[app].model
-                extra_where = '%s."%s" IN (SELECT "%s" FROM %s)' % (
-                    self.model._meta.db_table,
-                    self.model._meta.pk.name,
-                    model._meta.get_field(fn).attname,
-                    model._meta.db_table,
-                )
+                extra_where = f'{self.model._meta.db_table}."{self.model._meta.pk.name}" IN (SELECT "{model._meta.get_field(fn).attname}" FROM {model._meta.db_table})'
                 if None in nq:
                     nq[None] += [extra_where]
                 else:
                     nq[None] = [extra_where]
                 continue
-            if lt and hasattr(self, "lookup_%s" % lt):
+            if lt and hasattr(self, f"lookup_{lt}"):
                 # Custom lookup
-                getattr(self, "lookup_%s" % lt)(nq, np, v)
+                getattr(self, f"lookup_{lt}")(nq, np, v)
                 continue
             if np in self.fk_fields and lt:
                 # dereference
@@ -271,10 +266,10 @@ class DocInline:
                 if isinstance(f, GeoPointField):
                     pass
                 elif isinstance(f, ForeignKeyField):
-                    r["%s__label" % f.name] = smart_text(v)
+                    r[f"{f.name}__label"] = smart_text(v)
                     v = v.id
                 elif isinstance(f, PlainReferenceField):
-                    r["%s__label" % f.name] = smart_text(v)
+                    r[f"{f.name}__label"] = smart_text(v)
                     if hasattr(v, "id"):
                         v = str(v.id)
                     else:
@@ -315,7 +310,7 @@ class DocInline:
         if format == "ext" and self.sort_param in q:
             for r in self.app.deserialize(q[self.sort_param]):
                 if r["direction"] == "DESC":
-                    ordering += ["-%s" % r["property"]]
+                    ordering += ["-{}".format(r["property"])]
                 else:
                     ordering += [r["property"]]
         q = self.cleaned_query(q)

--- a/services/web/base/extapplication.py
+++ b/services/web/base/extapplication.py
@@ -95,12 +95,12 @@ class ExtApplication(Application):
     @property
     def js_app_class(self):
         m, a = self.get_app_id().split(".")
-        return "NOC.%s.%s.Application" % (m, a)
+        return f"NOC.{m}.{a}.Application"
 
     @property
     def launch_access(self):
         m, a = self.get_app_id().split(".")
-        return HasPerm("%s:%s:launch" % (m, a))
+        return HasPerm(f"{m}:{a}:launch")
 
     def deserialize(self, data):
         return orjson.loads(data)
@@ -196,18 +196,18 @@ class ExtApplication(Application):
             try:
                 limit = max(int(limit), 0)
             except ValueError:
-                return HttpResponse(400, "Invalid %s param" % self.limit_param)
+                return HttpResponse(400, f"Invalid {self.limit_param} param")
         if limit and limit < 0:
-            return HttpResponse(400, "Invalid %s param" % self.limit_param)
+            return HttpResponse(400, f"Invalid {self.limit_param} param")
         # page = q.get(self.page_param)
         start = q.get(self.start_param) or 0
         if start:
             try:
                 start = max(int(start), 0)
             except ValueError:
-                return HttpResponse(400, "Invalid %s param" % self.start_param)
+                return HttpResponse(400, f"Invalid {self.start_param} param")
         elif start and start < 0:
-            return HttpResponse(400, "Invalid %s param" % self.start_param)
+            return HttpResponse(400, f"Invalid {self.start_param} param")
         query = q.get(self.query_param)
         only = q.get(self.only_param)
         if only:
@@ -216,14 +216,14 @@ class ExtApplication(Application):
         if request.is_extjs and self.sort_param in q:
             for r in self.deserialize(q[self.sort_param]):
                 if r["direction"] == "DESC":
-                    ordering += ["-%s" % r["property"]]
+                    ordering += ["-{}".format(r["property"])]
                 else:
                     ordering += [r["property"]]
         grouping = None
         if request.is_extjs and self.group_param in q:
             r = self.deserialize(q[self.group_param])
             if r["direction"] == "DESC":
-                grouping = "-%s" % r["property"]
+                grouping = "-{}".format(r["property"])
             else:
                 grouping = r["property"]
         fs = None
@@ -374,4 +374,4 @@ class ExtApplication(Application):
         f = SlowOp.submit(fn, self.get_app_id(), request.user.username, *args, **kwargs)
         if f.done():
             return f.result()
-        return self.response_accepted(location="%sfutures/%s/" % (self.base_url, f.slow_op.id))
+        return self.response_accepted(location=f"{self.base_url}futures/{f.slow_op.id}/")

--- a/services/web/base/extdocapplication.py
+++ b/services/web/base/extdocapplication.py
@@ -123,7 +123,7 @@ class ExtDocApplication(ExtApplication):
                 self.has_uuid = True
         if not self.query_fields:
             self.query_fields = [
-                "%s__%s" % (n, self.query_condition)
+                f"{n}__{self.query_condition}"
                 for n, f in self.model._fields.items()
                 if f.unique and isinstance(f, StringField)
             ]
@@ -178,7 +178,7 @@ class ExtDocApplication(ExtApplication):
     def get_permissions(self):
         p = super().get_permissions()
         if self.secret_fields:
-            p.add("%s:secret" % self.get_app_id().replace(".", ":"))
+            p.add("{}:secret".format(self.get_app_id().replace(".", ":")))
         return p
 
     def get_custom_fields(self):
@@ -216,7 +216,7 @@ class ExtDocApplication(ExtApplication):
                     return f
                 return None
             if "__" not in f:
-                return "%s__%s" % (f, self.query_condition)
+                return f"{f}__{self.query_condition}"
             return f
 
         qfx = [get_q(f) for f in self.query_fields]
@@ -313,7 +313,7 @@ class ExtDocApplication(ExtApplication):
         Check current user has *secret* permission on given app
         :return:
         """
-        perm_name = "%s:secret" % (self.get_app_id().replace(".", ":"))
+        perm_name = "{}:secret".format(self.get_app_id().replace(".", ":"))
         return perm_name in Permission.get_effective_permissions(get_user())
 
     def set_file(self, files, o, file_attrs=None):
@@ -350,23 +350,23 @@ class ExtDocApplication(ExtApplication):
                 elif isinstance(f, GeoPointField):
                     pass
                 elif isinstance(f, EnumField):
-                    r["%s__label" % f.name] = v.name
+                    r[f"{f.name}__label"] = v.name
                     v = v.value
                 elif isinstance(f, ForeignKeyListField):
                     v = [{"label": str(vv.name), "id": vv.id} for vv in v]
                 elif isinstance(f, PlainReferenceListField):
                     v = [{"label": str(vv.name), "id": str(vv.id)} for vv in v]
                 elif isinstance(f, ForeignKeyField):
-                    r["%s__label" % f.name] = smart_text(v)
+                    r[f"{f.name}__label"] = smart_text(v)
                     v = v.id
                 elif isinstance(f, PlainReferenceField):
-                    r["%s__label" % f.name] = smart_text(v)
+                    r[f"{f.name}__label"] = smart_text(v)
                     if hasattr(v, "id"):
                         v = str(v.id)
                     else:
                         v = str(v)
                 elif isinstance(f, ReferenceField):
-                    r["%s__label" % f.name] = smart_text(v)
+                    r[f"{f.name}__label"] = smart_text(v)
                     if hasattr(v, "id"):
                         v = str(v.id)
                     else:
@@ -445,9 +445,9 @@ class ExtDocApplication(ExtApplication):
         model = self.parent_model or self.model
         parent = q.get("parent")
         if not parent:
-            qs = {"%s__exists" % self.parent_field: False}
+            qs = {f"{self.parent_field}__exists": False}
         else:
-            qs = {"%s" % self.parent_field: parent}
+            qs = {f"{self.parent_field}": parent}
         if model == DocCategory:
             qs["type"] = DocCategory._senders[self.model]
         data = model.objects.filter(**qs)
@@ -584,7 +584,7 @@ class ExtDocApplication(ExtApplication):
             o.delete()
         except ValueError as e:
             return self.render_json(
-                {"status": False, "message": "ERROR: %s" % e}, status=self.CONFLICT
+                {"status": False, "message": f"ERROR: {e}"}, status=self.CONFLICT
             )
         return HttpResponse(status=self.DELETED)
 

--- a/services/web/base/extmodelapplication.py
+++ b/services/web/base/extmodelapplication.py
@@ -120,15 +120,13 @@ class ExtModelApplication(ExtApplication):
         if not self.query_fields:
             # By default - search in unique text fields
             self.query_fields = [
-                "%s__%s" % (f.name, self.query_condition)
+                f"{f.name}__{self.query_condition}"
                 for f in self.model._meta.fields
                 if f.unique and isinstance(f, CharField)
             ]
         # Add searchable custom fields
         self.query_fields += [
-            "%s__%s" % (f.name, self.query_condition)
-            for f in self.get_custom_fields()
-            if f.is_searchable
+            f"{f.name}__{self.query_condition}" for f in self.get_custom_fields() if f.is_searchable
         ]
         # Install JSON API call when necessary
         if hasattr(self.model, "_json_collection"):
@@ -163,7 +161,7 @@ class ExtModelApplication(ExtApplication):
     def get_permissions(self):
         p = super().get_permissions()
         if self.secret_fields:
-            p.add("%s:secret" % self.get_app_id().replace(".", ":"))
+            p.add("{}:secret".format(self.get_app_id().replace(".", ":")))
         return p
 
     def get_validator(self, field):
@@ -229,7 +227,7 @@ class ExtModelApplication(ExtApplication):
 
         def get_q(f):
             if "__" not in f:
-                return "%s__%s" % (f, self.query_condition)
+                return f"{f}__{self.query_condition}"
             return f
 
         q = reduce(
@@ -307,9 +305,9 @@ class ExtModelApplication(ExtApplication):
                 if match:
                     field = self.rx_oper_splitter.match(p).group("field") + self.in_param
                     if field not in q:
-                        q[field] = "%s" % (q[p])
+                        q[field] = f"{q[p]}"
                     else:
-                        q[field] += ",%s" % (q[p])
+                        q[field] += f",{q[p]}"
                     del q[p]
         for p in q:
             if p.endswith("__exists"):
@@ -343,20 +341,15 @@ class ExtModelApplication(ExtApplication):
                 app, fn = v.split("__", 1)
                 model = getattr(self.site.apps[app], "model", None)
                 if model and not is_document(model):
-                    extra_where = '%s."%s" IN (SELECT "%s" FROM %s)' % (
-                        self.model._meta.db_table,
-                        self.model._meta.pk.name,
-                        model._meta.get_field(fn).attname,
-                        model._meta.db_table,
-                    )
+                    extra_where = f'{self.model._meta.db_table}."{self.model._meta.pk.name}" IN (SELECT "{model._meta.get_field(fn).attname}" FROM {model._meta.db_table})'
                     if None in nq:
                         nq[None] += [extra_where]
                     else:
                         nq[None] = [extra_where]
                 continue
-            if lt and hasattr(self, "lookup_%s" % lt):
+            if lt and hasattr(self, f"lookup_{lt}"):
                 # Custom lookup
-                getattr(self, "lookup_%s" % lt)(nq, np, v)
+                getattr(self, f"lookup_{lt}")(nq, np, v)
                 continue
             if np in {"effective_service_groups", "effective_client_groups"} and v:
                 nq[f"{np}__overlap"] = ResourceGroup.get_nested_ids(v)
@@ -381,7 +374,7 @@ class ExtModelApplication(ExtApplication):
         Check current user has *secret* permission on given app
         :return:
         """
-        perm_name = "%s:secret" % (self.get_app_id().replace(".", ":"))
+        perm_name = "{}:secret".format(self.get_app_id().replace(".", ":"))
         return perm_name in Permission.get_effective_permissions(get_user())
 
     def has_field_editable(self, field):
@@ -416,10 +409,10 @@ class ExtModelApplication(ExtApplication):
                 v = getattr(o, f.name)
                 if v:
                     r[f.name] = str(v.pk)
-                    r["%s__label" % f.name] = smart_text(v)
+                    r[f"{f.name}__label"] = smart_text(v)
                 else:
                     r[f.name] = None
-                    r["%s__label" % f.name] = ""
+                    r[f"{f.name}__label"] = ""
             elif not is_related_field(f):
                 v = f.value_from_object(o)
                 if (
@@ -437,10 +430,10 @@ class ExtModelApplication(ExtApplication):
                 v = getattr(o, f.name)
                 if v:
                     r[f.name] = v._get_pk_val()
-                    r["%s__label" % f.name] = smart_text(v)
+                    r[f"{f.name}__label"] = smart_text(v)
                 else:
                     r[f.name] = None
-                    r["%s__label" % f.name] = ""
+                    r[f"{f.name}__label"] = ""
         # Add m2m fields
         for n in self.m2m_fields:
             r[n] = [{"id": str(mmo.pk), "label": smart_text(mmo)} for mmo in getattr(o, n).all()]
@@ -463,7 +456,7 @@ class ExtModelApplication(ExtApplication):
             return
         if isinstance(value, str):
             value = [value]
-        tq = ("%%s::text[] <@ %s.tags" % self.db_table, [value])
+        tq = (f"%s::text[] <@ {self.db_table}.tags", [value])
         if None in q:
             q[None] += [tq]
         else:
@@ -651,9 +644,9 @@ class ExtModelApplication(ExtApplication):
             except ValidationError as e:
                 e_msg = []
                 for f in e.message_dict:
-                    e_msg += ["%s: %s" % (f, "; ".join(e.message_dict[f]))]
+                    e_msg += ["{}: {}".format(f, "; ".join(e.message_dict[f]))]
                 return self.render_json(
-                    {"status": False, "message": "Validation error: %s" % " | ".join(e_msg)},
+                    {"status": False, "message": "Validation error: {}".format(" | ".join(e_msg))},
                     status=self.BAD_REQUEST,
                 )
             # Check permissions
@@ -671,7 +664,7 @@ class ExtModelApplication(ExtApplication):
                     self.update_file(request.FILES, o, file_attrs)
             except IntegrityError as e:
                 return self.render_json(
-                    {"status": False, "message": "Integrity error: %s" % e}, status=self.CONFLICT
+                    {"status": False, "message": f"Integrity error: {e}"}, status=self.CONFLICT
                 )
             # Check format
             if request.is_extjs:
@@ -739,9 +732,9 @@ class ExtModelApplication(ExtApplication):
         except ValidationError as e:
             e_msg = []
             for f in e.message_dict:
-                e_msg += ["%s: %s" % (f, "; ".join(e.message_dict[f]))]
+                e_msg += ["{}: {}".format(f, "; ".join(e.message_dict[f]))]
             return self.render_json(
-                {"status": False, "message": "Validation error: %s" % " | ".join(e_msg)},
+                {"status": False, "message": "Validation error: {}".format(" | ".join(e_msg))},
                 status=self.BAD_REQUEST,
             )
         # Check permissions
@@ -789,7 +782,7 @@ class ExtModelApplication(ExtApplication):
             o.delete()
         except ValueError as e:
             return self.render_json(
-                {"status": False, "message": "ERROR: %s" % e}, status=self.CONFLICT
+                {"status": False, "message": f"ERROR: {e}"}, status=self.CONFLICT
             )
         return HttpResponse(status=self.DELETED)
 
@@ -811,7 +804,7 @@ class ExtModelApplication(ExtApplication):
         coll_name = self.model._json_collection["json_collection"]
         return {
             "path": str(Path("collections", coll_name) / o.get_json_path()),
-            "title": "%s: %s" % (coll_name, str(o)),
+            "title": f"{coll_name}: {o!s}",
             "content": o.to_json(),
             "description": "",
         }

--- a/services/web/base/modelinline.py
+++ b/services/web/base/modelinline.py
@@ -82,60 +82,58 @@ class ModelInline:
         if not self.query_fields:
             # By default - search in unique text fields
             self.query_fields = [
-                "%s__%s" % (f.name, self.query_condition)
+                f"{f.name}__{self.query_condition}"
                 for f in self.model._meta.fields
                 if f.unique and isinstance(f, CharField)
             ]
         # Add searchable custom fields
         self.query_fields += [
-            "%s__%s" % (f.name, self.query_condition)
-            for f in self.get_custom_fields()
-            if f.is_searchable
+            f"{f.name}__{self.query_condition}" for f in self.get_custom_fields() if f.is_searchable
         ]
 
     def contribute_to_class(self, app, name):
         # Add List handler
         app.add_view(
-            "api_%s_list" % name,
+            f"api_{name}_list",
             self.api_list,
             method=["GET"],
-            url=r"^(?P<parent>[^/]+)/%s/$" % name,
+            url=rf"^(?P<parent>[^/]+)/{name}/$",
             access="read",
             api=True,
         )
         # Add Create handler
         app.add_view(
-            "api_%s_create" % name,
+            f"api_{name}_create",
             self.api_create,
             method=["POST"],
-            url=r"^(?P<parent>[^/]+)/%s/$" % name,
+            url=rf"^(?P<parent>[^/]+)/{name}/$",
             access="create",
             api=True,
         )
         # Add Read Handler
         app.add_view(
-            "api_%s_read" % name,
+            f"api_{name}_read",
             self.api_read,
             method=["GET"],
-            url=r"^(?P<parent>[^/]+)/%s/(?P<id>\d+)/?$" % name,
+            url=rf"^(?P<parent>[^/]+)/{name}/(?P<id>\d+)/?$",
             access="read",
             api=True,
         )
         # Add Update Handler
         app.add_view(
-            "api_%s_update" % name,
+            f"api_{name}_update",
             self.api_update,
             method=["PUT"],
-            url=r"^(?P<parent>[^/]+)/%s/(?P<id>\d+)/?$" % name,
+            url=rf"^(?P<parent>[^/]+)/{name}/(?P<id>\d+)/?$",
             access="update",
             api=True,
         )
         # Add Delete Handler
         app.add_view(
-            "api_%s_delete" % name,
+            f"api_{name}_delete",
             self.api_delete,
             method=["DELETE"],
-            url=r"^(?P<parent>[^/]+)/%s/(?P<id>\d+)/?$" % name,
+            url=rf"^(?P<parent>[^/]+)/{name}/(?P<id>\d+)/?$",
             access="delete",
             api=True,
         )
@@ -193,7 +191,7 @@ class ModelInline:
 
         def get_q(f):
             if "__" not in f:
-                return "%s__%s" % (f, self.query_condition)
+                return f"{f}__{self.query_condition}"
             return f
 
         q = reduce(
@@ -272,20 +270,15 @@ class ModelInline:
                 # Unroll __referred
                 app, fn = v.split("__", 1)
                 model = self.app.site.apps[app].model
-                extra_where = '%s."%s" IN (SELECT "%s" FROM %s)' % (
-                    self.model._meta.db_table,
-                    self.model._meta.pk.name,
-                    model._meta.get_field(fn).attname,
-                    model._meta.db_table,
-                )
+                extra_where = f'{self.model._meta.db_table}."{self.model._meta.pk.name}" IN (SELECT "{model._meta.get_field(fn).attname}" FROM {model._meta.db_table})'
                 if None in nq:
                     nq[None] += [extra_where]
                 else:
                     nq[None] = [extra_where]
                 continue
-            if lt and hasattr(self, "lookup_%s" % lt):
+            if lt and hasattr(self, f"lookup_{lt}"):
                 # Custom lookup
-                getattr(self, "lookup_%s" % lt)(nq, np, v)
+                getattr(self, f"lookup_{lt}")(nq, np, v)
                 continue
             if np in self.fk_fields and lt:
                 # dereference
@@ -322,10 +315,10 @@ class ModelInline:
                 v = getattr(o, f.name)
                 if v:
                     r[f.name] = v._get_pk_val()
-                    r["%s__label" % f.name] = smart_text(v)
+                    r[f"{f.name}__label"] = smart_text(v)
                 else:
                     r[f.name] = None
-                    r["%s__label" % f.name] = ""
+                    r[f"{f.name}__label"] = ""
         # Add custom fields
         for f in self.custom_fields:
             if fields and f not in fields:
@@ -351,12 +344,12 @@ class ModelInline:
         if format == "ext" and self.sort_param in q:
             for r in self.app.deserialize(q[self.sort_param]):
                 if r["direction"] == "DESC":
-                    ordering += ["-%s" % r["property"]]
+                    ordering += ["-{}".format(r["property"])]
                 else:
                     ordering += [r["property"]]
         q = self.cleaned_query(q)
         if parent:
-            q["%s__id" % self.parent_rel] = parent
+            q[f"{self.parent_rel}__id"] = parent
         if None in q:
             ew = q.pop(None)
             data = self.queryset(request, query).filter(**q).extra(where=ew)
@@ -457,7 +450,7 @@ class ModelInline:
 
     def api_delete(self, request, parent, id):
         try:
-            q = {"id": int(id), "%s__id" % self.parent_rel: int(parent)}
+            q = {"id": int(id), f"{self.parent_rel}__id": int(parent)}
             o = self.queryset(request).get(**q)
         except self.model.DoesNotExist:
             return self.app.render_json(

--- a/services/web/base/repoinline.py
+++ b/services/web/base/repoinline.py
@@ -21,47 +21,46 @@ class RepoInline:
     def contribute_to_class(self, app, name):
         # Get last revision
         app.add_view(
-            "api_%s_get" % name,
+            f"api_{name}_get",
             self.api_get,
             method=["GET"],
-            url="^(?P<parent>[^/]+)/repo/%s/$" % name,
+            url=f"^(?P<parent>[^/]+)/repo/{name}/$",
             access=self.access,
             api=True,
         )
         # Get list of revisions
         app.add_view(
-            "api_%s_revisions" % name,
+            f"api_{name}_revisions",
             self.api_revisions,
             method=["GET"],
-            url="^(?P<parent>[^/]+)/repo/%s/revisions/$" % name,
+            url=f"^(?P<parent>[^/]+)/repo/{name}/revisions/$",
             access=self.access,
             api=True,
         )
         # Get particular revision
         app.add_view(
-            "api_%s_get_revision" % name,
+            f"api_{name}_get_revision",
             self.api_get_revision,
             method=["GET"],
-            url="^(?P<parent>[^/]+)/repo/%s/(?P<revision>[0-9a-f]{24})/$" % name,
+            url=f"^(?P<parent>[^/]+)/repo/{name}/(?P<revision>[0-9a-f]{{24}})/$",
             access=self.access,
             api=True,
         )
         # Get diff
         app.add_view(
-            "api_%s_diff" % name,
+            f"api_{name}_diff",
             self.api_get_diff,
             method=["GET"],
-            url="^(?P<parent>[^/]+)/repo/%s/(?P<rev1>[0-9a-f]{24})/(?P<rev2>[0-9a-f]{24})/$" % name,
+            url=f"^(?P<parent>[^/]+)/repo/{name}/(?P<rev1>[0-9a-f]{{24}})/(?P<rev2>[0-9a-f]{{24}})/$",
             access=self.access,
             api=True,
         )
         # Get mdiff
         app.add_view(
-            "api_%s_mdiff" % name,
+            f"api_{name}_mdiff",
             self.api_get_mdiff,
             method=["GET"],
-            url="^(?P<parent>[^/]+)/repo/%s/(?P<rev1>[0-9a-f]{24})/(?P<obj2>[^/]+)/(?P<rev2>[0-9a-f]{24})/$"
-            % name,
+            url=f"^(?P<parent>[^/]+)/repo/{name}/(?P<rev1>[0-9a-f]{{24}})/(?P<obj2>[^/]+)/(?P<rev2>[0-9a-f]{{24}})/$",
             access=self.access,
             api=True,
         )
@@ -70,7 +69,7 @@ class RepoInline:
         self.app = app
         self.logger = app.logger
         self.parent_model = self.app.model
-        self.check_access = getattr(self.app, "has_repo_%s_access" % self.field, None)
+        self.check_access = getattr(self.app, f"has_repo_{self.field}_access", None)
 
     def clean_parent(self, v):
         return int(v)

--- a/services/web/base/reportapplication.py
+++ b/services/web/base/reportapplication.py
@@ -74,7 +74,7 @@ class ReportApplication(Application):
         query = {}
         # Check format is valid for application
         if format not in self.supported_formats():
-            return self.response_not_found("Unsupported format '%s'" % format)
+            return self.response_not_found(f"Unsupported format '{format}'")
             # Display and check form if necessary
         form_class = self.get_form()
         if form_class:
@@ -97,7 +97,7 @@ class ReportApplication(Application):
                     inline_styles=self.inline_styles,
                 )
                 # Build result
-        rdata = getattr(self, "report_%s" % format)(request=request, **query)
+        rdata = getattr(self, f"report_{format}")(request=request, **query)
         # Render result
         if format == "html":
             return self.render(request, "report.html", data=rdata, app=self, is_report=True)

--- a/services/web/base/reportdatasources/base.py
+++ b/services/web/base/reportdatasources/base.py
@@ -263,7 +263,7 @@ class ReportModelFilter:
         ids = []
         moss = self.model.objects.filter()
         for f in formula.split("."):
-            self.logger.debug("Decoding: %s" % f)
+            self.logger.debug(f"Decoding: {f}")
             f_num, f_type, f_val = self.decode_re.findall(f.lower())[0]
             func_stat = self.f_map[f_type]
             func_stat = getattr(func_stat, "get_stat")(f_num, f_val)

--- a/services/web/base/reportdatasources/report_metrics.py
+++ b/services/web/base/reportdatasources/report_metrics.py
@@ -40,7 +40,7 @@ class ReportMetrics(BaseReportColumn):
 
     @staticmethod
     def get_mo_filter(ids, use_dictionary=False):
-        return "managed_object IN (%s)" % ", ".join([str(c) for c in ids])
+        return "managed_object IN ({})".format(", ".join([str(c) for c in ids]))
 
     def get_custom_conditions(self):
         return self.CUSTOM_FILTER
@@ -62,16 +62,18 @@ class ReportMetrics(BaseReportColumn):
             "q_order_by": self.KEY_FIELDS,
         }
         for num, field, alias in sorted(self.SELECT_QUERY_MAP, key=lambda x: x[0]):
-            func = self.SELECT_QUERY_MAP[(num, field, alias)] or "avg(%s)" % field
-            def_map["q_select"] += ["%s AS %s" % (func, alias or "a_" + field)]
+            func = self.SELECT_QUERY_MAP[(num, field, alias)] or f"avg({field})"
+            def_map["q_select"] += ["{} AS {}".format(func, alias or "a_" + field)]
         return " ".join(
             [
-                "SELECT %s" % ",".join(def_map["q_select"]),
-                "FROM %s" % self.TABLE_NAME,
-                "WHERE %s" % " AND ".join(def_map["q_where"]),
-                "GROUP BY %s" % ",".join(def_map["q_group"]),
-                "HAVING %s" % " AND ".join(def_map["q_having"]) if def_map["q_having"] else "",
-                "ORDER BY %s" % ",".join(def_map["q_order_by"]),
+                "SELECT {}".format(",".join(def_map["q_select"])),
+                f"FROM {self.TABLE_NAME}",
+                "WHERE {}".format(" AND ".join(def_map["q_where"])),
+                "GROUP BY {}".format(",".join(def_map["q_group"])),
+                "HAVING {}".format(" AND ".join(def_map["q_having"]))
+                if def_map["q_having"]
+                else "",
+                "ORDER BY {}".format(",".join(def_map["q_order_by"])),
             ]
         )
 

--- a/services/web/base/reportdatasources/report_objectcaps.py
+++ b/services/web/base/reportdatasources/report_objectcaps.py
@@ -29,7 +29,7 @@ class ReportObjectCaps(BaseReportColumn):
     builtin_sorted = True
 
     ATTRS = {
-        "c_%s" % str(key): value
+        f"c_{key!s}": value
         for key, value in Capability.objects.filter().order_by("name").scalar("id", "name")
     }
     unknown_value = ([""] * len(ATTRS),)

--- a/services/web/base/reportdatasources/report_objectifacesstatusstat.py
+++ b/services/web/base/reportdatasources/report_objectifacesstatusstat.py
@@ -42,7 +42,7 @@ class ReportObjectIfacesStatusStat(BaseReportColumn):
                 if speed >= t:
                     if speed // t * t == speed:
                         return "%d%s" % (speed // t, n)
-                    return "%.2f%s" % (float(speed) / t, n)
+                    return f"{float(speed) / t:.2f}{n}"
             return str(speed)
 
         oper = True

--- a/services/web/base/reportdatasources/report_objectstat.py
+++ b/services/web/base/reportdatasources/report_objectstat.py
@@ -37,8 +37,8 @@ class IsolatorClass:
     @cachetools.cached(cachetools.TTLCache(maxsize=20, ttl=600))
     def get_stat(self, num, value):
         # print("%s a %s, %s" % (self.name, num, value))
-        if hasattr(self, "_%s_%s" % (num, self.name)):
-            a = getattr(self, "_%s_%s" % (num, self.name))
+        if hasattr(self, f"_{num}_{self.name}"):
+            a = getattr(self, f"_{num}_{self.name}")
             return a(value)
         return self.default(num, value)
 
@@ -85,7 +85,7 @@ class AttributeIsolator(IsolatorClass):
             # Cross link
             num1, num2 = num.split("0", 1)
             ff2 = [n.name for n in self.OP_ATTR_MAP[num]["model"]._meta.fields][int(num2)]
-            field = "%s__%s" % (self.fields[int(num1)], ff2)
+            field = f"{self.fields[int(num1)]}__{ff2}"
         else:
             field = self.fields[int(num)]
 

--- a/services/web/base/simplereport.py
+++ b/services/web/base/simplereport.py
@@ -53,10 +53,10 @@ class ReportNode:
         """
         Return opening XML tag
         """
-        s = "<%s" % self.tag
+        s = f"<{self.tag}"
         for k, v in kwargs.items():
             if v:
-                s += " %s='%s'" % (k, self.quote(v))
+                s += f" {k}='{self.quote(v)}'"
         s += ">"
         return s
 
@@ -64,7 +64,7 @@ class ReportNode:
         """
         Return closing XML tag
         """
-        return "</%s>" % self.tag
+        return f"</{self.tag}>"
 
     def indent(self, s, n=1):
         """
@@ -152,8 +152,8 @@ class TextSection(ReportSection):
         """
         s = []
         if self.title:
-            s += ["<h2>%s</h2>" % self.quote(self.title)]
-        s += ["<p>%s</p>" % self.quote(p) for p in self.paragraphs]
+            s += [f"<h2>{self.quote(self.title)}</h2>"]
+        s += [f"<p>{self.quote(p)}</p>" for p in self.paragraphs]
         return "\n".join(s)
 
 
@@ -202,8 +202,8 @@ class TableColumn(ReportNode):
             if align
             else None
         )
-        self.format = getattr(self, "f_%s" % format) if isinstance(format, str) else format
-        self.total = getattr(self, "ft_%s" % total) if isinstance(total, str) else total
+        self.format = getattr(self, f"f_{format}") if isinstance(format, str) else format
+        self.total = getattr(self, f"ft_{total}") if isinstance(total, str) else total
         self.total_label = total_label
         self.total_data = []
         self.subtotal_data = []
@@ -250,7 +250,7 @@ class TableColumn(ReportNode):
                 attrs["align"] = "right"
             elif self.align & self.H_ALIGN_MASK == self.ALIGN_CENTER:
                 attrs["align"] = "center"
-        return " " + " ".join(["%s='%s'" % (k, self.quote(v)) for k, v in attrs.items()])
+        return " " + " ".join([f"{k}='{self.quote(v)}'" for k, v in attrs.items()])
 
     def format_html(self, s):
         """
@@ -261,7 +261,7 @@ class TableColumn(ReportNode):
         d = self.format_data(s)
         if not isinstance(d, SafeString):
             d = self.quote(d)
-        return "<td%s>%s</td>" % (self.html_td_attrs(), d)
+        return f"<td{self.html_td_attrs()}>{d}</td>"
 
     def format_html_total(self):
         """
@@ -274,7 +274,7 @@ class TableColumn(ReportNode):
             total = self.total_label
         else:
             total = ""
-        return "<td%s><b>%s</b></td>" % (self.html_td_attrs(), total)
+        return f"<td{self.html_td_attrs()}><b>{total}</b></td>"
 
     def format_html_subtotal(self, d):
         """
@@ -288,7 +288,7 @@ class TableColumn(ReportNode):
             total = self.total_label
         else:
             total = ""
-        return "<td%s><b>%s</b></td>" % (self.html_td_attrs(), total)
+        return f"<td{self.html_td_attrs()}><b>{total}</b></td>"
 
     def f_date(self, f):
         """
@@ -323,9 +323,9 @@ class TableColumn(ReportNode):
         f = decimal.Decimal(f)
         for limit, divider, suffix in SIZE_DATA:
             if f < limit:
-                return ("%8.2f%s" % (f / divider, suffix)).strip()
+                return (f"{f / divider:8.2f}{suffix}").strip()
         limit, divider, suffix = SIZE_DATA[-1]
-        return ("%8.2f%s" % (f / divider, suffix)).strip()
+        return (f"{f / divider:8.2f}{suffix}").strip()
 
     def f_numeric(self, f):
         """
@@ -369,7 +369,7 @@ class TableColumn(ReportNode):
         """
         Display url field
         """
-        return SafeString('<a href="%s", target="_blank">Link</a>' % url)
+        return SafeString(f'<a href="{url}", target="_blank">Link</a>')
 
     def f_integer(self, f):
         """
@@ -387,7 +387,7 @@ class TableColumn(ReportNode):
         """
         Returns a pretty-printed object
         """
-        return SafeString("<pre>%s</pre>" % pprint.pformat(f))
+        return SafeString(f"<pre>{pprint.pformat(f)}</pre>")
 
     def f_string(self, f):
         """
@@ -515,16 +515,16 @@ class TableSection(ReportSection):
                 "   var buttons = $('.button').prop('disabled', false);",
                 "});",
                 "</script>",
-                "<table class='report-table' summary='%s'>" % self.quote(self.name),
+                f"<table class='report-table' summary='{self.quote(self.name)}'>",
             ]
         else:
-            s = ["<table class='report-table' summary='%s'>" % self.quote(self.name)]
+            s = [f"<table class='report-table' summary='{self.quote(self.name)}'>"]
         # Render header
         s += ["<thead>"]
         s += ["<tr>"]
         if self.enumerate:
             s += ["<th>#</th>"]
-        s += ["<th>%s</th>" % self.quote(c.title) for c in self.columns]
+        s += [f"<th>{self.quote(c.title)}</th>" for c in self.columns]
         s += ["</tr>"]
         s += ["</thead>"]
         s += ["<tbody>"]

--- a/services/web/base/site.py
+++ b/services/web/base/site.py
@@ -62,16 +62,16 @@ class URL:
                 raise TypeError("Invalid type for 'method'")
             for m in method:
                 if m not in HTTP_METHODS:
-                    raise ValueError("Invalid method '%s'" % m)
+                    raise ValueError(f"Invalid method '{m}'")
             self.method = set(method)
 
     def __repr__(self):
-        return "<URL %s>" % smart_text(self)
+        return f"<URL {smart_text(self)}>"
 
     def __str__(self):
         s = self.url
         if self.name:
-            s += ", name='%s'" % self.name
+            s += f", name='{self.name}'"
         return s
 
 
@@ -214,7 +214,7 @@ class Site:
                                 g = orjson.loads(request.body)
                             except ValueError as e:
                                 logger.error("Unable to decode JSON: %s", e)
-                                errors = "Unable to decode JSON: %s" % e
+                                errors = f"Unable to decode JSON: {e}"
                         else:
                             g = {k: v[0] if len(v) == 1 else v for k, v in request.POST.lists()}
                         if not errors:
@@ -257,10 +257,10 @@ class Site:
                             stmt = q["sql"].strip().split(" ", 1)[0].upper()
                             sc[stmt] += 1
                             tsc += 1
-                            app_logger.debug("SQL %(sql)s %(time)ss" % q)
+                            app_logger.debug("SQL {sql} {time}s".format(**q))
                     x = ", ".join("%s: %d" % (k, cv) for k, cv in sc.items())
                     if x:
-                        x = " (%s)" % x
+                        x = f" ({x})"
                     app_logger.debug("SQL statements: %d%s" % (tsc, x))
             except PermissionDenied as e:
                 return HttpResponseForbidden(e)
@@ -323,7 +323,7 @@ class Site:
             else:
                 r = {"id": self.get_menu_id(path), "title": p, "children": []}
                 if p in self.folder_glyps:
-                    r["iconCls"] = "fa fa-%s" % self.folder_glyps[p]
+                    r["iconCls"] = f"fa fa-{self.folder_glyps[p]}"
                 root["children"] += [r]
                 root = r
         path += parts
@@ -332,11 +332,11 @@ class Site:
             "id": self.get_menu_id(path),
             "title": parts[0],
             "app": app,
-            "iconCls": "fa fa-%s noc-edit" % app.glyph,
+            "iconCls": f"fa fa-{app.glyph} noc-edit",
         }
         if view:
             r["access"] = self.site_access(app, view)
-            app.menu_url = ("/%s/%s/%s" % (app.module, app.app, view.url[1:])).replace("$", "")
+            app.menu_url = (f"/{app.module}/{app.app}/{view.url[1:]}").replace("$", "")
         else:
             r["access"] = lambda user: app.launch_access.check(app, user)
         root["children"] += [r]
@@ -373,7 +373,7 @@ class Site:
                 elif isinstance(view.url, URL):
                     view_url = view.url
                 else:
-                    raise ValueError("Invalid URL object: %s" % view.url)
+                    raise ValueError(f"Invalid URL object: {view.url}")
                 app_url_map[view_url.url] += [(view_url, view)]
             # Install URLs
             for url in app_url_map:
@@ -396,9 +396,9 @@ class Site:
             # Collect nested application routes
             mod_includes = []
             for app in sorted(patterns[module]):
-                mod_includes += [path("%s/" % app, include((patterns[module][app], app)))]
+                mod_includes += [path(f"{app}/", include((patterns[module][app], app)))]
             # Install module routes
-            self.urlpatterns += [path("%s/" % module, include((mod_includes, module)))]
+            self.urlpatterns += [path(f"{module}/", include((mod_includes, module)))]
         # Django JS Translation
         # @todo: Remove?
         self.urlpatterns.append(
@@ -418,7 +418,7 @@ class Site:
         """
         app_id = app_class.get_app_id()
         if app_id in self.apps:
-            raise Exception("Application %s is already registered" % app_id)
+            raise Exception(f"Application {app_id} is already registered")
         self.pending_applications += [app_class]
 
     def do_register(self, app_class):
@@ -431,7 +431,7 @@ class Site:
         # Register application
         app_id = app_class.get_app_id()
         if app_id in self.apps:
-            raise Exception("Application %s is already registered" % app_id)
+            raise Exception(f"Application {app_id} is already registered")
         # Initialize application
         app = app_class(self)
         self.apps[app_id] = app
@@ -444,7 +444,7 @@ class Site:
         self.app_count += 1
 
     def add_module_menu(self, m):
-        mn = "noc.services.web.apps.%s" % m[4:]  # Strip noc.
+        mn = f"noc.services.web.apps.{m[4:]}"  # Strip noc.
         mod_name = importlib.import_module(mn).MODULE_NAME
         r = {"id": self.get_menu_id([m]), "title": mod_name, "children": []}
         self.menu += [r]
@@ -545,7 +545,7 @@ class Site:
             kw = kwargs.copy()
             query = ""
             if "QUERY" in kw:
-                query = "?%s" % urlencode(kw["QUERY"])
+                query = "?{}".format(urlencode(kw["QUERY"]))
                 del kw["QUERY"]
             return reverse(url, args=args, kwargs=kw) + query
         return url
@@ -577,7 +577,7 @@ class Site:
             pr = getattr(self.apps[app], "predefined_reports", None)
             if pr:
                 for pr in self.apps[app].predefined_reports:
-                    yield "%s:%s" % (app, pr), self.apps[app].predefined_reports[pr]
+                    yield f"{app}:{pr}", self.apps[app].predefined_reports[pr]
 
     @classmethod
     def is_json(cls, content_type: str) -> bool:


### PR DESCRIPTION
**Purpose:** Replace `%` string formatting with `.format()` and f-strings across `services/web/`, continuing the project-wide modernization (#379 covered migrations, this covers the web service).

**Key changes:**
- 79 files in `services/web/` (+497/-511)
- `%s → f"{var}"` for all simple substitutions
- `"%06x" → "{val:06x}"` for hex color formatting  
- `{24}` regex quantifiers properly doubled (`{{24}}`) in f-strings; raw f-strings (`rf"..."`) used where literal backslashes are needed
- `.format(*tuple)` used where multiple values need unpacking (SQL queries, SQL CASE statements)

**Notable areas:**
- `services/web/apps/inv/` — 14+ plugin files with URL regex patterns updated
- `services/web/apps/sa/managedobject.py` — SQL CASE statement generation for profile/platform/version sorting
- `services/web/apps/fm/alarm/views.py` — HTML string generation in summary function
- `services/web/base/` — application routing, access check, and model inline patterns