### PR TITLE
DLink.DxS.get_interface_status_ex - Avoiding crashes on service inter…

### DIFF
--- a/sa/profiles/DLink/DxS/get_interface_status_ex.py
+++ b/sa/profiles/DLink/DxS/get_interface_status_ex.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # DLink.DxS.get_interface_status_ex
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -22,5 +22,8 @@ class Script(BaseScript):
         :param speed:
         :return:
         """
+        # Avoiding crashes on service interfaces
+        if data.get("oper_status") is None:
+            return False
         # Some devices reporting 1410065408 instead 4294967295
         return speed in [1410065408, 4294967295] and data["oper_status"]

--- a/sa/profiles/DLink/DxS/get_interface_status_ex.py
+++ b/sa/profiles/DLink/DxS/get_interface_status_ex.py
@@ -23,7 +23,7 @@ class Script(BaseScript):
         :return:
         """
         # Avoiding crashes on service interfaces
-        if data.get("oper_status") is None:
+        if "oper_status" not in data:
             return False
         # Some devices reporting 1410065408 instead 4294967295
         return speed in [1410065408, 4294967295] and data["oper_status"]


### PR DESCRIPTION
**Purpose:** Prevent `KeyError` crashes in `DLink.DxS.get_interface_status_ex` when service interfaces lack the `oper_status` key.

**Key changes:**
- Add early-return guard (`if "oper_status" not in data: return False`) before accessing `data["oper_status"]`
- Update copyright year to 2026

**Implementation details:**
- The guard preserves existing behavior for normal interfaces (where `oper_status` is present)
- For service interfaces that don't expose this key, the function now safely returns `False` instead of crashing with `KeyError`
- This change only affects devices that use the `DLink.DxS` profile
