### PR TITLE
smart_text/smart_bytes typing

### DIFF
--- a/core/comp.py
+++ b/core/comp.py
@@ -1,14 +1,21 @@
 # ----------------------------------------------------------------------
 # Compatibility routines
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
+
+# Python modules
+from typing import Protocol
 
 DEFAULT_ENCODING = "utf-8"
 
 
-def smart_bytes(s, encoding=DEFAULT_ENCODING):
+class SupportsStr(Protocol):
+    def __str__(self) -> str: ...
+
+
+def smart_bytes(s: bytes | str | SupportsStr, encoding: str = DEFAULT_ENCODING) -> bytes:
     """
     Convert strings to bytes when necessary
     """
@@ -19,7 +26,9 @@ def smart_bytes(s, encoding=DEFAULT_ENCODING):
     return str(s).encode(encoding)
 
 
-def smart_text(s, errors="strict", encoding=DEFAULT_ENCODING):
+def smart_text(
+    s: str | bytes | SupportsStr, errors: str = "strict", encoding: str = DEFAULT_ENCODING
+) -> str:
     """
     Convert bytes to string when necessary
     """


### PR DESCRIPTION
Add static type annotations to `smart_text` and `introduce structural Protocol-based parameter typing for `SupportsStr` — any object implementing `__str__()`. Both functions already accept arbitrary objects via duck-typing (`str(s)` fallback); this PR makes that explicit in the type system.

**Key changes**

- New `SupportsStr` Protocol (line 13) — minimal structural requirement for anything convertible to string
- `smart_bytes(s, encoding) → bytes` — typed with `bytes | str | SupportsStr` union
- `smart_text(s, errors, encoding) → str` — typed with `str | bytes | SupportsStr` union

**Notable implementation details**

- Uses `typing.Protocol` instead of ABC — lighter weight, no runtime overhead
- No behavioral changes: function bodies remain identical
