### PR TITLE
pyproject.toml: Remove `black` settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,10 +150,6 @@ version = {attr = "noc.__version__"}
 [tool.setuptools.package-data]
 "noc" = ["py.typed", "**/*.j2"]
 
-[tool.black]
-line-length = 100 # Must be same as tool.ruff.line-length
-target-version = ['py310'] 
-
 [tool.coverage.run]
 omit = ['*tests*']
 
@@ -165,8 +161,8 @@ directory = "build/coverage"
 
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.
-exclude = [".git", "build", "dist", "var", "share", "collections", "node_modules", "ansible"] 
-line-length = 100 # Must be same as tool.black.line-length
+exclude = [".git", "build", "dist", "var", "share", "collections", "node_modules", "ansible"]
+line-length = 100
 # Assume Python 3.12
 target-version = "py312"
 # Always autofix, but never try to fix `F401` (unused imports).


### PR DESCRIPTION
**Purpose**
Remove stale Black formatter configuration from `pyproject.toml`. The project uses `ruff format` exclusively (see AGENTS.md), so the `[tool.black]` section is unnecessary and may create confusion.

**Key changes**
- Removed the entire `[tool.black]` section (line-length, target-version)
- Removed stale comment referencing Black in `[tool.ruff.line-length]`
- Fixed trailing whitespace on `[tool.ruff].exclude` line
