### PR TITLE
print-files utility

### DIFF
--- a/scripts/print-files.py
+++ b/scripts/print-files.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# ----------------------------------------------------------------------
+# print-files script
+# ----------------------------------------------------------------------
+# Copyright (C) 2007-2025 The NOC Project
+# See LICENSE for details
+# ----------------------------------------------------------------------
+
+"""Print all files and directories specified by arguments."""
+
+# Python modules
+from pathlib import Path
+from typing import Iterable
+import sys
+
+HEADER_LEN = 72
+
+
+def iter_files(paths: Iterable[str]) -> Iterable[Path]:
+    for arg in paths:
+        path = Path(arg)
+        if path.is_dir():
+            yield from (p for p in path.rglob("*") if p.is_file())
+        elif path.is_file():
+            yield path
+
+
+def main(*args: str) -> None:
+    paths = args if args else (str(Path.cwd()),)
+    for path in iter_files(paths):
+        header = f"===[ File: {path} ]"
+        if len(header) < HEADER_LEN:
+            header += "=" * (HEADER_LEN - len(header))
+        print(header)
+        print(path.read_text())
+        print()
+
+
+if __name__ == "__main__":
+    main(*sys.argv[1:])


### PR DESCRIPTION
**Purpose:** Add a simple CLI utility to recursively print all file contents from specified directories or files. Useful for debugging, archival, or CI scenarios where you need to see the full contents of a directory subtree in a single output.

**Key changes:**
- New file: `scripts/print-files.py` (40 lines, executable mode)

**Notable implementation details:**
- Accepts paths as arguments; defaults to current working directory if no argument is provided
- Recursively iterates directories using `path.rglob("*")` and yields only files
- Prints each file with a formatted header (`===[ File: <path> ]`) padded to 72 characters
- Uses `Path.read_text()` (UTF-8 by default) for reading file contents
