### PR TITLE
correlator: remove self.version (one-time usage)

### DIFF
--- a/services/correlator/service.py
+++ b/services/correlator/service.py
@@ -92,7 +92,6 @@ class CorrelatorService(FastAPIService):
 
     def __init__(self) -> None:
         super().__init__()
-        self.version = version.version
         self.rules: dict[ObjectId, list[EventAlarmRule]] = {}
         self.disposition_rules: dict[ObjectId, list[EventAlarmRule]] = {}
         self.object_avail_rules: dict[bool, list[EventAlarmRule]] = {}
@@ -280,7 +279,7 @@ class CorrelatorService(FastAPIService):
         r += [str(t), str(v)]
         r += [format_frames(get_traceback_frames(tb))]
         r = "\n".join(r)
-        event.mark_as_failed(version=self.version, traceback=r)
+        event.mark_as_failed(version=version.version, traceback=r)
 
     def set_root_cause(self, a: ActiveAlarm) -> bool:
         """


### PR DESCRIPTION
Remove unnecessary `self.version` instance attribute from `CorrelatorService`. The attribute was assigned once in `__init__` and used only once (~190 lines later) to pass the version string to `Event.mark_as_failed()`. Replacing it with a direct module-level reference eliminates unnecessary state storage.

### Key Changes
- Remove `self.version = version.version` from `CorrelatorService.__init__`
- Replace the single call site `event.mark_as_failed(version=self.version, ...)` with `event.mark_as_failed(version=version.version, ...)`

### Notable Implementation Details
- The `from noc.core.version import version` import already exists (line 63), so no new imports are needed
- `mark_as_failed()` in `fm/models/activeevent.py` expects a `version` string parameter — the signature remains unchanged

### Testing Information
- No behavioral change — same version value passed at runtime
