### PR TITLE
services: use f-strings and .format()

### DIFF
--- a/services/activator/paths/activator.py
+++ b/services/activator/paths/activator.py
@@ -115,7 +115,7 @@ class ActivatorAPI(JSONRPCAPI):
             result = script.run()
         except script.ScriptError as e:
             metrics["error", ("type", "script_error")] += 1
-            raise APIError("Script error: %s" % e.__doc__)
+            raise APIError(f"Script error: {e.__doc__}")
         if not streaming or not result:
             if return_metrics:
                 return {"metrics": script.apply_metrics({}), "result": result}

--- a/services/bi/paths/bi.py
+++ b/services/bi/paths/bi.py
@@ -469,7 +469,7 @@ class BIAPI(JSONRPCAPI):
                 {
                     "id": u.id,
                     "username": u.username,
-                    "full_name": "%s %s" % (u.last_name, u.first_name),
+                    "full_name": f"{u.last_name} {u.first_name}",
                 }
                 for u in qs
             ),
@@ -498,7 +498,7 @@ class BIAPI(JSONRPCAPI):
             if ar.user:
                 i["user"] = {
                     "id": ar.user.id,
-                    "name": "%s %s" % (ar.user.last_name, ar.user.first_name),
+                    "name": f"{ar.user.last_name} {ar.user.first_name}",
                 }
             if ar.group:
                 i["group"] = {"id": ar.group.id, "name": ar.group.name}
@@ -546,7 +546,7 @@ class BIAPI(JSONRPCAPI):
         except ValueError as e:
             self.logger.error("Validation items with rights: %s", e)
             metrics["error", ("type", "validation")] += 1
-            raise APIError("Validation error %s" % e)
+            raise APIError(f"Validation error {e}")
         for i in items:
             da = DashboardAccess(level=i.get("level", -1))
             if i.get("user"):

--- a/services/card/cards/base.py
+++ b/services/card/cards/base.py
@@ -198,12 +198,12 @@ class BaseCard:
                     if collapse and c < 2:
                         badge = ""
                     else:
-                        badge = ' <span class="badge">%s</span>' % c
+                        badge = f' <span class="badge">{c}</span>'
                     order = getattr(pv, "display_order", 100)
                     v += [
                         (
                             (order, -c),
-                            '<i class="%s" title="%s"></i>%s' % (pv.glyph, pv.name, badge),
+                            f'<i class="{pv.glyph}" title="{pv.name}"></i>{badge}',
                         )
                     ]
             return " ".join(i[1] for i in sorted(v, key=operator.itemgetter(0)))
@@ -221,8 +221,9 @@ class BaseCard:
             r += [get_summary(s["service"], ServiceProfile)]
         if s.get("fresh_alarms"):
             r += [
-                '<i class="fa fa-exclamation-triangle"></i><span class="badge">%s</span>'
-                % s["fresh_alarms"]["FreshAlarm"]
+                '<i class="fa fa-exclamation-triangle"></i><span class="badge">{}</span>'.format(
+                    s["fresh_alarms"]["FreshAlarm"]
+                )
             ]
         r = [x for x in r if x]
         return "&nbsp;".join(r)
@@ -261,11 +262,7 @@ class BaseCard:
     @classmethod
     def f_object_console(cls, object):
         s = {1: "telnet", 2: "ssh", 3: "http", 4: "https"}[object.scheme]
-        return "<a href='%s://%s/'><i class='fa fa-terminal'></i> %s</a>" % (
-            s,
-            object.address,
-            s.upper(),
-        )
+        return f"<a href='{s}://{object.address}/'><i class='fa fa-terminal'></i> {s.upper()}</a>"
 
     @staticmethod
     def update_dict(s, d):

--- a/services/card/cards/interfacepath.py
+++ b/services/card/cards/interfacepath.py
@@ -159,7 +159,7 @@ class InterfacePathCard(BaseCard):
             if cv >= t:
                 if cv // t * t == cv:
                     return "%d%s" % (cv // t, n)
-                return "%.2f%s" % (float(cv) / t, n)
+                return f"{float(cv) / t:.2f}{n}"
         return str(cv)
 
     def get_ajax_data(self, **kwargs):
@@ -180,11 +180,11 @@ class InterfacePathCard(BaseCard):
             argMax(errors_out, ts) AS errors_out
           FROM interface
           WHERE
-            date >= toDate('%s')
-            AND ts >= toDateTime('%s')
-            AND (%s)
+            date >= toDate('{}')
+            AND ts >= toDateTime('{}')
+            AND ({})
           GROUP BY managed_object, iface
-        """ % (
+        """.format(
             from_ts.date().isoformat(),
             from_ts.isoformat(sep=" "),
             " OR ".join(

--- a/services/card/cards/maintenance.py
+++ b/services/card/cards/maintenance.py
@@ -44,9 +44,9 @@ class MaintenanceCard(BaseCard):
         affected = []
         summary = {"service": {}, "subscriber": {}}
         # Maintenance
-        SQL = """SELECT id, name, platform, address
+        SQL = f"""SELECT id, name, platform, address
             FROM sa_managedobject
-            WHERE affected_maintenances @> '{"%s": {}}' ORDER BY address;""" % str(self.object.id)
+            WHERE affected_maintenances @> '{{"{self.object.id!s}": {{}}}}' ORDER BY address;"""
         for mo in ManagedObject.objects.raw(SQL):
             ss = ServiceSummary.get_object_summary(mo.id)
             update_dict(summary["service"], ss.get("service", {}))

--- a/services/card/cards/managedobject.py
+++ b/services/card/cards/managedobject.py
@@ -411,7 +411,7 @@ class ManagedObjectCard(BaseCard):
                 {
                     "scope": "managedobject",
                     "id": mo.id,
-                    "label": "%s (%s) [%s]" % (mo.name, mo.address, mo.platform),
+                    "label": f"{mo.name} ({mo.address}) [{mo.platform}]",
                 }
             ]
         return r

--- a/services/card/cards/monmap.py
+++ b/services/card/cards/monmap.py
@@ -134,7 +134,7 @@ class MonMapCard(BaseCard):
             str(o["_id"]): (
                 o["name"],
                 {
-                    "%s.%s" % (item["interface"], item["attr"]): item["value"]
+                    "{}.{}".format(item["interface"], item["attr"]): item["value"]
                     for item in o.get("data", [])
                 },
             )
@@ -166,7 +166,7 @@ class MonMapCard(BaseCard):
                 ss[status] += 1
                 ss["total"] += 1
                 services_ss = [
-                    "%s-%s" % (sm, status) for sm in services_map.get(mo_id, [self.fake_service])
+                    f"{sm}-{status}" for sm in services_map.get(mo_id, [self.fake_service])
                 ]
                 ss["objects"] += [
                     {"id": mo_id, "name": mo_name, "status": status, "services": services_ss}
@@ -299,7 +299,7 @@ class MonMapCard(BaseCard):
                     elif collapse and c < 2:
                         badge = "</div>"
                     else:
-                        badge = '<span class="badge">%s</span></div>' % c
+                        badge = f'<span class="badge">{c}</span></div>'
                     html2 = "".join(
                         [
                             "<td style='text-align: center; width: ",
@@ -325,8 +325,9 @@ class MonMapCard(BaseCard):
             r += [get_summary(s["service"], ServiceProfile)]
         if s.get("fresh_alarms"):
             r += [
-                '<i class="fa fa-exclamation-triangle"></i><span class="badge">%s</span>'
-                % s["fresh_alarms"]["FreshAlarm"]
+                '<i class="fa fa-exclamation-triangle"></i><span class="badge">{}</span>'.format(
+                    s["fresh_alarms"]["FreshAlarm"]
+                )
             ]
         r = [x for x in r if x]
         return "&nbsp;".join(r)
@@ -339,8 +340,8 @@ class MonMapCard(BaseCard):
         if not info_all:
             pipeline += [{"$match": {"managed_object": {"$in": mos_ids}}}]
 
-        group = {"_id": {"mo": "$managed_object"}, "count": {"$push": "$%s.profile" % name}}
-        pipeline += [{"$unwind": "$%s" % name}, {"$group": group}]
+        group = {"_id": {"mo": "$managed_object"}, "count": {"$push": f"${name}.profile"}}
+        pipeline += [{"$unwind": f"${name}"}, {"$group": group}]
         for ss in (
             ServiceSummary._get_collection()
             .with_options(read_preference=ReadPreference.SECONDARY_PREFERRED)

--- a/services/card/cards/object.py
+++ b/services/card/cards/object.py
@@ -160,11 +160,11 @@ class ObjectCard(BaseCard):
         SQL = """SELECT managed_object, arrayStringConcat(path) as iface, argMax(ts, ts), argMax(load_in, ts), argMax(load_out, ts), argMax(errors_in, ts), argMax(errors_out, ts)
                 FROM interface
                 WHERE
-                  date >= toDate('%s')
-                  AND ts >= toDateTime('%s')
-                  AND managed_object IN (%s)
+                  date >= toDate('{}')
+                  AND ts >= toDateTime('{}')
+                  AND managed_object IN ({})
                 GROUP BY managed_object, iface
-                """ % (
+                """.format(
             from_date.date().isoformat(),
             from_date.isoformat(sep=" "),
             ", ".join(bi_map),
@@ -209,15 +209,15 @@ class ObjectCard(BaseCard):
             # tb_fields = [f[1] for f in fields]
             # mt_name = [f[2] for f in fields]
             fields = list(fields)
-            SQL = """SELECT managed_object, argMax(ts, ts), %s
-                  FROM %s
+            SQL = """SELECT managed_object, argMax(ts, ts), {}
+                  FROM {}
                   WHERE
-                    date >= toDate('%s')
-                    AND ts >= toDateTime('%s')
-                    AND managed_object IN (%s)
+                    date >= toDate('{}')
+                    AND ts >= toDateTime('{}')
+                    AND managed_object IN ({})
                   GROUP BY managed_object
-                  """ % (
-                ", ".join(["argMax(%s, ts) as %s" % (f[1], f[1]) for f in fields]),
+                  """.format(
+                ", ".join([f"argMax({f[1]}, ts) as {f[1]}" for f in fields]),
                 table,
                 from_date.date().isoformat(),
                 from_date.isoformat(sep=" "),

--- a/services/card/cards/phonenumber.py
+++ b/services/card/cards/phonenumber.py
@@ -61,7 +61,7 @@ class PhoneNumberCard(BaseCard):
                 {
                     "scope": "phonenumber",
                     "id": str(p.id),
-                    "label": "%s: %s" % (p.dialplan.name, p.number),
+                    "label": f"{p.dialplan.name}: {p.number}",
                 }
             ]
         return r

--- a/services/card/cards/phonerange.py
+++ b/services/card/cards/phonerange.py
@@ -68,7 +68,7 @@ class PhoneRangeCard(BaseCard):
                 {
                     "scope": "phonerange",
                     "id": str(p.id),
-                    "label": "%s (%s - %s)" % (p.name, p.from_number, p.to_number),
+                    "label": f"{p.name} ({p.from_number} - {p.to_number})",
                 }
             ]
         return r

--- a/services/card/cards/tt.py
+++ b/services/card/cards/tt.py
@@ -84,4 +84,4 @@ class TTCard(BaseCard):
             )
         if not a:
             return
-        self.redirect("/api/card/view/alarm/%s/" % a.id)
+        self.redirect(f"/api/card/view/alarm/{a.id}/")

--- a/services/card/paths/card.py
+++ b/services/card/paths/card.py
@@ -114,7 +114,7 @@ class CardAPI(BaseAPI):
             for f in os.listdir(p):
                 if not f.endswith(".py"):
                     continue
-                mn = "%s.%s.%s" % (basename, cls.CARDS_PREFIX.replace(os.path.sep, "."), f[:-3])
+                mn = "{}.{}.{}".format(basename, cls.CARDS_PREFIX.replace(os.path.sep, "."), f[:-3])
                 m = importlib.import_module(mn)
                 for d in dir(m):
                     c = getattr(m, d)

--- a/services/classifier/cloningrule.py
+++ b/services/classifier/cloningrule.py
@@ -19,7 +19,7 @@ class CloningRule:
             self.value_re = value_re
 
         def __str__(self):
-            return "%s : %s" % (self.key_re, self.value_re)
+            return f"{self.key_re} : {self.value_re}"
 
     def __init__(self, rule) -> None:
         self.re_mode = rule.re != r"^.*$"  # Search by "re"
@@ -27,19 +27,19 @@ class CloningRule:
         try:
             self.re = re.compile(rule.re)
         except Exception as why:
-            raise InvalidPatternException("Error in '%s': %s" % (rule.re, why))
+            raise InvalidPatternException(f"Error in '{rule.re}': {why}")
         try:
             self.key_re = re.compile(rule.key_re)
         except Exception as why:
-            raise InvalidPatternException("Error in '%s': %s" % (rule.key_re, why))
+            raise InvalidPatternException(f"Error in '{rule.key_re}': {why}")
         try:
             self.value_re = re.compile(rule.value_re)
         except Exception as why:
-            raise InvalidPatternException("Error in '%s': %s" % (rule.value_re, why))
+            raise InvalidPatternException(f"Error in '{rule.value_re}': {why}")
         try:
             self.rewrite_from = re.compile(rule.rewrite_from)
         except Exception as why:
-            raise InvalidPatternException("Error in '%s': %s" % (rule.rewrite_from, why))
+            raise InvalidPatternException(f"Error in '{rule.rewrite_from}': {why}")
         self.rewrite_to = rule.rewrite_to
 
     def match(self, rule):

--- a/services/classifier/patternset.py
+++ b/services/classifier/patternset.py
@@ -39,7 +39,7 @@ class PatternSet:
             try:
                 re.compile(p.pattern)
             except re.error as e:
-                logger.error("Invalid ignore pattern '%s' (%s)" % (p.pattern, e))
+                logger.error(f"Invalid ignore pattern '{p.pattern}' ({e})")
                 continue
             i_patterns[p.source.value] += [str(p.id), p.pattern]
             n += 1
@@ -53,7 +53,7 @@ class PatternSet:
         try:
             re.compile(data["message_rx"])
         except re.error as e:
-            logger.error("Invalid ignore pattern '%s' (%s)" % (data["message_rx"], e))
+            logger.error("Invalid ignore pattern '{}' ({})".format(data["message_rx"], e))
             return
         update = False
         for p in self.i_patterns.get(source) or []:

--- a/services/classifier/rule.py
+++ b/services/classifier/rule.py
@@ -76,7 +76,7 @@ class VarTransformRule:
         """
         if len(v) != 6:
             return v
-        return ":".join("%02X" % ord(x) for x in v)
+        return ":".join(f"{ord(x):02X}" for x in v)
 
     @staticmethod
     def oid_to_str(v: str):
@@ -259,7 +259,7 @@ class Rule:
                 rx_key = re.compile(cls.unhex_re(key_re), re.MULTILINE | re.DOTALL)
                 rxs.append(key_re)
             except Exception as e:
-                raise InvalidPatternException("Error in '%s': %s" % (key_re, e))
+                raise InvalidPatternException(f"Error in '{key_re}': {e}")
         # Process value pattern
         if cls.is_exact(value_re):
             x_value = cls.unescape(value_re.strip("^$"))
@@ -268,7 +268,7 @@ class Rule:
                 rx_value = re.compile(cls.unhex_re(value_re), re.MULTILINE | re.DOTALL)
                 rxs.append(value_re)
             except Exception as e:
-                raise InvalidPatternException("Error in '%s': %s" % (value_re, e))
+                raise InvalidPatternException(f"Error in '{value_re}': {e}")
         # Save patterns
         if x_key and x_value:
             return partial(match_eq, x_value, x_key), rxs

--- a/services/classifier/service.py
+++ b/services/classifier/service.py
@@ -199,7 +199,7 @@ class ClassifierService(FastAPIService):
         report_callback = PeriodicCallback(self.report, 1000)
         report_callback.start()
         await self.subscribe_stream(
-            "events.%s" % config.pool,
+            f"events.{config.pool}",
             self.slot_number,
             self.on_event,
             async_cursor=config.classifier.allowed_async_cursor,

--- a/services/classifier/trigger.py
+++ b/services/classifier/trigger.py
@@ -43,7 +43,7 @@ class Trigger:
     def call(self, event):
         if not self.match(event):
             return
-        logging.debug("Calling trigger '%s'" % self.name)
+        logging.debug(f"Calling trigger '{self.name}'")
         # Notify if necessary
         if self.notification_group and self.template:
             subject = {}

--- a/services/correlator/alarmaction.py
+++ b/services/correlator/alarmaction.py
@@ -98,7 +98,7 @@ class AlarmActionRunner:
                 self.log_alarm(message=ctx["subject"])
                 r = ActionResult(status=ActionStatus.SUCCESS)
             case _:
-                raise NotImplementedError("Action %s not implemented" % action)
+                raise NotImplementedError(f"Action {action} not implemented")
         return r
 
     def check_escalated(self, tt_system: TTSystem) -> str | None:

--- a/services/correlator/rcacondition.py
+++ b/services/correlator/rcacondition.py
@@ -32,7 +32,7 @@ class RCACondition:
             if k == "managed_object" and v == "alarm.managed_object.id":
                 self.same_object = True
             x += [f"'{k}': {v}"]
-        self.match_condition = compile("{%s}" % ", ".join(x), "<string>", "eval")
+        self.match_condition = compile("{{{}}}".format(", ".join(x)), "<string>", "eval")
         # Build reverse match condition expression
         x = [
             f"'alarm_class': ObjectId('{alarm_class.id}')",
@@ -44,7 +44,7 @@ class RCACondition:
             x += ["'id__ne': alarm.id"]
         if self.same_object:
             x += ["'managed_object': alarm.managed_object"]
-        self.reverse_match_condition = compile("{%s}" % ", ".join(x), "<string>", "eval")
+        self.reverse_match_condition = compile("{{{}}}".format(", ".join(x)), "<string>", "eval")
 
     def __str__(self):
         return self.name

--- a/services/correlator/rule.py
+++ b/services/correlator/rule.py
@@ -147,7 +147,7 @@ class EventAlarmRule:
             elif ctx and ctx.get(k.alias):
                 v = ctx[k.alias]
             elif k.required:
-                raise ValueError("Not exists required var: %s" % k.name)
+                raise ValueError(f"Not exists required var: {k.name}")
             else:
                 continue
             if k.value_type:

--- a/services/correlator/service.py
+++ b/services/correlator/service.py
@@ -149,7 +149,7 @@ class CorrelatorService(FastAPIService):
         # Subscribe stream, move to separate task to let the on_activate to terminate
         self.loop.create_task(
             self.subscribe_stream(
-                "dispose.%s" % config.pool,
+                f"dispose.{config.pool}",
                 self.slot_number,
                 self.on_dispose_event,
                 async_cursor=config.correlator.allowed_async_cursor,
@@ -276,7 +276,7 @@ class CorrelatorService(FastAPIService):
         # Prepare traceback
         t, v, tb = sys.exc_info()
         now = datetime.datetime.now()
-        r = ["UNHANDLED EXCEPTION (%s)" % str(now)]
+        r = [f"UNHANDLED EXCEPTION ({now!s})"]
         r += [str(t), str(v)]
         r += [format_frames(get_traceback_frames(tb))]
         r = "\n".join(r)

--- a/services/correlator/trigger.py
+++ b/services/correlator/trigger.py
@@ -45,7 +45,7 @@ class Trigger:
         if not self.match(alarm):
             return
         print(self.resource_group)
-        logger.info("Calling trigger '%s'" % self.name)
+        logger.info(f"Calling trigger '{self.name}'")
         # Notify if necessary
         if self.notification_group and self.template:
             self.notification_group.notify(

--- a/services/datastream/paths/datastream.py
+++ b/services/datastream/paths/datastream.py
@@ -197,7 +197,7 @@ class DatastreamAPI:
             filters = ds_filter or []
             ids = ds_id or None
             if ids:
-                filters += ["id(%s)" % ",".join(ids)]
+                filters += ["id({})".format(",".join(ids))]
             # Start from change
             if ds_from:
                 change_id = ds_from

--- a/services/datastream/streams/address.py
+++ b/services/datastream/streams/address.py
@@ -32,7 +32,7 @@ class AddressDataStream(DataStream):
             "id": str(address.id),
             "name": qs(address.name),
             "address": str(address.address),
-            "afi": "ipv%s" % address.afi,
+            "afi": f"ipv{address.afi}",
             "source": address.source,
         }
         if address.description:

--- a/services/datastream/streams/alarm.py
+++ b/services/datastream/streams/alarm.py
@@ -159,8 +159,8 @@ class AlarmDataStream(DataStream):
     def filter_alarmclass(cls, *args):
         ids = [str(AlarmClass.get_by_name(a).id) for a in args if AlarmClass.get_by_name(a)]
         if len(ids) == 1:
-            return {"%s.alarmclass" % cls.F_META: ids[0]}
-        return {"%s.alarmclass" % cls.F_META: {"$in": ids}}
+            return {f"{cls.F_META}.alarmclass": ids[0]}
+        return {f"{cls.F_META}.alarmclass": {"$in": ids}}
 
     @classmethod
     def get_meta_headers(cls, data: dict[str, Any]) -> dict[str, bytes] | None:

--- a/services/datastream/streams/cfgping.py
+++ b/services/datastream/streams/cfgping.py
@@ -96,4 +96,4 @@ class CfgPingDataStream(DataStream):
 
     @classmethod
     def filter_pool(cls, name):
-        return {"%s.pool" % cls.F_META: name}
+        return {f"{cls.F_META}.pool": name}

--- a/services/datastream/streams/dnszone.py
+++ b/services/datastream/streams/dnszone.py
@@ -153,7 +153,7 @@ class DNSZoneDataStream(DataStream):
         :param zone:
         :return:
         """
-        suffix = ".%s." % zone.name
+        suffix = f".{zone.name}."
         length = len(zone.name)
         for z in zone.children:
             nested_nses = set()
@@ -205,11 +205,11 @@ class DNSZoneDataStream(DataStream):
         # @todo: Get ttl from profile
         # Build query
         length = len(zone.name) + 1
-        q = Q(fqdn__iexact=zone.name) | Q(fqdn__iendswith=".%s" % zone.name)
-        for z in DNSZone.objects.filter(name__iendswith=".%s" % zone.name).values_list(
+        q = Q(fqdn__iexact=zone.name) | Q(fqdn__iendswith=f".{zone.name}")
+        for z in DNSZone.objects.filter(name__iendswith=f".{zone.name}").values_list(
             "name", flat=True
         ):
-            q &= ~(Q(fqdn__iexact=z) | Q(fqdn__iendswith=".%s" % z))
+            q &= ~(Q(fqdn__iexact=z) | Q(fqdn__iendswith=f".{z}"))
         for afi, fqdn, address in Address.objects.filter(q).values_list("afi", "fqdn", "address"):
             yield RR(
                 zone=zone.name,
@@ -233,7 +233,7 @@ class DNSZoneDataStream(DataStream):
             """
             x = a.split(".")
             x.reverse()
-            return "%s.in-addr.arpa" % (".".join(x))
+            return "{}.in-addr.arpa".format(".".join(x))
 
         length = len(zone.name) + 1
         for a in Address.objects.filter(afi="4").extra(
@@ -275,7 +275,7 @@ class DNSZoneDataStream(DataStream):
         :param zone:
         :return:
         """
-        suffix = ".%s." % zone.name
+        suffix = f".{zone.name}."
         # Create missed A records for NSses from zone
         # Find in-zone NSes
         in_zone_nses = {}
@@ -315,14 +315,14 @@ class DNSZoneDataStream(DataStream):
                     name=n,
                     ttl=zone.profile.zone_ttl,
                     type="CNAME",
-                    rdata="%s.%s/32" % (n, n),
+                    rdata=f"{n}.{n}/32",
                 )
                 for ns in nses:
                     if not ns.endswith("."):
                         ns += "."
                     yield RR(
                         zone=zone.name,
-                        name="%s/32" % n,
+                        name=f"{n}/32",
                         ttl=zone.profile.zone_ttl,
                         type="NS",
                         rdata=ns,

--- a/services/datastream/streams/managedobject.py
+++ b/services/datastream/streams/managedobject.py
@@ -525,7 +525,7 @@ class ManagedObjectDataStream(DataStream):
 
     @classmethod
     def filter_pool(cls, name: str):
-        return {"%s.pool" % cls.F_META: name}
+        return {f"{cls.F_META}.pool": name}
 
     @classmethod
     def filter_service_group(cls, name: str):

--- a/services/datastream/streams/prefix.py
+++ b/services/datastream/streams/prefix.py
@@ -32,7 +32,7 @@ class PrefixDataStream(DataStream):
             "id": str(prefix.id),
             "name": qs(prefix.name),
             "prefix": qs(prefix.prefix),
-            "afi": "ipv%s" % prefix.afi,
+            "afi": f"ipv{prefix.afi}",
             "source": prefix.source,
         }
         if prefix.description:

--- a/services/discovery/jobs/base.py
+++ b/services/discovery/jobs/base.py
@@ -83,7 +83,7 @@ class MODiscoveryJob(PeriodicJob):
         if self.check_timings:
             self.logger.info(
                 "Timings: %s",
-                ", ".join("%s = %.2fms" % (n, t * 1000) for n, t in self.check_timings),
+                ", ".join(f"{n} = {t * 1000:.2f}ms" for n, t in self.check_timings),
             )
         super().schedule_next(status)
         # Update alarm statuses
@@ -93,7 +93,7 @@ class MODiscoveryJob(PeriodicJob):
         # Update diagnostics statuses
         self.update_diagnostics(self.problems)
         # Write job log
-        key = "discovery-%s-%s" % (self.attrs[self.ATTR_CLASS], self.attrs[self.ATTR_KEY])
+        key = f"discovery-{self.attrs[self.ATTR_CLASS]}-{self.attrs[self.ATTR_KEY]}"
         problems = {}
         for p in list(self.problems):
             if not p.check:
@@ -412,7 +412,7 @@ class DiscoveryCheck:
         self.service = job.service
         self.job = job
         self.object: ManagedObject = self.job.object
-        self.logger = self.job.logger.get_logger("[%s" % self.name)
+        self.logger = self.job.logger.get_logger(f"[{self.name}")
         self.if_name_cache = {}  # mo, name -> Interface
         self.if_mac_cache = {}  # mo, mac -> Interface
         self.if_ip_cache = {}
@@ -595,7 +595,7 @@ class DiscoveryCheck:
         :type msg: str
         """
         if changes:
-            self.logger.info("%s: %s" % (msg, ", ".join("%s = %s" % (k, v) for k, v in changes)))
+            self.logger.info("{}: {}".format(msg, ", ".join(f"{k} = {v}" for k, v in changes)))
 
     def get_interface_by_name(self, name, mo=None):
         """
@@ -641,7 +641,7 @@ class DiscoveryCheck:
             li = list(
                 Interface.objects.filter(
                     managed_object=self.object.id,
-                    ipv4_addresses__startswith="%s/" % ip,
+                    ipv4_addresses__startswith=f"{ip}/",
                     type="physical",
                 )
             )
@@ -759,11 +759,9 @@ class DiscoveryCheck:
         if not obj.object_profile.neighbor_cache_ttl:
             # Disabled cache
             return
-        keys = [
-            "mo-neighbors-%s-%s" % (x, obj.id) for x in obj.segment.profile.get_topology_methods()
-        ]
+        keys = [f"mo-neighbors-{x}-{obj.id}" for x in obj.segment.profile.get_topology_methods()]
         if keys:
-            self.logger.info("Invalidating neighor cache: %s" % ", ".join(keys))
+            self.logger.info("Invalidating neighor cache: {}".format(", ".join(keys)))
             cache.delete_many(keys, TopologyDiscoveryCheck.NEIGHBOR_CACHE_VERSION)
 
     def get_confdb(self):
@@ -806,20 +804,19 @@ class TopologyDiscoveryCheck(DiscoveryCheck):
         loops = {}  # first interface, second interface
         problems = {}
         # Check local side
-        ln_key = "mo-neighbors-%s-%s" % (self.name, self.object.id)
+        ln_key = f"mo-neighbors-{self.name}-{self.object.id}"
         for li, ro, ri in self.cached_neighbors(self.object, ln_key, self.iter_neighbors):
             # Resolve remote object
             remote_object = self.get_neighbor(ro)
             if not remote_object:
-                problems[li] = "Remote object '%s' is not found" % str(ro)
+                problems[li] = f"Remote object '{ro!s}' is not found"
                 self.logger.info("Remote object '%s' is not found. Skipping", str(ro))
                 continue
             # Resolve remote interface name
             remote_interface = self.get_remote_interface(remote_object, ri)
             if not remote_interface:
-                problems[li] = "Cannot resolve remote interface %s:%r. Skipping" % (
-                    remote_object.name,
-                    ri,
+                problems[li] = (
+                    f"Cannot resolve remote interface {remote_object.name}:{ri!r}. Skipping"
                 )
                 self.logger.info(
                     "Cannot resolve remote interface %s:%r. Skipping", remote_object.name, ri
@@ -866,7 +863,7 @@ class TopologyDiscoveryCheck(DiscoveryCheck):
                 continue
             else:
                 try:
-                    rn_key = "mo-neighbors-%s-%s" % (self.name, remote_object.id)
+                    rn_key = f"mo-neighbors-{self.name}-{remote_object.id}"
                     remote_neighbors = self.cached_neighbors(
                         remote_object, rn_key, self.iter_neighbors
                     )
@@ -876,15 +873,14 @@ class TopologyDiscoveryCheck(DiscoveryCheck):
                     )
                     self.set_problem(
                         path=next(iter(candidates[remote_object]))[0],
-                        message="Cannot get neighbors from candidate %s: %s"
-                        % (remote_object.name, e),
+                        message=f"Cannot get neighbors from candidate {remote_object.name}: {e}",
                     )
                     continue
                 confirmed = set()
             for li, ro_id, ri in remote_neighbors:
                 ro = self.get_neighbor(ro_id)
                 if not ro or ro.id != self.object.id:
-                    self.logger.debug("Candidates check %s %s %s %s" % (li, ro_id, ro, ri))
+                    self.logger.debug(f"Candidates check {li} {ro_id} {ro} {ri}")
                     continue  # To other objects
                 remote_interface = self.get_remote_interface(self.object, ri)
                 if remote_interface:
@@ -894,7 +890,7 @@ class TopologyDiscoveryCheck(DiscoveryCheck):
                     "Candidates: %s, Confirmed: %s", candidates[remote_object], confirmed
                 )
             for ll, rr in candidates[remote_object] - confirmed:
-                problems[ll] = "Pending link: %s - %s:%s" % (ll, remote_object, rr)
+                problems[ll] = f"Pending link: {ll} - {remote_object}:{rr}"
                 li = self.clean_interface(self.object, ll)
                 if not li:
                     self.logger.info("Cannot clean interface %s:%s. Skipping", self.object, ll)
@@ -949,12 +945,12 @@ class TopologyDiscoveryCheck(DiscoveryCheck):
                     if (mo.id, n[0]) in self.interface_aliases
                 }
                 cache.set(
-                    "%s-aliases" % key, alias_cache, ttl=ttl, version=self.NEIGHBOR_CACHE_VERSION
+                    f"{key}-aliases", alias_cache, ttl=ttl, version=self.NEIGHBOR_CACHE_VERSION
                 )
             metrics["neighbor_cache_misses"] += 1
         else:
             self.logger.info("Use neighbors cache")
-            alias_cache = cache.get("%s-aliases" % key, version=self.NEIGHBOR_CACHE_VERSION)
+            alias_cache = cache.get(f"{key}-aliases", version=self.NEIGHBOR_CACHE_VERSION)
             self.logger.debug("Alias cache is %s", alias_cache)
             if alias_cache:
                 self.interface_aliases.update(alias_cache)
@@ -1269,13 +1265,13 @@ class TopologyDiscoveryCheck(DiscoveryCheck):
                 try:
                     li.unlink()
                 except ValueError as e:
-                    self.logger.info("Failed to unlink %s: %s" % (llink, e))
+                    self.logger.info(f"Failed to unlink {llink}: {e}")
                     return
             if rlink:
                 try:
                     ri.unlink()
                 except ValueError as e:
-                    self.logger.info("Failed to unlink %s: %s" % (llink, e))
+                    self.logger.info(f"Failed to unlink {llink}: {e}")
                     return
             self.logger.info(
                 "Linking: %s:%s -- %s:%s",
@@ -1584,10 +1580,10 @@ class PolicyDiscoveryCheck(DiscoveryCheck):
         :return:
         """
         for method in self.policy_map[self.get_policy()]:
-            check = getattr(self, "can_get_data_from_%s" % method)
+            check = getattr(self, f"can_get_data_from_{method}")
             if not check():
                 continue
-            getter = getattr(self, "request_data_from_%s" % method)
+            getter = getattr(self, f"request_data_from_{method}")
             data = getter()
             if data is not None:
                 return data

--- a/services/discovery/jobs/box/address.py
+++ b/services/discovery/jobs/box/address.py
@@ -368,24 +368,24 @@ class AddressCheck(DiscoveryCheck):
         if self.is_preferred(address.source, discovered_address.source):
             changes = []
             if address.source != discovered_address.source:
-                changes += ["source: %s -> %s" % (address.source, discovered_address.source)]
+                changes += [f"source: {address.source} -> {discovered_address.source}"]
                 address.source = discovered_address.source
             if discovered_address.source in LOCAL_SRC:
                 # Check name
                 name = self.get_address_name(discovered_address)
                 if name and name != address.name:
-                    changes += ["name: %s -> %s" % (address.name, name)]
+                    changes += [f"name: {address.name} -> {name}"]
                     address.name = name
                 # Check fqdn
                 if discovered_address.fqdn != address.fqdn and discovered_address.fqdn:
-                    changes += ["fqdn: %s -> %s" % (address.fqdn, discovered_address.fqdn)]
+                    changes += [f"fqdn: {address.fqdn} -> {discovered_address.fqdn}"]
                     address.fqdn = discovered_address.fqdn
                 # @todo: Change profile
                 # Change managed object
                 if discovered_address.source in LOCAL_SRC and (
                     not address.managed_object or address.managed_object.id != self.object.id
                 ):
-                    changes += ["object: %s -> %s" % (address.managed_object, self.object)]
+                    changes += [f"object: {address.managed_object} -> {self.object}"]
                     address.managed_object = self.object
                 # Change subinterface
                 if (
@@ -393,12 +393,11 @@ class AddressCheck(DiscoveryCheck):
                     and address.subinterface != discovered_address.subinterface
                 ):
                     changes += [
-                        "subinterface: %s -> %s"
-                        % (address.subinterface, discovered_address.subinterface)
+                        f"subinterface: {address.subinterface} -> {discovered_address.subinterface}"
                     ]
                     address.subinterface = discovered_address.subinterface
             if discovered_address.mac and address.mac != discovered_address.mac:
-                changes += ["mac: %s -> %s" % (address.mac, discovered_address.mac)]
+                changes += [f"mac: {address.mac} -> {discovered_address.mac}"]
                 address.mac = discovered_address.mac
             if changes:
                 self.logger.info(

--- a/services/discovery/jobs/box/asset.py
+++ b/services/discovery/jobs/box/asset.py
@@ -311,7 +311,9 @@ class AssetCheck(DiscoveryCheck):
             o.set_data("asset", "revision", revision)
             o.save()
             o.log(
-                "Object revision changed: %s -> %s" % (o.get_data("asset", "revision"), revision),
+                "Object revision changed: {} -> {}".format(
+                    o.get_data("asset", "revision"), revision
+                ),
                 system="DISCOVERY",
                 managed_object=self.object,
                 op="CHANGE",
@@ -329,7 +331,9 @@ class AssetCheck(DiscoveryCheck):
             o.set_data("asset", "mfg_date", mfg_date)
             o.save()
             o.log(
-                "Object manufacturing date: %s -> %s" % (o.get_data("asset", "mfg_date"), mfg_date),
+                "Object manufacturing date: {} -> {}".format(
+                    o.get_data("asset", "mfg_date"), mfg_date
+                ),
                 system="DISCOVERY",
                 managed_object=self.object,
                 op="CHANGE",
@@ -466,7 +470,7 @@ class AssetCheck(DiscoveryCheck):
             self.logger.info("Changing name to '%s'", n)
             obj.save()
             obj.log(
-                "Change name to '%s'" % n,
+                f"Change name to '{n}'",
                 system="DISCOVERY",
                 managed_object=self.object,
                 op="CHANGE",
@@ -500,7 +504,7 @@ class AssetCheck(DiscoveryCheck):
         """
         s = s or ""
         for c in ctx:
-            s = s.replace("{%s}" % c, str(ctx[c]))
+            s = s.replace(f"{{{c}}}", str(ctx[c]))
         return s
 
     def submit_connections(self):
@@ -765,7 +769,7 @@ class AssetCheck(DiscoveryCheck):
                 o.set_data("stack", "member", m)
                 o.save()
                 o.log(
-                    "Setting stack member %s" % m,
+                    f"Setting stack member {m}",
                     system="DISCOVERY",
                     managed_object=self.object,
                     op="CHANGE",
@@ -859,7 +863,7 @@ class AssetCheck(DiscoveryCheck):
 
     def set_context(self, name: str, value: str | None):
         self.ctx[name] = value
-        n = "N%s" % name
+        n = f"N{name}"
         if n not in self.ctx:
             self.ctx[n] = 0
         else:
@@ -870,7 +874,7 @@ class AssetCheck(DiscoveryCheck):
         for n in names:
             if n in self.ctx:
                 del self.ctx[n]
-            m = "N%s" % n
+            m = f"N{n}"
             if m in self.ctx:
                 del self.ctx[m]
         self.logger.debug("Reset context scopes %s -> %s", ", ".join(names), str_dict(self.ctx))
@@ -1085,7 +1089,7 @@ class AssetCheck(DiscoveryCheck):
             sm = obj.get_data("stack", "member")
             if sm is not None:
                 # Stack member
-                name += "#%s" % sm
+                name += f"#{sm}"
         return name
 
     def disconnect_connections(self):

--- a/services/discovery/jobs/box/job.py
+++ b/services/discovery/jobs/box/job.py
@@ -138,7 +138,7 @@ class BoxDiscoveryJob(MODiscoveryJob):
             check = self.TOPOLOGY_METHODS.get(m)
             if not check:
                 continue
-            if getattr(self.object.object_profile, "enable_box_discovery_%s" % check.name):
+            if getattr(self.object.object_profile, f"enable_box_discovery_{check.name}"):
                 check(self).run()
         if self.object.object_profile.enable_box_discovery_sla:
             SLACheck(self).run()

--- a/services/discovery/jobs/box/prefix.py
+++ b/services/discovery/jobs/box/prefix.py
@@ -236,30 +236,22 @@ class PrefixCheck(DiscoveryCheck):
         if self.is_preferred(prefix.source, discovered_prefix.source):
             changes = []
             if prefix.source != discovered_prefix.source:
-                changes += ["source: %s -> %s" % (prefix.source, discovered_prefix.source)]
+                changes += [f"source: {prefix.source} -> {discovered_prefix.source}"]
                 prefix.source = discovered_prefix.source
             if discovered_prefix.source in LOCAL_SRC:
                 # Check name
                 name = self.get_prefix_name(discovered_prefix)
                 if name and name != prefix.name:
-                    changes += ["name: %s -> %s" % (prefix.name, name)]
+                    changes += [f"name: {prefix.name} -> {name}"]
                     prefix.name = name
             if discovered_prefix.asn and prefix.asn != discovered_prefix.asn:
                 changes += [
-                    "asn: %s -> %s"
-                    % (
-                        prefix.asn.asn if prefix.asn else None,
-                        discovered_prefix.asn.asn if discovered_prefix.asn else None,
-                    )
+                    f"asn: {prefix.asn.asn if prefix.asn else None} -> {discovered_prefix.asn.asn if discovered_prefix.asn else None}"
                 ]
                 prefix.asn = discovered_prefix.asn
             if discovered_prefix.vlan and prefix.vlan != discovered_prefix.vlan:
                 changes += [
-                    "vlan: %s -> %s"
-                    % (
-                        str(prefix.vlan) if prefix.vlan else None,
-                        str(discovered_prefix.vlan) if discovered_prefix.vlan else None,
-                    )
+                    f"vlan: {str(prefix.vlan) if prefix.vlan else None} -> {str(discovered_prefix.vlan) if discovered_prefix.vlan else None}"
                 ]
                 prefix.vlan = discovered_prefix.vlan
             if changes:

--- a/services/discovery/jobs/box/profile.py
+++ b/services/discovery/jobs/box/profile.py
@@ -84,5 +84,5 @@ class ProfileCheck(DiscoveryCheck):
             message=checker.get_error(),
             fatal=self.object.profile.id == Profile.get_generic_profile_id(),
         )
-        self.logger.debug("Result %s" % self.job.problems)
+        self.logger.debug(f"Result {self.job.problems}")
         return None

--- a/services/discovery/jobs/box/rep.py
+++ b/services/discovery/jobs/box/rep.py
@@ -29,7 +29,7 @@ class REPCheck(TopologyDiscoveryCheck):
                 continue  # Not found
             elif len(o) != 2:
                 # Something strange. REP Topology is ring, more 2 neighbors is strange...
-                self.logger.error("Invalid REP discovery result: %r" % topology)
+                self.logger.error(f"Invalid REP discovery result: {topology!r}")
                 continue
             elif len(o) == 2:
                 # Left and right ports

--- a/services/discovery/jobs/box/stp.py
+++ b/services/discovery/jobs/box/stp.py
@@ -25,7 +25,7 @@ class STPCheck(TopologyDiscoveryCheck):
     def handler(self):
         self.logger.info("Checking %s topology", self.name)
         roots = self.cached_neighbors(
-            self.object, "mo-neighbors-stp-root-%s" % self.object.id, self.get_root_ports
+            self.object, f"mo-neighbors-stp-root-{self.object.id}", self.get_root_ports
         )
         for ro in roots:
             remote_object = self.get_neighbor(ro)
@@ -34,7 +34,7 @@ class STPCheck(TopologyDiscoveryCheck):
                 continue
             rdmap = self.cached_neighbors(
                 remote_object,
-                "mo-neighbors-stp-desg-%s" % remote_object.id,
+                f"mo-neighbors-stp-desg-{remote_object.id}",
                 self.get_designated_ports,
             )
             for li, rpid in roots[ro]:
@@ -57,7 +57,7 @@ class STPCheck(TopologyDiscoveryCheck):
                         (iface["interface"], self.convert_port_id(iface["designated_port_id"]))
                     )
         roots = {ro: list(roots[ro]) for ro in roots}
-        self.logger.debug("Roots ports: %s" % roots)
+        self.logger.debug(f"Roots ports: {roots}")
         return roots
 
     def get_designated_ports(self, ro):
@@ -78,7 +78,7 @@ class STPCheck(TopologyDiscoveryCheck):
             self.logger.error("Cannot get neighbors from candidate %s: %s", ro.name, e)
             self.set_problem(
                 # path=list(candidates[remote_object])[0][0],
-                message="Cannot get neighbors from candidate %s: %s" % (ro.name, e)
+                message=f"Cannot get neighbors from candidate {ro.name}: {e}"
             )
             return dmap
         for i in result["instances"]:
@@ -86,7 +86,7 @@ class STPCheck(TopologyDiscoveryCheck):
                 if iface["role"] == "designated":
                     pi = self.convert_port_id(iface["port_id"])
                     dmap[pi] = iface["interface"]
-        self.logger.debug("Designate port map %s" % dmap)
+        self.logger.debug(f"Designate port map {dmap}")
         return dmap
 
     get_neighbor = TopologyDiscoveryCheck.get_neighbor_by_mac

--- a/services/discovery/jobs/box/suggestcli.py
+++ b/services/discovery/jobs/box/suggestcli.py
@@ -46,7 +46,7 @@ class SuggestCLICheck(DiscoveryCheck):
         self.logger.info("Failed to guess CLI credentials")
         self.set_problem(
             alarm_class="Discovery | Guess | CLI Credentials",
-            message="Failed to guess CLI credentials (%s)" % message,
+            message=f"Failed to guess CLI credentials ({message})",
             fatal=True,
         )
 
@@ -62,7 +62,7 @@ class SuggestCLICheck(DiscoveryCheck):
             r = open_sync_rpc(
                 "activator", pool=self.object.pool.name, calling_service="discovery"
             ).script(
-                "%s.login" % self.object.profile.name,
+                f"{self.object.profile.name}.login",
                 {
                     "cli_protocol": "ssh" if self.object.scheme == SSH else "telnet",
                     "address": self.object.address,

--- a/services/discovery/jobs/box/vlan.py
+++ b/services/discovery/jobs/box/vlan.py
@@ -260,7 +260,7 @@ class VLANCheck(PolicyDiscoveryCheck):
 
     def get_data_from_confdb(self):
         r = [
-            {"vlan_id": d["vlan"], "name": d.get("name", "VLAN %s" % d["vlan"])}
+            {"vlan_id": d["vlan"], "name": d.get("name", "VLAN {}".format(d["vlan"]))}
             for d in self.confdb.query(self.VLAN_QUERY)
         ]
         return IGetVlans().clean_result(r)

--- a/services/discovery/jobs/box/vpn.py
+++ b/services/discovery/jobs/box/vpn.py
@@ -263,14 +263,14 @@ class VPNCheck(DiscoveryCheck):
         if self.is_preferred(vpn.source, discovered_vpn.source):
             changes = []
             if vpn.source != discovered_vpn.source:
-                changes += ["source: %s -> %s" % (vpn.source, discovered_vpn.source)]
+                changes += [f"source: {vpn.source} -> {discovered_vpn.source}"]
                 vpn.source = discovered_vpn.source
             if (
                 discovered_vpn.name
                 and discovered_vpn.name != vpn.name
                 and self.get_unique_vpn_name(discovered_vpn) != vpn.name
             ):
-                changes += ["name: %s -> %s" % (vpn.name, discovered_vpn.name)]
+                changes += [f"name: {vpn.name} -> {discovered_vpn.name}"]
                 vpn.name = discovered_vpn.name
             if changes:
                 self.logger.info("Changing %s: %s", vpn.vpn_id, ", ".join(changes))
@@ -324,4 +324,4 @@ class VPNCheck(DiscoveryCheck):
         :param vpn: DiscoveredVPN
         :return: unique name
         """
-        return "%s (%s)" % (self.get_vpn_name(vpn), vpn.vpn_id or vpn.rd)
+        return f"{self.get_vpn_name(vpn)} ({vpn.vpn_id or vpn.rd})"

--- a/services/discovery/jobs/periodic/alarms.py
+++ b/services/discovery/jobs/periodic/alarms.py
@@ -61,8 +61,9 @@ class AlarmsCheck(DiscoveryCheck):
                     if not managed_object:
                         managed_object = self.object
                         self.logger.warning(
-                            "No object %s for alarm: \n%s"
-                            % (objcet_alarms[new_event]["path"][0], objcet_alarms[new_event])
+                            "No object {} for alarm: \n{}".format(
+                                objcet_alarms[new_event]["path"][0], objcet_alarms[new_event]
+                            )
                         )
                 else:
                     managed_object = self.object
@@ -78,7 +79,7 @@ class AlarmsCheck(DiscoveryCheck):
                 raw_vars = event.raw_vars
                 self.raise_event(event.managed_object.id, event.managed_object.pool.name, raw_vars)
                 event.mark_as_archived("Close event")
-                self.logger.info("Close event %s" % event)
+                self.logger.info(f"Close event {event}")
 
     @classmethod
     def find_cpe(cls, name, co_id=None):

--- a/services/discovery/jobs/segment/mac.py
+++ b/services/discovery/jobs/segment/mac.py
@@ -53,11 +53,11 @@ class MACDiscoveryCheck(TopologyDiscoveryCheck):
         SQL = """SELECT managed_object, mac, argMax(ts, ts), argMax(interface, ts)
         FROM mac
         WHERE
-          date >= toDate('%s')
-          AND ts >= toDateTime('%s')
-          AND managed_object IN (%s)
+          date >= toDate('{}')
+          AND ts >= toDateTime('{}')
+          AND managed_object IN ({})
         GROUP BY ts, managed_object, mac
-        """ % (
+        """.format(
             t0.date().isoformat(),
             t0.isoformat(sep=" "),
             ", ".join(bi_map),

--- a/services/escalator/escalation.py
+++ b/services/escalator/escalation.py
@@ -905,7 +905,7 @@ class DeescalationSequence(BaseSequence):
             metrics["escalation_tt_close_retry"] += 1
             self.tts.register_failure()
             self.alarm.set_escalation_close_error(
-                "[%s] %s" % (self.alarm.managed_object.tt_system.name, r.error)
+                f"[{self.alarm.managed_object.tt_system.name}] {r.error}"
             )
             self.escalation_doc.leader.escalation_status = "temp"
             self.escalation_doc.leader.escalation_error = str(r.error)
@@ -915,7 +915,7 @@ class DeescalationSequence(BaseSequence):
             self.logger.info("Failed to close tt %s: %s", self.tt_id, r.error)
             metrics["escalation_tt_close_fail"] += 1
             self.alarm.set_escalation_close_error(
-                "[%s] %s" % (self.alarm.managed_object.tt_system.name, r.error)
+                f"[{self.alarm.managed_object.tt_system.name}] {r.error}"
             )
             self.escalation_doc.leader.escalation_status = "fail"
             self.escalation_doc.leader.escalation_error = str(r.error)
@@ -976,7 +976,7 @@ class DeescalationSequence(BaseSequence):
         """
         if not self.notification_group:
             return
-        self.log_alarm("Sending close notification to group %s" % self.notification_group.name)
+        self.log_alarm(f"Sending close notification to group {self.notification_group.name}")
         self.notification_group.notify(self.subject, self.body)
         metrics["escalation_notify"] += 1
 

--- a/services/escalator/maintenance.py
+++ b/services/escalator/maintenance.py
@@ -49,9 +49,9 @@ def start_maintenance(maintenance_id):
     e_ctx_items = [
         ECtxItem(id=m.escalate_managed_object.id, tt_id=m.escalate_managed_object.tt_system_id)
     ]
-    SQL = """SELECT id, name, tt_system_id
+    SQL = f"""SELECT id, name, tt_system_id
         FROM sa_managedobject
-        WHERE affected_maintenances @> '{"%s": {}}';""" % str(maintenance_id)
+        WHERE affected_maintenances @> '{{"{maintenance_id!s}": {{}}}}';"""
     for mo in ManagedObject.objects.raw(SQL):
         logger.info("[%s] Appending object %s to TT", maintenance_id, mo)
         e_ctx_items.append(ECtxItem(id=mo.id, tt_id=mo.tt_system_id))

--- a/services/escalator/tt/stub.py
+++ b/services/escalator/tt/stub.py
@@ -26,7 +26,7 @@ class StubTTSystem(BaseTTSystem):
 
     def __init__(self, name, connection) -> None:
         super().__init__(name, connection)
-        self.logger = logging.getLogger("StubTTSystem.%s" % name)
+        self.logger = logging.getLogger(f"StubTTSystem.{name}")
 
     def create(self, ctx: EscalationContext) -> str:
         with Span(server="stub_tt", service="create"):

--- a/services/escalator/tt/tg_bot.py
+++ b/services/escalator/tt/tg_bot.py
@@ -37,7 +37,7 @@ class TGBotTTSystem(BaseTTSystem):
         """
         super().__init__(name, connection)
         p = urlparse(connection)
-        self.url = "https://%s%s" % (p.netloc, p.path)
+        self.url = f"https://{p.netloc}{p.path}"
         self.http_client = HttpClient(
             connect_timeout=10,
             timeout=self.TU_REQUEST_TIMEOUT,

--- a/services/escalator/wait_tt.py
+++ b/services/escalator/wait_tt.py
@@ -42,7 +42,7 @@ def wait_tt(alarm_id):
     if ti and ti["resolved"]:
         # Close alarm
         alarm.clear_alarm(
-            "Closed by TT %s" % alarm.escalation_tt,
+            f"Closed by TT {alarm.escalation_tt}",
             ts=ti.get("close_ts", datetime.datetime.now()),
             force=True,
         )

--- a/services/grafanads/paths/managedobject.py
+++ b/services/grafanads/paths/managedobject.py
@@ -132,7 +132,7 @@ class ManagedObjectJsonDS(JsonDSAPI):
                         "annotation": annotation,
                         "time": mktime(d["timestamp"].timetuple()) * 1000
                         + d["timestamp"].microsecond / 1000,
-                        "title": "[CLEAR] %s" % AlarmClass.get_by_id(d["alarm_class"]).name,
+                        "title": "[CLEAR] {}".format(AlarmClass.get_by_id(d["alarm_class"]).name),
                         # "tags": X,
                         # "text": X
                     }

--- a/services/login/backends/ldap.py
+++ b/services/login/backends/ldap.py
@@ -180,7 +180,7 @@ class LdapBackend(BaseAuthBackend):
             if not connect.bind():
                 raise self.LoginError(f"Failed to bind to LDAP: {connect.result}")
         except (LDAPCommunicationError, LDAPServerPoolExhaustedError) as e:
-            self.logger.error("Failed to bind to LDAP: connect failed by %s" % e)
+            self.logger.error(f"Failed to bind to LDAP: connect failed by {e}")
             raise self.LoginError(f"Failed to bind to LDAP: connect failed by {e}")
         return connect
 
@@ -194,7 +194,7 @@ class LdapBackend(BaseAuthBackend):
         """
         if ldap_domain.type == "ad":
             if "\\" not in user and "@" not in user:
-                user = r"%s\%s" % (ldap_domain.name, user)
+                user = rf"{ldap_domain.name}\{user}"
             kwargs = {"user": user, "authentication": ldap3.NTLM}
         else:
             # For Open LDAP userDN getting used bind_user, because it used for bind operation

--- a/services/login/paths/token.py
+++ b/services/login/paths/token.py
@@ -75,7 +75,7 @@ async def token(
             return JSONResponse(
                 content={
                     "error": "unauthorized_client",
-                    "error_description": "Access denied (%s)" % e,
+                    "error_description": f"Access denied ({e})",
                 },
                 status_code=HTTPStatus.FORBIDDEN,
             )

--- a/services/mib/paths/mib.py
+++ b/services/mib/paths/mib.py
@@ -52,7 +52,7 @@ class MIBAPI(JSONRPCAPI):
         :param name: MIB name
         :return: path
         """
-        return os.path.join(config.path.mib_path, "%s.mib" % name)
+        return os.path.join(config.path.mib_path, f"{name}.mib")
 
     @api
     def get_text(self, name):
@@ -104,7 +104,7 @@ class MIBAPI(JSONRPCAPI):
                     self.logger.error("Required MIB missed: %s", smart_text(match.group(1)))
                     return {
                         "status": False,
-                        "msg": "Required MIB missed: %s" % smart_text(match.group(1)),
+                        "msg": f"Required MIB missed: {smart_text(match.group(1))}",
                         "code": ERR_MIB_MISSED,
                     }
                 match = self.rx_macro_not_imported.search(line.strip())
@@ -124,14 +124,12 @@ class MIBAPI(JSONRPCAPI):
                 if match:
                     return {
                         "status": False,
-                        "msg": "Illegal subtype: %s" % smart_text(match.group(1)),
+                        "msg": f"Illegal subtype: {smart_text(match.group(1))}",
                         "code": ERR_MIB_MISSED,
                     }
                 match = self.rx_object_identifier_unknown.search(line.strip())
                 if match:
-                    self.logger.warning(
-                        "Object Identifier unknown: %s" % smart_text(match.group(1))
-                    )
+                    self.logger.warning(f"Object Identifier unknown: {smart_text(match.group(1))}")
                     # return {
                     #     "status": False,
                     #     "msg": "Object Identifier unknown: %s" % smart_text(match.group(1)),
@@ -165,7 +163,7 @@ class MIBAPI(JSONRPCAPI):
                     if md is None:
                         return {
                             "status": False,
-                            "msg": "Required MIB missed: %s" % rm,
+                            "msg": f"Required MIB missed: {rm}",
                             "code": ERR_MIB_MISSED,
                         }
                     depends_on[rm] = md
@@ -210,7 +208,7 @@ class MIBAPI(JSONRPCAPI):
                 if i in m.MIB:
                     cdata += [
                         {
-                            "name": "%s::%s" % (mib_name, node),
+                            "name": f"{mib_name}::{node}",
                             "oid": v["oid"],
                             "description": v.get("description"),
                             "syntax": (

--- a/services/mrt/paths/mrt.py
+++ b/services/mrt/paths/mrt.py
@@ -61,7 +61,7 @@ async def _run_script(current_user, oid, script, args, span_id=0, bi_id=None):
             span.set_error_from_exc(e, getattr(e, "remote_code", 1))
             return {"id": str(oid), "error": str(e)}
         except RPCError as e:
-            logger.error("RPC Error: %s" % str(e))
+            logger.error(f"RPC Error: {e!s}")
             span.set_error_from_exc(e, getattr(e, "code", 1))
             return {"id": str(oid), "error": str(e)}
         except Exception as e:

--- a/services/nbi/paths/objectmetrics.py
+++ b/services/nbi/paths/objectmetrics.py
@@ -137,14 +137,10 @@ class ObjectMetricsAPI(NBIAPI):
         from_date = from_ts.strftime("%Y-%m-%d")
         to_date = to_ts.strftime("%Y-%m-%d")
         if from_date == to_date:
-            date_q = "date = '%s'" % from_date
+            date_q = f"date = '{from_date}'"
         else:
-            date_q = "date >= '%s' AND date <= '%s'" % (from_date, to_date)
-        date_q = "%s AND ts >= '%s' AND ts <= '%s'" % (
-            date_q,
-            from_ts.replace(tzinfo=None).isoformat(),
-            to_ts.replace(tzinfo=None).isoformat(),
-        )
+            date_q = f"date >= '{from_date}' AND date <= '{to_date}'"
+        date_q = f"{date_q} AND ts >= '{from_ts.replace(tzinfo=None).isoformat()}' AND ts <= '{to_ts.replace(tzinfo=None).isoformat()}'"
         connect = ClickhouseClient()
         scope_data = {}
         for table in scopes:
@@ -160,10 +156,10 @@ class ObjectMetricsAPI(NBIAPI):
                 else:
                     qx += [
                         "(managed_object = %d AND path[4] IN (%s))"
-                        % (wx[0], ", ".join("'%s'" % x for x in wx[1]))
+                        % (wx[0], ", ".join(f"'{x}'" for x in wx[1]))
                     ]
             fields = ["ts", "managed_object", "path", *sorted(scopes[table][0])]
-            query = "SELECT %s FROM %s WHERE %s AND (%s)" % (
+            query = "SELECT {} FROM {} WHERE {} AND ({})".format(
                 ", ".join(fields),
                 table,
                 date_q,

--- a/services/nbi/paths/objectstatus.py
+++ b/services/nbi/paths/objectstatus.py
@@ -55,7 +55,7 @@ class ObjectStatusAPI(NBIAPI):
         try:
             objects = [int(o) for o in req.objects]
         except ValueError as e:
-            raise HTTPException(400, "Bad request: %s" % e)
+            raise HTTPException(400, f"Bad request: {e}")
         statuses = ManagedObject.get_statuses(objects)
         return {"statuses": [{"id": str(o), "status": statuses.get(o, False)} for o in objects]}
 

--- a/services/nbi/paths/path.py
+++ b/services/nbi/paths/path.py
@@ -137,7 +137,7 @@ class PathAPI(NBIAPI):
                 start, start_iface = self.get_object_and_interface(**dict(req.from_))
         except ValueError as e:
             raise HTTPException(
-                404, {"status": False, "error": "Failed to find start of path: %s" % e}
+                404, {"status": False, "error": f"Failed to find start of path: {e}"}
             )
         # Find end of path
         if hasattr(req.to, "level"):
@@ -150,7 +150,7 @@ class PathAPI(NBIAPI):
                 goal = ManagedObjectGoal(end)
             except ValueError as e:
                 raise HTTPException(
-                    404, {"status": False, "error": "Failed to find end of path: %s" % e}
+                    404, {"status": False, "error": f"Failed to find end of path: {e}"}
                 )
         # Trace the path
         if hasattr(req, "config"):

--- a/services/nbi/paths/servicestatus.py
+++ b/services/nbi/paths/servicestatus.py
@@ -86,7 +86,7 @@ class ServiceStatusAPI(NBIAPI):
                 if svc:
                     ids.add(svc.id)
         except ValueError as e:
-            raise HTTPException(400, "Bad request: %s" % e)
+            raise HTTPException(400, f"Bad request: {e}")
         if not ids:
             raise HTTPException(400, "Not requested service")
         statuses = []

--- a/services/ping/service.py
+++ b/services/ping/service.py
@@ -97,7 +97,7 @@ class PingService(FastAPIService):
                 await client.query(
                     limit=config.ping.ds_limit,
                     filters=[
-                        "pool(%s)" % config.pool,
+                        f"pool({config.pool})",
                         "shard(%d,%d)" % (self.slot_number, self.total_slots),
                     ],
                     block=True,

--- a/services/selfmon/collectors/base.py
+++ b/services/selfmon/collectors/base.py
@@ -28,7 +28,7 @@ class BaseCollector:
 
     def __init__(self, service) -> None:
         self.service = service
-        self.ttl = getattr(config.selfmon, "%s_ttl" % self.name, 30)
+        self.ttl = getattr(config.selfmon, f"{self.name}_ttl", 30)
         self.last_metrics = {}
         self.logger = PrefixLoggerAdapter(logger, self.name)
         self.t0 = int(time.time())
@@ -36,7 +36,7 @@ class BaseCollector:
 
     @classmethod
     def is_enabled(cls):
-        return getattr(config.selfmon, "enable_%s" % cls.name)
+        return getattr(config.selfmon, f"enable_{cls.name}")
 
     def can_run_at(self, t):
         """

--- a/services/selfmon/collectors/fm.py
+++ b/services/selfmon/collectors/fm.py
@@ -120,21 +120,21 @@ class FMObjectCollector(BaseCollector):
         for shard in set(TTSystem.objects.filter(is_active=True).values_list("shard_name")):
             yield (
                 ("fm_escalation_pool_count", ("shard", shard)),
-                db["noc.schedules.escalator.%s" % shard].estimated_document_count(),
+                db[f"noc.schedules.escalator.{shard}"].estimated_document_count(),
             )
             yield (
                 ("fm_escalation_queue_open_pool_count", ("shard", shard)),
-                db["noc.schedules.escalator.%s" % shard].count_documents(
+                db[f"noc.schedules.escalator.{shard}"].count_documents(
                     {"key": "noc.services.escalator.escalation.escalate"}
                 ),
             )
             yield (
                 ("fm_escalation_queue_close_pool_count", ("shard", shard)),
-                db["noc.schedules.escalator.%s" % shard].count_documents(
+                db[f"noc.schedules.escalator.{shard}"].count_documents(
                     {"key": "noc.services.escalator.escalation.notify_close"}
                 ),
             )
-            first_escalation = db["noc.schedules.escalator.%s" % shard].find_one(sort=[("ts", -1)])
+            first_escalation = db[f"noc.schedules.escalator.{shard}"].find_one(sort=[("ts", -1)])
             if first_escalation:
                 # yield ("escalation_last_ts", ("shard", shard)), time.mktime(last_escalation["ts"].timetuple())
                 yield (
@@ -142,7 +142,7 @@ class FMObjectCollector(BaseCollector):
                     self.calc_lag(time.mktime(first_escalation["ts"].timetuple()), now),
                 )
 
-            last_escalation = db["noc.schedules.escalator.%s" % shard].find_one(sort=[("ts", 1)])
+            last_escalation = db[f"noc.schedules.escalator.{shard}"].find_one(sort=[("ts", 1)])
             if last_escalation:
                 # yield ("escalation_last_ts", ("shard", shard)), time.mktime(last_escalation["ts"].timetuple())
                 yield (

--- a/services/selfmon/collectors/task.py
+++ b/services/selfmon/collectors/task.py
@@ -36,9 +36,9 @@ class TaskObjectCollector(BaseCollector):
         for name, shard in self.schedulers:
             if shard:
                 for s in shard:
-                    r["noc.schedules.%s.%s" % (name, s)] = {"name": name, "shard": s}
+                    r[f"noc.schedules.{name}.{s}"] = {"name": name, "shard": s}
             else:
-                r["noc.schedules.%s" % name] = {"name": name}
+                r[f"noc.schedules.{name}"] = {"name": name}
         return r
 
     def iter_metrics(self):

--- a/services/syslogcollector/service.py
+++ b/services/syslogcollector/service.py
@@ -108,7 +108,7 @@ class SyslogCollectorService(FastAPIService):
     async def get_pool_partitions(self, pool: str) -> int:
         parts = self.pool_partitions.get(pool)
         if not parts:
-            parts = await self.get_stream_partitions("events.%s" % pool)
+            parts = await self.get_stream_partitions(f"events.{pool}")
             self.pool_partitions[pool] = parts
         return parts
 
@@ -260,7 +260,7 @@ class SyslogCollectorService(FastAPIService):
             self.logger.info(
                 "Dropping %d messages with invalid sources: %s",
                 total,
-                ", ".join("%s: %s" % (s, self.invalid_sources[s]) for s in self.invalid_sources),
+                ", ".join(f"{s}: {self.invalid_sources[s]}" for s in self.invalid_sources),
             )
             self.invalid_sources = defaultdict(int)
         if not self.updated:

--- a/services/trapcollector/service.py
+++ b/services/trapcollector/service.py
@@ -111,7 +111,7 @@ class TrapCollectorService(FastAPIService):
     async def get_pool_partitions(self, pool: str) -> int:
         parts = self.pool_partitions.get(pool)
         if not parts:
-            parts = await self.get_stream_partitions("events.%s" % pool)
+            parts = await self.get_stream_partitions(f"events.{pool}")
             self.pool_partitions[pool] = parts
         return parts
 
@@ -248,7 +248,7 @@ class TrapCollectorService(FastAPIService):
             self.logger.info(
                 "Dropping %d messages with invalid sources: %s",
                 total,
-                ", ".join("%s: %s" % (s, self.invalid_sources[s]) for s in self.invalid_sources),
+                ", ".join(f"{s}: {self.invalid_sources[s]}" for s in self.invalid_sources),
             )
             self.invalid_sources = defaultdict(int)
         if not self.updated:


### PR DESCRIPTION
**services: use f-strings and .format()**

### Purpose
Migrate `%`-string formatting to f-strings and `.format()` across all `services/` modules as part of the project-wide string formatting modernization.

### Key Changes
- Replace legacy `"text %s" % var` patterns with `f"text {var}"` or `"text {}".format(var)` throughout 66 service files
- Apply to: error messages, log statements, SQL query construction, JSON key building, URL path assembly, and data serialization

### Notable Implementation Details
- `.format()` used selectively for complex expressions (ternary operators inside brackets) where f-strings would require unreadable nested curly-brace escaping
- Proper `{{}}` brace escaping maintained in raw SQL with JSON patterns (`maintenance.py`, `escalator/maintenance.py`) and compiled string templates (`rcacondition.py`)
- Format specifiers converted correctly: `"%.2f"` → `{:.2f}`, `"%02X"` → `{02X}`

### Files Changed (66 total)
- `services/activator/`, `services/bi/`, `services/card/`, `services/classifier/`, `services/correlator/`
- `services/datastream/`, `services/discovery/`, `services/escalator/`, `services/grafanads/`
- `services/login/`, `services/mib/`, `services/mrt/`, `services/nbi/`, `services/ping/`
- `services/selfmon/`, `services/syslogcollector/`, `services/trapcollector/`

### Related PRs
Part of series: #380 (services/web), #381 (sa.profiles), #382 (core/), #384 (core/prettyjson)
