### PR TITLE
Remove rulename_quote function

### DIFF
--- a/fm/models/eventclass.py
+++ b/fm/models/eventclass.py
@@ -1,12 +1,11 @@
 # ---------------------------------------------------------------------
 # EventClass model
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2025 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
 # Python modules
-import re
 from pathlib import Path
 from threading import Lock
 from typing import Optional
@@ -455,16 +454,3 @@ class EventClass(Document):
                 }
             )
         return r
-
-
-rx_rule_name_quote = re.compile("[^a-zA-Z0-9]+")
-
-
-def rulename_quote(s):
-    """
-    Convert arbitrary string to pyrule name
-
-    >>> rulename_quote("Unknown | Default")
-    'Unknown_Default'
-    """
-    return rx_rule_name_quote.sub("_", s)


### PR DESCRIPTION
Remove unused `rulename_quote()` function and associated regex from the EventClass model.

**Key changes**
- Deleted `rx_rule_name_quote` regex pattern (`^[^a-zA-Z0-9]+$`)
- Deleted `rulename_quote()` function (docstring + implementation)
- Removed unused `import re`
- Updated copyright year: 2025 → 2026

**Notable implementation details**
- Zero external references to either symbol exist in the codebase (verified via full-text search)
- No imports of `rulename_quote` from other modules
- The function was a simple string sanitizer that converted arbitrary strings to "pyrule names" by replacing non-alphanumeric characters with underscores
dead code