### PR TITLE
Remove unneccessary type=smart_text usage in commands

### DIFF
--- a/commands/beef.py
+++ b/commands/beef.py
@@ -44,34 +44,34 @@ class Command(BaseCommand):
             help="Ignore beef policy setings in ManagedObject",
         )
         collect_parser.add_argument("--storage", help="External storage name or url")
-        collect_parser.add_argument("--path", type=smart_text, help="Path name")
-        collect_parser.add_argument("--description", type=smart_text, help="Set beef description")
+        collect_parser.add_argument("--path", help="Path name")
+        collect_parser.add_argument("--description", help="Set beef description")
         collect_parser.add_argument("objects", nargs=argparse.REMAINDER, help="Object names or ids")
         # view command
         view_parser = subparsers.add_parser("view")
         view_parser.add_argument("--storage", help="External storage name or url")
-        view_parser.add_argument("--path", type=smart_text, help="Beef UUID or path name")
+        view_parser.add_argument("--path", help="Beef UUID or path name")
         # edit command
         export_parser = subparsers.add_parser("export")
         export_parser.add_argument("--storage", help="External storage name or url")
-        export_parser.add_argument("--path", type=smart_text, help="Beef UUID or path name")
+        export_parser.add_argument("--path", help="Beef UUID or path name")
         export_parser.add_argument("--export-path", help="Path file for export")
         # edit command
         import_parser = subparsers.add_parser("import")
         import_parser.add_argument("--storage", help="External storage name or url")
-        import_parser.add_argument("--path", type=smart_text, help="Path name")
+        import_parser.add_argument("--path", help="Path name")
         import_parser.add_argument("paths", nargs=argparse.REMAINDER, help="Path to imported beef")
         # list command
         list_parser = subparsers.add_parser("list")  # noqa
         list_parser.add_argument("--storage", help="External storage name or url")
-        list_parser.add_argument("--path", type=smart_text, help="Beef UUID or path name")
+        list_parser.add_argument("--path", help="Beef UUID or path name")
         # test command
         run_parser = subparsers.add_parser("run")
         run_parser.add_argument(
             "--script", action="append", help="Script name for runs. Default (get_version)"
         )
         run_parser.add_argument("--storage", help="External storage name")
-        run_parser.add_argument("--path", type=smart_text, help="Beef UUID or path name")
+        run_parser.add_argument("--path", help="Beef UUID or path name")
         run_parser.add_argument("--access-preference", default="CS", help="Access preference")
         out_group = run_parser.add_mutually_exclusive_group()
         out_group.add_argument(
@@ -88,20 +88,18 @@ class Command(BaseCommand):
         # create-test-case
         create_test_case_parser = subparsers.add_parser("create-test-case")
         create_test_case_parser.add_argument("--storage", help="External storage name")
-        create_test_case_parser.add_argument("--path", type=smart_text, help="Path name")
+        create_test_case_parser.add_argument("--path", help="Path name")
         create_test_case_parser.add_argument("--test-storage", help="External storage name")
-        create_test_case_parser.add_argument("--test-path", type=smart_text, help="Path name")
+        create_test_case_parser.add_argument("--test-path", help="Path name")
         create_test_case_parser.add_argument("--config-storage", help="External storage name")
-        create_test_case_parser.add_argument(
-            "--config-path", type=smart_text, default="/", help="Path name"
-        )
+        create_test_case_parser.add_argument("--config-path", default="/", help="Path name")
         create_test_case_parser.add_argument(
             "--build", action="store_true", default=False, help="Build test case after create"
         )
         # build-test-case
         build_test_case_parser = subparsers.add_parser("build-test-case")
         build_test_case_parser.add_argument("--test-storage", help="External storage name")
-        build_test_case_parser.add_argument("--test-path", type=smart_text, help="Path name")
+        build_test_case_parser.add_argument("--test-path", help="Path name")
 
     def handle(self, cmd, *args, **options):
         setup_asyncio()

--- a/commands/confdb.py
+++ b/commands/confdb.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # ./noc confdb
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -15,7 +15,6 @@ from noc.config import config
 from noc.core.mongo.connection import connect
 from noc.core.profile.loader import loader
 from noc.core.text import format_table
-from noc.core.comp import smart_text
 
 
 class Command(BaseCommand):
@@ -29,18 +28,18 @@ class Command(BaseCommand):
         syntax_parser.add_argument("path", nargs=argparse.REMAINDER)
         # tokenizer command
         tokenizer_parser = subparsers.add_parser("tokenizer")
-        tokenizer_parser.add_argument("--object", type=smart_text, help="Managed Object ID")
+        tokenizer_parser.add_argument("--object", help="Managed Object ID")
         tokenizer_parser.add_argument("--profile", help="Profile Name")
         tokenizer_parser.add_argument("--config", help="Config Path")
         # config command
         normalizer_parser = subparsers.add_parser("normalizer")
-        normalizer_parser.add_argument("--object", type=smart_text, help="Managed Object ID")
+        normalizer_parser.add_argument("--object", help="Managed Object ID")
         normalizer_parser.add_argument("--profile", help="Profile Name")
         normalizer_parser.add_argument("--config", help="Config Path")
         normalizer_parser.add_argument("--errors-policy", help="Errors Policy")
         # query command
         query_parser = subparsers.add_parser("query")
-        query_parser.add_argument("--object", type=smart_text, help="Managed Object ID")
+        query_parser.add_argument("--object", help="Managed Object ID")
         query_parser.add_argument("--profile", help="Profile Name")
         query_parser.add_argument("--config", help="Config Path")
         query_parser.add_argument("query", help="Query request")
@@ -49,7 +48,7 @@ class Command(BaseCommand):
         dump_parser.add_argument(
             "--show-hints", action="store_true", help="Disable cleanup hints section"
         )
-        dump_parser.add_argument("--object", type=smart_text, help="Managed Object ID")
+        dump_parser.add_argument("--object", help="Managed Object ID")
 
     def handle(self, cmd, *args, **options):
         return getattr(self, f"handle_{cmd}")(*args, **options)

--- a/commands/script.py
+++ b/commands/script.py
@@ -76,9 +76,7 @@ class Command(BaseCommand):
             help="Set SNMP Rate-limit setting",
         )
         parser.add_argument("--update-spec", help="Append all issued commands to spec")
-        parser.add_argument(
-            "-o", dest="beef_output", type=smart_text, help="Save script output to beef"
-        )
+        parser.add_argument("-o", dest="beef_output", help="Save script output to beef")
         parser.add_argument("script", nargs=1, help="Script name")
         parser.add_argument("object_name", nargs=1, help="Object name")
         parser.add_argument(


### PR DESCRIPTION
Remove unnecessary `type=smart_text` wrappers from argparse argument definitions in CLI commands. This is part of the ongoing smart_text/smart_bytes cleanup series (#405, #404).

**Key changes**

- **commands/beef.py**: Removed `type=smart_text` from 12 argparse arguments across all subcommands (collect, view, export, import, list, run, create-test-case, build-test-case)
- **commands/confdb.py**: Removed `type=statext` and the unused import from 4 argparse arguments; updated copyright year to 2026
- **commands/script.py**: Removed `type=smart_text` from the `-o` argument

**Notable implementation details**

- Remaining runtime uses of `smart_text`/`smart_bytes` in beef.py (path construction, BEEF I/O) and script.py (vendor name encoding) are correctly preserved — these are actual conversions, not argparse type coercion
- Removing `type=smarttext` from `argparse.add_argument()` is safe as argparse defaults to `str` which behaves identically for CLI string arguments
