### PR TITLE
Remove excessive smart_text usage

### DIFF
--- a/sa/profiles/Alcatel/TIMOS/get_lldp_neighbors.py
+++ b/sa/profiles/Alcatel/TIMOS/get_lldp_neighbors.py
@@ -80,14 +80,14 @@ class Script(BaseScript):
         if port_type == "5" and "\n " in port:
             remote_port = port.replace("\n                        ", "")
             remote_port = remote_port.replace(":", "").replace("\n", "")
-            remote_port = smart_text(codecs.decode(remote_port, "hex"))
+            remote_port = codecs.decode(remote_port, "hex").decode()
         elif port_type == "5" and "\n" in port:
             remote_port = port.replace("\n", "")
             remote_port = remote_port.replace(":", "").replace("\n", "")
-            remote_port = smart_text(codecs.decode(remote_port, "hex"))
+            remote_port = codecs.decode(remote_port, "hex").decode()
         elif port_type == "5" and "\n " not in port:
             remote_port = remote_port.replace(":", "").replace("\n", "")
-            remote_port = smart_text(codecs.decode(remote_port, "hex"))
+            remote_port = codecs.decode(remote_port, "hex").decode()
         elif port_type == "7":
             return port.replace("\n", "")
         return remote_port

--- a/sa/profiles/DCN/DCWL/get_interface_status_ex.py
+++ b/sa/profiles/DCN/DCWL/get_interface_status_ex.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # DCN.DCWL.get_interface_status_ex
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -11,7 +11,6 @@ import codecs
 # NOC modules
 from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igetinterfacestatusex import IGetInterfaceStatusEx
-from noc.core.comp import smart_text
 
 
 class Script(BaseScript):
@@ -75,7 +74,7 @@ class Script(BaseScript):
                 ssid = value["ssid"].replace(" ", "").replace("Managed", "")
                 if ssid.startswith("2a2d"):
                     # 2a2d - hex string
-                    ssid = smart_text(codecs.decode(ssid, "hex"))
+                    ssid = codecs.decode(ssid, "hex").decode()
                 bss = self.get_bss_status(value["bss"])
                 if not bss:
                     continue

--- a/sa/profiles/DCN/DCWL/get_interfaces.py
+++ b/sa/profiles/DCN/DCWL/get_interfaces.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # DCN.DCWL.get_interfaces
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -12,7 +12,6 @@ import codecs
 from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igetinterfaces import IGetInterfaces
 from noc.core.ip import IPv4
-from noc.core.comp import smart_text
 
 
 class Script(BaseScript):
@@ -118,7 +117,7 @@ class Script(BaseScript):
                 ssid = value["ssid"].replace(" ", "").replace("Managed", "")
                 if ssid.startswith("2a2d"):
                     # 2a2d - hex string
-                    ssid = smart_text(codecs.decode(ssid, "hex"))
+                    ssid = codecs.decode(ssid, "hex").decode()
                 r = self.get_bss_detail(value["bss"])
                 bss_ifname = f"{ifname}.{ssid}"
                 if r:

--- a/sa/profiles/DCN/DCWL/get_metrics.py
+++ b/sa/profiles/DCN/DCWL/get_metrics.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # DCN.DCWL.get_metrics
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2023 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -12,7 +12,6 @@ import codecs
 # NOC modules
 from noc.sa.profiles.Generic.get_metrics import Script as GetMetricsScript, metrics
 from noc.core.validators import is_ipv4
-from noc.core.comp import smart_text
 
 
 class Script(GetMetricsScript):
@@ -157,7 +156,7 @@ class Script(GetMetricsScript):
                 ssid = data["ssid"].strip().replace(" ", "").replace("Managed", "")
                 if ssid.startswith("2a2d"):
                     # 2a2d - hex string
-                    ssid = smart_text(codecs.decode(ssid, "hex"))
+                    ssid = codecs.decode(ssid, "hex").decode()
                 iface = f"{data['name']}.{ssid}"
             else:
                 iface = data["name"]

--- a/sa/profiles/Eltex/WOP/get_interface_status_ex.py
+++ b/sa/profiles/Eltex/WOP/get_interface_status_ex.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # Eltex.WOP.get_interface_status_ex
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -11,7 +11,6 @@ import codecs
 # NOC modules
 from noc.sa.profiles.Generic.get_interface_status_ex import Script as BaseScript
 from noc.sa.interfaces.igetinterfacestatusex import IGetInterfaceStatusEx
-from noc.core.comp import smart_text
 from noc.core.mib import mib
 
 
@@ -80,7 +79,7 @@ class Script(BaseScript):
                 ssid = value["ssid"].replace(" ", "").replace("Managed", "")
                 if ssid.startswith("2a2d"):
                     # 2a2d - hex string
-                    ssid = smart_text(codecs.decode(ssid, "hex"))
+                    ssid = codecs.decode(ssid, "hex").decode()
                 bss = self.get_bss_status(value["bss"])
                 if not bss:
                     continue

--- a/sa/profiles/Eltex/WOP/get_interfaces.py
+++ b/sa/profiles/Eltex/WOP/get_interfaces.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # Eltex.WOP.get_interfaces
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -13,7 +13,6 @@ import enum
 from noc.sa.profiles.Generic.get_interfaces import Script as BaseScript
 from noc.sa.interfaces.igetinterfaces import IGetInterfaces
 from noc.core.ip import IPv4
-from noc.core.comp import smart_text
 from noc.core.mib import mib
 
 
@@ -130,7 +129,7 @@ class Script(BaseScript):
                 ssid = value["ssid"].replace(" ", "").replace("Managed", "")
                 if ssid.startswith("2a2d"):
                     # 2a2d - hex string
-                    ssid = smart_text(codecs.decode(ssid, "hex"))
+                    ssid = codecs.decode(ssid, "hex").decode()
                 r = self.get_bss_detail(value["bss"])
                 bss_ifname = f"{ifname}.{ssid}"
                 if r:

--- a/sa/profiles/Eltex/WOP/get_metrics.py
+++ b/sa/profiles/Eltex/WOP/get_metrics.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # Eltex.WOP.get_metrics
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -12,7 +12,6 @@ import codecs
 # NOC modules
 from noc.sa.profiles.Generic.get_metrics import Script as GetMetricsScript, metrics
 from noc.core.validators import is_ipv4
-from noc.core.comp import smart_text
 
 
 class Script(GetMetricsScript):
@@ -140,7 +139,7 @@ class Script(GetMetricsScript):
                 ssid = data["ssid"].strip().replace(" ", "").replace("Managed", "")
                 if ssid.startswith("2a2d"):
                     # 2a2d - hex string
-                    ssid = smart_text(codecs.decode(ssid, "hex"))
+                    ssid = codecs.decode(ssid, "hex").decode()
                 iface = "{}.{}".format(data["name"], ssid)
             else:
                 iface = data["name"]

--- a/sa/profiles/MikroTik/SwOS/get_interfaces.py
+++ b/sa/profiles/MikroTik/SwOS/get_interfaces.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # MikroTik.SwOS.get_interfaces
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -13,7 +13,6 @@ from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igetinterfaces import IGetInterfaces
 from noc.core.ip import IPv4
 from noc.core.script.http.base import HTTPError
-from noc.core.comp import smart_text
 
 
 class Script(BaseScript):
@@ -54,9 +53,9 @@ class Script(BaseScript):
             else:
                 ifname = "SFP"
             if links.get("nm"):
-                descr = smart_text(codecs.decode(links["nm"][port - 1], "hex"))
+                descr = codecs.decode(links["nm"][port - 1], "hex").decode()
             elif links.get("nm%d" % (port - 1)):
-                descr = smart_text(codecs.decode(links["nm%d" % (port - 1)], "hex"))
+                descr = codecs.decode(links["nm%d" % (port - 1)], "hex").decode()
             else:
                 descr = None
             iface = {

--- a/sa/profiles/MikroTik/SwOS/get_inventory.py
+++ b/sa/profiles/MikroTik/SwOS/get_inventory.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # MikroTik.SwOS.get_inventory
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -11,7 +11,6 @@ import codecs
 # NOC modules
 from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igetinventory import IGetInventory
-from noc.core.comp import smart_text
 
 
 class Script(BaseScript):
@@ -34,11 +33,11 @@ class Script(BaseScript):
         if sfps.get("vnd"):
             sfp_count = len(sfps["vnd"])
             for i in range(sfp_count):
-                vendor = smart_text(codecs.decode(sfps["vnd"][i], "hex")).strip()
-                part_no = smart_text(codecs.decode(sfps["pnr"][i], "hex")).strip()
-                revision = smart_text(codecs.decode(sfps["rev"][i], "hex")).strip()
-                serial = smart_text(codecs.decode(sfps["ser"][i], "hex")).strip()
-                date = smart_text(codecs.decode(sfps["dat"][i], "hex")).strip()
+                vendor = codecs.decode(sfps["vnd"][i], "hex").decode().strip()
+                part_no = codecs.decode(sfps["pnr"][i], "hex").decode().strip()
+                revision = codecs.decode(sfps["rev"][i], "hex").decode().strip()
+                serial = codecs.decode(sfps["ser"][i], "hex").decode().strip()
+                date = codecs.decode(sfps["dat"][i], "hex").decode().strip()
                 dt = date.split("-")
                 year = "20" + dt[0]
                 parts = [year, dt[1], dt[2]]
@@ -58,11 +57,11 @@ class Script(BaseScript):
                     }
                 ]
         elif sfps.get("vndr"):
-            vendor = smart_text(codecs.decode(sfps["vndr"], "hex")).strip()
-            part_no = smart_text(codecs.decode(sfps["ptnr"], "hex")).strip()
-            revision = smart_text(codecs.decode(sfps["rev"], "hex")).strip()
-            serial = smart_text(codecs.decode(sfps["ser"], "hex")).strip()
-            date = smart_text(codecs.decode(sfps["date"], "hex")).strip()
+            vendor = codecs.decode(sfps["vndr"], "hex").decode().strip()
+            part_no = codecs.decode(sfps["ptnr"], "hex").decode().strip()
+            revision = codecs.decode(sfps["rev"], "hex").decode().strip()
+            serial = codecs.decode(sfps["ser"], "hex").decode().strip()
+            date = codecs.decode(sfps["date"], "hex").decode().strip()
             dt = date.split("-")
             year = "20" + dt[0]
             parts = [year, dt[1], dt[2]]

--- a/sa/profiles/MikroTik/SwOS/get_version.py
+++ b/sa/profiles/MikroTik/SwOS/get_version.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # MikroTik.SwOS.get_version
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -11,7 +11,6 @@ import codecs
 # NOC modules
 from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igetversion import IGetVersion
-from noc.core.comp import smart_text
 
 
 class Script(BaseScript):
@@ -23,7 +22,7 @@ class Script(BaseScript):
         sys_info = self.profile.parseBrokenJson(self.http.get("/sys.b", cached=True, eof_mark=b"}"))
         return {
             "vendor": "MikroTik",
-            "platform": smart_text(codecs.decode(sys_info["brd"], "hex")),
-            "version": smart_text(codecs.decode(sys_info["ver"], "hex")),
-            "attributes": {"Serial Number": smart_text(codecs.decode(sys_info["sid"], "hex"))},
+            "platform": codecs.decode(sys_info["brd"], "hex").decode(),
+            "version": codecs.decode(sys_info["ver"], "hex").decode(),
+            "attributes": {"Serial Number": codecs.decode(sys_info["sid"], "hex").decode()},
         }

--- a/sa/profiles/NSN/TIMOS/get_lldp_neighbors.py
+++ b/sa/profiles/NSN/TIMOS/get_lldp_neighbors.py
@@ -71,7 +71,7 @@ class Script(BaseScript):
             #                       "XGigabitEthernet0/0/48"
             remote_port_name1, remote_port__name2 = port.rsplit("\n", 1)
             remote_port_name1 = re.sub(r"\n|\s+", "", remote_port_name1)
-            return smart_text(codecs.decode(remote_port_name1.strip().replace(":", ""), "hex"))
+            return codecs.decode(remote_port_name1.strip().replace(":", ""), "hex").decode()
         if port_type == "7":
             return port.replace("\n", "")
         return port


### PR DESCRIPTION
Remove unnecessary `smart_text` function calls in device profile scripts where the sole purpose is converting hex-decoded bytes to string.

**Key changes:**
- Replace `smart_text(codecs.decode(x, "hex"))` with `codecs.decode(x, "hex").decode()` across 11 files
- The `.decode()` call without arguments defaults to UTF-8, which matches the project's encoding convention (AGENTS.md states all text is UTF-8)
- Update copyright years from 2019–2023 to 2026 as a side effect

**Affected files (all in `sa/profiles/`):**
- `Alcatel/TIMOS/get_lldp_neighbors.py`
- `DCN/DCWL/get_interface_status_ex.py`, `get_interfaces.py`, `get_metrics.py`
- `Eltex/WOP/get_interface_status_ex.py`, `get_interfaces.py`, `get_metrics.py`
- `MikroTik/SwOS/get_interfaces.py`, `get_inventory.py`, `get_version.py`
- `NSN/TIMOS/get_lldp_neighbors.py`

**Notable details:**
- Semantic equivalence verified: the prior `smart_text` implementation for bytes input simply called `.decode(encoding)` where encoding defaults to UTF-8, so replacing with `.decode()` directly is functionally identical
- Two `get_lldp_neighbors.py` files (Alcatel, NSN) retain `smart_text` usage — correct, as they use it for non-hex contexts (`.rstrip("\x00")`) where `smart_text` serves its intended purpose