### PR TITLE
Refactor to_json, docstrings and typing

### DIFF
--- a/core/escape.py
+++ b/core/escape.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # Escape/unescape to various encodings
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -12,9 +12,17 @@ import binascii
 from noc.core.comp import smart_bytes, smart_text
 
 
-def json_escape(s):
+def json_escape(s: str | bool | None) -> str:
     """
-    Escape JSON predefined sequences
+    Escape a value for safe inclusion into a JSON string.
+
+    Args:
+        s: String value to escape. ``bool`` values are converted to JSON
+            literals (``"true"`` or ``"false"``), while ``None`` is
+            converted to an empty string.
+
+    Returns:
+        Escaped string representation of the value.
     """
     if isinstance(s, bool):
         return "true" if s else "false"

--- a/core/prettyjson.py
+++ b/core/prettyjson.py
@@ -1,69 +1,110 @@
 # ---------------------------------------------------------------------
 # Pretty JSON formatter
-# ---------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# ----------------------------------------------------------------------
+# Copyright (C) 2007-2019 The NOC Project
 # See LICENSE for details
-# ---------------------------------------------------------------------
+# ----------------------------------------------------------------------
 
 # Python modules
+from __future__ import annotations
+
 import uuid
-from functools import reduce
+from collections.abc import Collection
 
 # NOC modules
 from noc.core.escape import json_escape
 from noc.core.text import indent
 
 
-class PrettyJSON:
-    @classmethod
-    def to_json(cls, o, order=None) -> str:
-        r = cls.convert(o, 0, order)
-        if not r.endswith("\n"):
-            r += "\n"
-        return r
+def _convert(
+    value: object,
+    level: int,
+    order: Collection[str] | None,
+) -> str:
+    """
+    Convert a Python object to a pretty-printed JSON fragment.
 
-    @classmethod
-    def convert(cls, o, i, order=None):
-        if o is None:
-            return indent("null", i)
-        if isinstance(o, str):
-            return indent(f'"{json_escape(o)}"', i)
-        if isinstance(o, bool):
-            return indent("true" if o else "false", i)
-        if isinstance(o, int):
-            return indent("%d" % o, i)
-        if isinstance(o, float):
-            return indent(str(o), i)
-        if isinstance(o, uuid.UUID):
-            return indent(f'"{o}"', i)
-        if isinstance(o, list):
-            if len(o) == 0:
-                return indent("[]", i)
-            t = [cls.convert(e, 0, order) for e in o]
-            lt = reduce(lambda x, y: x + y, [len(x) for x in t])
-            lt += i + (len(o) - 1) * 2
-            if lt > 72:
-                # Long line
-                r = [indent("[", i)]
-                r += [",\n".join(indent(x, i + 4) for x in t)]
-                r += [indent("]", i)]
-                return "\n".join(r)
-            items = ", ".join(t)
-            r = f"[{items}]"
-            return indent(r, i)
-        if isinstance(o, dict):
-            if not o:
-                return indent("{}", i)
-            keys = sorted(o)
-            if order:
-                nk = [k for k in order if k in keys]
-                nk += [k for k in keys if k not in order]
-                keys = nk
-            r = ",\n".join(
-                f"{cls.convert(k, 0, order)}: {cls.convert(o[k], 0, order)}" for k in keys
+    Args:
+        value: Value to serialize.
+        level: Current indentation level.
+        order: Optional preferred ordering for dictionary keys.
+
+    Returns:
+        Pretty-printed JSON fragment.
+    """
+    if value is None:
+        return indent("null", level)
+
+    if isinstance(value, str):
+        return indent(f'"{json_escape(value)}"', level)
+
+    if isinstance(value, bool):
+        return indent("true" if value else "false", level)
+
+    if isinstance(value, int):
+        return indent(str(value), level)
+
+    if isinstance(value, float):
+        return indent(str(value), level)
+
+    if isinstance(value, uuid.UUID):
+        return indent(f'"{value}"', level)
+
+    if isinstance(value, list):
+        if not value:
+            return indent("[]", level)
+
+        items = [_convert(item, 0, order) for item in value]
+        line_length = sum(map(len, items)) + level + (len(items) - 1) * 2
+
+        if line_length > 72:
+            body = ",\n".join(indent(item, level + 4) for item in items)
+            return "\n".join(
+                (
+                    indent("[", level),
+                    body,
+                    indent("]", level),
+                )
             )
-            return indent(f"{{\n{indent(r, 4)}\n}}", i)
-        raise ValueError(f"Cannot encode {o!r}")
+
+        return indent(f"[{', '.join(items)}]", level)
+
+    if isinstance(value, dict):
+        if not value:
+            return indent("{}", level)
+
+        keys = sorted(value)
+        if order:
+            keys = [k for k in order if k in value] + [k for k in keys if k not in order]
+
+        body = ",\n".join(
+            f"{_convert(key, 0, order)}: {_convert(value[key], 0, order)}" for key in keys
+        )
+        return indent(f"{{\n{indent(body, 4)}\n}}", level)
+
+    raise TypeError(f"Cannot encode {type(value).__name__}: {value!r}")
 
 
-to_json = PrettyJSON.to_json
+def to_json(
+    value: object,
+    order: Collection[str] | None = None,
+) -> str:
+    """
+    Serialize an object to pretty-printed JSON.
+
+    Supported types are ``None``, ``str``, ``bool``, ``int``, ``float``,
+    ``uuid.UUID``, ``list``, and ``dict``.
+
+    Args:
+        value: Value to serialize.
+        order: Optional preferred ordering for dictionary keys. Keys not
+            listed here are appended in sorted order.
+
+    Returns:
+        Pretty-printed JSON terminated by a trailing newline.
+
+    Raises:
+        TypeError: If the value contains an unsupported type.
+    """
+    result = _convert(value, 0, order)
+    return result if result.endswith("\n") else f"{result}\n"

--- a/tests/test_prettyjson.py
+++ b/tests/test_prettyjson.py
@@ -27,5 +27,5 @@ def test_prettyjson(config, expected):
     ("config", "expected"), [(("key1", "value1", "key2", "value2", "key3", "value3"), True)]
 )
 def test_prettyjson_error(config, expected):
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         assert to_json(config).startswith("{\n") == expected


### PR DESCRIPTION
Refactor `core/prettyjson.py` from class-based to function-based API with proper type annotations, and add type hints to `core/escape.py`'s `json_escape` function.

### Key changes
- Remove `PrettyJSON` class; expose `_convert()` and `to_json()` as module-level functions
- Add full type signatures (`object`, `int`, `Collection[str] | None`)
- Replace `reduce(lambda x, y: x + y, ...)` with `sum(map(len, items))`
- Migrate `%d % o` → `str(value)` for integer formatting consistency
- Change encoding error from `ValueError` to `TypeError` (semantically correct)
- Add comprehensive docstrings (`Args`, `Returns`, `Raises`) in all public functions

### Notable implementation details
- The `to_json()` function signature remains compatible — it still exposes a callable accepting positional `value` and optional `order`. All 50+ importers across the codebase use `from noc.core.prettyjson import to_json` with positional arguments only.
- `PrettyJSON` class had zero callers across the entire repository (verified via search).
- Bool check order preserved correctly (`isinstance(value, bool)` before `int`, since `bool` is a subclass of `int`).
