### PR TITLE
Replace python-jose with PyJWT

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ node = [
   "py-consul==1.7.1",
   "python-creole==1.4.10",
   "python-dateutil==2.9.0",
-  "python-jose[cryptography]==3.5.0",
+  "PyJWT==2.13.0",
   "setproctitle==1.3.5",
   "starlette>=1.3.1", # Used by FastAPI, restricted by security reasons
   "uvicorn==0.40.0",

--- a/services/login/auth.py
+++ b/services/login/auth.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # Authentication handler
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2025 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -12,7 +12,8 @@ import datetime
 import re
 
 # Third-party modules
-from jose import jwt, jwk
+import jwt
+from jwt import ExpiredSignatureError, InvalidTokenError
 from fastapi.responses import Response
 
 # NOC modules
@@ -26,9 +27,6 @@ logger = logging.getLogger(__name__)
 
 # Fields excluded from logging
 HIDDEN_FIELDS = {"password", "new_password", "old_password", "retype_password"}
-
-# Build JWK for sign/verify
-jwt_key = jwk.construct(config.secret_key, algorithm=config.login.jwt_algorithm).to_dict()
 
 
 class ChangeCredentialsError(NOCError):
@@ -108,7 +106,11 @@ def get_jwt_token(user: str, expire: int | None = None, audience: str | None = N
     }
     if audience:
         payload["aud"] = audience
-    return jwt.encode(payload, jwt_key, algorithm=config.login.jwt_algorithm)
+    return jwt.encode(
+        payload,
+        config.secret_key,
+        algorithm=config.login.jwt_algorithm,
+    )
 
 
 def get_user_from_jwt(token: str, audience: str | None = None) -> str:
@@ -127,7 +129,10 @@ def get_user_from_jwt(token: str, audience: str | None = None) -> str:
     """
     try:
         token = jwt.decode(
-            token, jwt_key, algorithms=[config.login.jwt_algorithm], audience=audience
+            token,
+            config.secret_key,
+            algorithms=[config.login.jwt_algorithm],
+            audience=audience,
         )
         user = None
         if isinstance(token, dict):
@@ -137,9 +142,9 @@ def get_user_from_jwt(token: str, audience: str | None = None) -> str:
         if not user:
             raise ValueError("Malformed token")
         return user
-    except jwt.ExpiredSignatureError:
+    except ExpiredSignatureError:
         raise ValueError("Expired token")
-    except jwt.JWTError as e:
+    except InvalidTokenError as e:
         raise ValueError(str(e))
 
 
@@ -159,7 +164,10 @@ def get_exp_from_jwt(token: str, audience: str | None = None) -> int:
     """
     try:
         token = jwt.decode(
-            token, jwt_key, algorithms=[config.login.jwt_algorithm], audience=audience
+            token,
+            config.secret_key,
+            algorithms=[config.login.jwt_algorithm],
+            audience=audience,
         )
         exp = None
         if isinstance(token, dict):
@@ -167,9 +175,9 @@ def get_exp_from_jwt(token: str, audience: str | None = None) -> int:
         if not exp:
             raise ValueError("Malformed token")
         return exp
-    except jwt.ExpiredSignatureError:
+    except ExpiredSignatureError:
         raise ValueError("Expired token")
-    except jwt.JWTError as e:
+    except InvalidTokenError as e:
         raise ValueError(str(e))
 
 

--- a/services/login/paths/is_logged.py
+++ b/services/login/paths/is_logged.py
@@ -12,7 +12,6 @@ from fastapi import APIRouter, Cookie
 from fastapi.responses import JSONResponse
 import jwt
 from jwt import InvalidTokenError
-import orjson
 
 # NOC modules
 from noc.config import config

--- a/services/login/paths/is_logged.py
+++ b/services/login/paths/is_logged.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # /api/login/is_logged/ path
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -10,12 +10,12 @@
 # Third-party modules
 from fastapi import APIRouter, Cookie
 from fastapi.responses import JSONResponse
-from jose import jwt, JWTError
+import jwt
+from jwt import InvalidTokenError
 import orjson
 
 # NOC modules
 from noc.config import config
-from noc.core.comp import smart_text
 
 router = APIRouter()
 
@@ -30,11 +30,11 @@ async def is_logged(jwt_cookie: str | None = Cookie(None, alias=config.login.jwt
         try:
             token = jwt.decode(
                 jwt_cookie,
-                smart_text(orjson.dumps(config.secret_key)),
+                config.secret_key,
                 algorithms=[config.login.jwt_algorithm],
                 audience="auth",
             )
             result = isinstance(token, dict) and "sub" in token
-        except JWTError:
+        except InvalidTokenError:
             pass
     return JSONResponse(result, status_code=200)


### PR DESCRIPTION
**Purpose:** Drop `python-jose[cryptography]` dependency in favor of the lighter, more actively maintained `PyJWT`. Our usage is limited to HMAC HS256/384/512 symmetric algorithms — no asymmetric cryptography needed.

**Key changes:**
- pyproject.toml: replace `python-jose[cryptography]==3.5.0` with `PyJWT==2.13.0`
- services/login/auth.py: migrate from jose/JWK → direct PyJWT API using `config.secret_key` as the signing key
- services/login/paths/is_logged.py: simplify verification to use `config.secret_key` directly; remove `orjson` and `smart_text` imports no longer needed

**Notable implementation details:**
- Token generation: `jwt.encode(payload, secret, algorithm=...)` — standard PyJWT API
- Token verification: `jwt.decode(token, secret, algorithms=[...], audience=...)` — standard PyJWT API
- Exception handling: `ExpiredSignatureError` → "Expired token", `InvalidTokenError` catches all other decode failures including audience/issuer mismatches and malformed tokens
- The previous JWK-based approach was unnecessary overhead since we only use HMAC symmetric keys
