### PR TITLE
additional typing in commands/

### DIFF
--- a/commands/alarm.py
+++ b/commands/alarm.py
@@ -92,7 +92,7 @@ class AlarmConfig(BaseModel):
 class Command(BaseCommand):
     help = "Manage alarms"
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         test_rule = subparsers.add_parser("test-rule", help="Test Alarm Rule")
         test_rule.add_argument("--rule", help="Alarm Rule", required=False)

--- a/commands/beef.py
+++ b/commands/beef.py
@@ -32,7 +32,7 @@ class Command(BaseCommand):
     DEFAULT_BEEF_IMPORT_PATH_TEMPLATE = "imports/{0.box.profile}/{0.uuid}.beef.json.bz2"
     DEFAULT_TEST_CASE_TEMPLATE = "ad-hoc/{0.profile.name}/{0.uuid}/"
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         # collect command
         collect_parser = subparsers.add_parser("collect")

--- a/commands/bi.py
+++ b/commands/bi.py
@@ -42,7 +42,7 @@ class Command(BaseCommand):
     EXTRACT_WINDOW = config.bi.extract_window
     MIN_WINDOW = datetime.timedelta(seconds=2)
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         # Args
         parser.add_argument(

--- a/commands/cdag.py
+++ b/commands/cdag.py
@@ -6,6 +6,7 @@
 # ----------------------------------------------------------------------
 
 # Python modules
+import argparse
 import os
 import datetime
 from collections import defaultdict
@@ -34,7 +35,7 @@ NS = 1_000_000_000
 
 
 class Command(BaseCommand):
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         # Args
         parser.add_argument("--config", help="Graph config path", action="append", required=True)

--- a/commands/check-metric.py
+++ b/commands/check-metric.py
@@ -1,11 +1,12 @@
 # ----------------------------------------------------------------------
 # ./noc script
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
 # Python modules
+import argparse
 
 # Third-party modules
 import orjson
@@ -17,7 +18,7 @@ from noc.core.profile.loader import loader as profile_loader
 
 
 class Command(BaseCommand):
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(
             "--json",
             action="store_true",

--- a/commands/classify.py
+++ b/commands/classify.py
@@ -111,7 +111,7 @@ class Command(BaseCommand):
     DEFAULT_TARGET = Target.default()
     UNKNOWN_SYSLOG = "Unknown | Syslog"
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         # import
         import_parser = subparsers.add_parser("import", help="Parse and import text files")

--- a/commands/clean-label.py
+++ b/commands/clean-label.py
@@ -1,9 +1,12 @@
 # ----------------------------------------------------------------------
 # cleaning label commands
 # ----------------------------------------------------------------------
-# Copyright (C) 2021 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
+
+# Python modules
+import argparse
 
 # Third-party modules
 from django.db import connection
@@ -27,7 +30,7 @@ models = [
 class Command(BaseCommand):
     help = "Cleaning label"
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         (
             parser.add_argument(
                 "label",

--- a/commands/collection.py
+++ b/commands/collection.py
@@ -23,7 +23,7 @@ from noc.models import is_document
 
 
 class Command(BaseCommand):
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", help="sub-commands help", required=True)
         # sync
         subparsers.add_parser("sync", help="Synchronize collections")

--- a/commands/confdb.py
+++ b/commands/confdb.py
@@ -20,7 +20,7 @@ from noc.core.text import format_table
 class Command(BaseCommand):
     PREFIX = config.path.cp_new
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         # syntax command
         syntax_parser = subparsers.add_parser("syntax")

--- a/commands/config.py
+++ b/commands/config.py
@@ -15,7 +15,7 @@ from noc.core.management.base import BaseCommand
 
 
 class Command(BaseCommand):
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         dump_parser = subparsers.add_parser("dump")
         dump_parser.add_argument(

--- a/commands/convert-moin.py
+++ b/commands/convert-moin.py
@@ -31,7 +31,7 @@ rx_hexseq = re.compile(r"\(((?:[0-9a-f][0-9a-f])+)\)")
 class Command(BaseCommand):
     help = "Import MoinMoin wiki into NOC KB"
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         (
             parser.add_argument(
                 "-e", "--encoding", dest="encoding", default="utf-8", help="Encoding"

--- a/commands/crashinfo.py
+++ b/commands/crashinfo.py
@@ -27,7 +27,7 @@ class Command(BaseCommand):
 
     rx_xtype = re.compile(r"^<(?:type|class) '(?P<xtype>[^']+)'>\s+")
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         # list command
         subparsers.add_parser("list")

--- a/commands/csv-export.py
+++ b/commands/csv-export.py
@@ -23,7 +23,7 @@ from noc.core.mongo.connection import connect
 class Command(BaseCommand):
     help = "Export model to CSV"
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         (
             parser.add_argument(
                 "-t",

--- a/commands/csv-import.py
+++ b/commands/csv-import.py
@@ -24,7 +24,7 @@ from noc.core.mongo.connection import connect
 class Command(BaseCommand):
     help = "Import data from csv file"
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         (parser.add_argument("-r", "--resolve", dest="resolve", action="store", default="fail"),)
         (parser.add_argument("-d", "--delimiter", dest="delimiter", action="store", default=","),)
         parser.add_argument("args", nargs=argparse.REMAINDER, help="List of extractor names")

--- a/commands/datastream.py
+++ b/commands/datastream.py
@@ -63,7 +63,7 @@ class Command(BaseCommand):
     }
     BI_ID_DATASTREAM = {"cfgmetricsources", "cfgmetricstarget"}  # DataStream that used bi_id as ID
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         subparsers.add_parser("list")
         # rebuild

--- a/commands/discovery.py
+++ b/commands/discovery.py
@@ -83,7 +83,7 @@ class Command(BaseCommand):
         "segment": ["mac"],
     }
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         run_parser = subparsers.add_parser("run")
         run_parser.add_argument(

--- a/commands/dnszone.py
+++ b/commands/dnszone.py
@@ -31,7 +31,7 @@ class Command(BaseCommand):
     # Time multipliers
     TIMES = {"s": 1, "m": 60, "h": 3600, "d": 86400, "w": 604800}
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd")
         import_parser = subparsers.add_parser("import")
         (

--- a/commands/dump-addr.py
+++ b/commands/dump-addr.py
@@ -19,7 +19,7 @@ from noc.gis.models.division import Division
 class Command(BaseCommand):
     help = "Dump address database"
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         # parser.add_argument("-c", "--country",
         #                     dest="countries",
         #                     action="append")

--- a/commands/dump-crashinfo.py
+++ b/commands/dump-crashinfo.py
@@ -17,7 +17,7 @@ from noc.core.management.base import BaseCommand
 class Command(BaseCommand):
     help = "Dump crashinfo file"
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument("args", nargs=argparse.REMAINDER, help="List traceback files")
 
     def handle(self, *args, **options):

--- a/commands/escalation.py
+++ b/commands/escalation.py
@@ -24,7 +24,7 @@ from noc.core.defer import call_later
 
 
 class Command(BaseCommand):
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         check_parser = subparsers.add_parser("check")
         check_parser.add_argument(

--- a/commands/etl.py
+++ b/commands/etl.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
     SUMMARY_MASK = "%20s | %8s | %8s | %8s\n"
     CONTROL_MESSAGE = """Summary of %s changes: %d, overload control number: %d\n"""
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument("--system", action="append", help="System to extract")
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         # load command

--- a/commands/events.py
+++ b/commands/events.py
@@ -47,7 +47,7 @@ def unescape(s):
 class Command(BaseCommand):
     help = "Manage events"
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         # parser.add_argument("-s", "--selector", dest="selector", help="Selector name"),
         # parser.add_argument("-s", "--resource-group", dest="resource_group", help="Group"),
         # parser.add_argument("-o", "--object", dest="object", help="Managed Object's name"),

--- a/commands/fix.py
+++ b/commands/fix.py
@@ -18,7 +18,7 @@ from noc.config import config
 class Command(BaseCommand):
     FIX_DIRS = config.get_customized_paths("fixes")
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         subparsers.add_parser("list")
         apply_parser = subparsers.add_parser("apply")

--- a/commands/forensic.py
+++ b/commands/forensic.py
@@ -1,11 +1,12 @@
 # ----------------------------------------------------------------------
 # forensic
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
 # Python modules
+import argparse
 import sys
 import re
 from collections import namedtuple
@@ -32,7 +33,7 @@ class Command(BaseCommand):
 
     REFRESH_INTERVAL = 1
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", help="sub-commands help", required=True)
         # sync
         incomplete_parser = subparsers.add_parser("incomplete", help="Show incomplete operations")

--- a/commands/get-device-identity.py
+++ b/commands/get-device-identity.py
@@ -17,7 +17,7 @@ from noc.core.error import NOCError
 
 
 class Command(BaseCommand):
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(
             "devices",
             nargs=argparse.REMAINDER,

--- a/commands/get-device-sample.py
+++ b/commands/get-device-sample.py
@@ -1,9 +1,12 @@
 # ----------------------------------------------------------------------
 # Get sample devices for each platform
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2017 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
+
+# Python modules
+import argparse
 
 # NOC modules
 from noc.core.management.base import BaseCommand
@@ -14,7 +17,7 @@ from noc.sa.models.managedobject import ManagedObject
 
 
 class Command(BaseCommand):
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(
             "-s", "--sample", type=int, default=5, help="Amount of samples for each platform"
         )

--- a/commands/gridvcs.py
+++ b/commands/gridvcs.py
@@ -43,7 +43,7 @@ class Command(BaseCommand):
         "object_comment",
     }
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         parser.add_argument(
             "--repo",

--- a/commands/help.py
+++ b/commands/help.py
@@ -17,7 +17,7 @@ from noc.config import config
 
 
 class Command(BaseCommand):
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument("command", nargs=argparse.REMAINDER, help="Show command's help")
 
     def handle(self, command=None, *args, **options):

--- a/commands/index.py
+++ b/commands/index.py
@@ -1,9 +1,12 @@
 # ----------------------------------------------------------------------
 # Full-Text search manipulation
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2015 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
+
+# Python modules
+import argparse
 
 # NOC modules
 from noc.core.management.base import BaseCommand
@@ -13,7 +16,7 @@ from noc.models import FTS_MODELS, get_model
 
 
 class Command(BaseCommand):
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", help="sub-commands help", required=True)
         # Search parameters
         search_parser = subparsers.add_parser("search", help="Full-text search")

--- a/commands/interface-profile.py
+++ b/commands/interface-profile.py
@@ -21,7 +21,7 @@ from noc.core.text import alnum_key
 class Command(BaseCommand):
     help = "Apply interface classification"
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         # extract command
         show_parser = subparsers.add_parser("show", help="Show interface profiles")

--- a/commands/inventory.py
+++ b/commands/inventory.py
@@ -26,7 +26,7 @@ class Command(BaseCommand):
     def printbox_border(self):
         self.print("=" * (self.PB_LENGTH + 4))
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         # find-serial command
         find_serial_parser = subparsers.add_parser("find-serial")

--- a/commands/job.py
+++ b/commands/job.py
@@ -59,7 +59,7 @@ class Command(BaseCommand):
             return Scheduler(scheduler, pool=pool)
         return Scheduler(scheduler)
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         (
             parser.add_argument(
                 "--scheduler",

--- a/commands/l3-topology.py
+++ b/commands/l3-topology.py
@@ -1,11 +1,12 @@
 # ---------------------------------------------------------------------
 # L3 topology
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
 # Python modules
+import argparse
 import os
 import tempfile
 import subprocess
@@ -26,7 +27,7 @@ class Command(BaseCommand):
     help = "Show L3 topology"
     LAYOUT = ["neato", "cicro", "sfdp", "dot", "twopi"]
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         (
             parser.add_argument(
                 "--afi", dest="afi", action="store", default="4", help="AFI (ipv4/ipv6)"

--- a/commands/liftbridge.py
+++ b/commands/liftbridge.py
@@ -39,7 +39,7 @@ class Command(BaseCommand):
             msg = f"Not a valid date: '{s}'."
             raise argparse.ArgumentTypeError(msg)
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         # show-metadata
         subparsers.add_parser("show-metadata")

--- a/commands/link.py
+++ b/commands/link.py
@@ -28,7 +28,7 @@ ALARM_CLASSES_NAME = [
 class Command(BaseCommand):
     help = "Show Links"
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         # show command
         show_parser = subparsers.add_parser("show", help="Show link")

--- a/commands/login.py
+++ b/commands/login.py
@@ -1,12 +1,13 @@
 # ----------------------------------------------------------------------
 # Login debugging utility
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
 # Python modules
 import getpass
+import argparse
 
 # NOC modules
 from noc.core.management.base import BaseCommand
@@ -15,7 +16,7 @@ from noc.services.login.backends.base import BaseAuthBackend
 
 
 class Command(BaseCommand):
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(
             "--backend",
             action="store",

--- a/commands/metrics.py
+++ b/commands/metrics.py
@@ -40,7 +40,7 @@ NS = 1_000_000_000
 class Command(BaseCommand):
     TOPIC = "chwriter"
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         # load command
         load_parser = subparsers.add_parser("load", help="Load metrics to clickhouse")

--- a/commands/mib.py
+++ b/commands/mib.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
 
     svc = open_sync_rpc("mib")
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument("--local", action="store_true", help="Not use mib service for import")
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         # get

--- a/commands/migrate-ch.py
+++ b/commands/migrate-ch.py
@@ -5,6 +5,9 @@
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
+# Python modules
+import argparse
+
 # NOC modules
 from noc.core.management.base import BaseCommand
 from noc.core.clickhouse.connect import connection
@@ -21,7 +24,7 @@ from noc.config import config
 
 
 class Command(BaseCommand):
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument("--host", dest="host", help="ClickHouse address")
         parser.add_argument("--port", dest="port", type=int, help="ClickHouse port")
         parser.add_argument(

--- a/commands/migrate-liftbridge.py
+++ b/commands/migrate-liftbridge.py
@@ -1,13 +1,14 @@
 # ----------------------------------------------------------------------
 # Liftbridge streams synchronization tool
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2022 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
 # Python modules
 from functools import partial
 from typing import Iterable
+import argparse
 
 # NOC modules
 from noc.core.management.base import BaseCommand
@@ -23,7 +24,7 @@ from noc.main.models.pool import Pool
 
 
 class Command(BaseCommand):
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(
             "--slots",
             dest="slots",

--- a/commands/msgstream.py
+++ b/commands/msgstream.py
@@ -36,7 +36,7 @@ class Command(BaseCommand):
             msg = f"Not a valid date: '{s}'."
             raise argparse.ArgumentTypeError(msg)
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         # show-metadata
         sm = subparsers.add_parser("show-metadata")

--- a/commands/net-scan.py
+++ b/commands/net-scan.py
@@ -41,7 +41,7 @@ ICMP_DIAG = "ICMP"
 
 
 class Command(BaseCommand):
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument("--in", action="append", dest="input", help="File with addresses")
         parser.add_argument(
             "--pool",

--- a/commands/network-scan.py
+++ b/commands/network-scan.py
@@ -51,7 +51,7 @@ class Command(BaseCommand):
     CHECK_VERSION = {SNMP_v1: "snmp_v2c_get", SNMP_v2c: "snmp_v1_get"}
     SNMP_VERSION = {0: "SNMP_v1", 1: "SNMP_v2c"}
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument("--in", action="append", dest="inputs", help="File with addresses")
         parser.add_argument(
             "--import", action="append", dest="imports", help="File to import into NOC"

--- a/commands/newapp.py
+++ b/commands/newapp.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
 
     help = "Create application skeleton"
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         (parser.add_argument("--model", "-m", dest="model", help="List configs"),)
         (
             parser.add_argument(

--- a/commands/notify.py
+++ b/commands/notify.py
@@ -1,9 +1,12 @@
 # ----------------------------------------------------------------------
 # Notification utility
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2017 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
+
+# Python modules
+import argparse
 
 # NOC modules
 from noc.core.management.base import BaseCommand
@@ -12,7 +15,7 @@ from noc.main.models.notificationgroup import NotificationGroup
 
 
 class Command(BaseCommand):
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument("--dry-run", action="store_true", help="Dry Run (Do not send message)")
         parser.add_argument(
             "--notification-group",

--- a/commands/nri-link.py
+++ b/commands/nri-link.py
@@ -1,9 +1,12 @@
 # ----------------------------------------------------------------------
 # ./noc apply-nri-links
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
+
+# Python modules
+import argparse
 
 # Third-party modules
 from pymongo.errors import BulkWriteError
@@ -21,7 +24,7 @@ from noc.core.etl.portmapper.loader import loader
 class Command(BaseCommand):
     BATCH_SIZE = 100
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         # view command
         subparsers.add_parser("apply")

--- a/commands/nri.py
+++ b/commands/nri.py
@@ -20,7 +20,7 @@ from noc.core.text import alnum_key, format_table
 class Command(BaseCommand):
     PORT_ERROR = "ERROR!"
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         # portmap command
         portmap_parser = subparsers.add_parser("portmap")

--- a/commands/parse-events.py
+++ b/commands/parse-events.py
@@ -29,7 +29,7 @@ from noc.sa.models.profile import Profile
 
 
 class Command(BaseCommand):
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument("paths", nargs="+", help="List of input file paths")
         parser.add_argument("--profile", default="Generic.Host", help="Object profile")
         parser.add_argument("--format", default="syslog", help="Input format")

--- a/commands/ping.py
+++ b/commands/ping.py
@@ -22,7 +22,7 @@ from noc.config import config
 
 
 class Command(BaseCommand):
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument("--in", action="append", dest="input", help="File with addresses")
         parser.add_argument(
             "--jobs", action="store", type=int, default=100, dest="jobs", help="Concurrent jobs"

--- a/commands/prefix-list.py
+++ b/commands/prefix-list.py
@@ -1,9 +1,12 @@
 # ---------------------------------------------------------------------
 # ./noc prefix-list
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2018 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
+
+# Python modules
+import argparse
 
 # NOC modules
 from noc.core.management.base import BaseCommand, CommandError
@@ -15,7 +18,7 @@ from noc.sa.models.profile import Profile
 class Command(BaseCommand):
     help = "CLI Prefix-list builder"
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         (
             parser.add_argument(
                 "--output",

--- a/commands/pretty.py
+++ b/commands/pretty.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 #  Pretty command
 # ----------------------------------------------------------------------
-#  Copyright (C) 2007-2019 The NOC Project
+#  Copyright (C) 2007-2026 The NOC Project
 #  See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -9,6 +9,7 @@
 import json
 import sys
 import pprint
+import argparse
 
 # Third-party modules
 import yaml
@@ -18,7 +19,7 @@ from noc.core.management.base import BaseCommand
 
 
 class Command(BaseCommand):
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(
             "--yaml", action="store_const", dest="format", const="yaml", help="YAML output"
         )

--- a/commands/pythonpath.py
+++ b/commands/pythonpath.py
@@ -1,12 +1,13 @@
 # ---------------------------------------------------------------------
 # display PYTHONPATH
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2010 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
 # Python modules
 import sys
+import argparse
 
 # NOC modules
 from noc.core.management.base import BaseCommand
@@ -15,7 +16,7 @@ from noc.core.management.base import BaseCommand
 class Command(BaseCommand):
     help = "Display PYTHONPATH"
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(
             "--list",
             "-l",

--- a/commands/rca-debug.py
+++ b/commands/rca-debug.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # ./noc rca-debug
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -9,6 +9,7 @@
 import datetime
 from collections import namedtuple
 import operator
+import argparse
 
 # NOC modules
 from noc.core.management.base import BaseCommand
@@ -34,7 +35,7 @@ Record = namedtuple(
 
 
 class Command(BaseCommand):
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument("--delta", type=int, default=60, help="Alarm delta")
         parser.add_argument(
             "--trace", action="store_true", default=False, help="Trace RCA decision"

--- a/commands/report.py
+++ b/commands/report.py
@@ -27,7 +27,7 @@ from noc.main.models.report import Report
 class Command(BaseCommand):
     DEFAULT_LIMIT = 20
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         run_parser = subparsers.add_parser("run")
         run_parser.add_argument("--report", "-r", help="Report to run", required=True)

--- a/commands/rpc.py
+++ b/commands/rpc.py
@@ -16,7 +16,7 @@ from noc.core.service.error import RPCError
 
 
 class Command(BaseCommand):
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(
             "--pretty",
             action="store_true",

--- a/commands/run.py
+++ b/commands/run.py
@@ -21,7 +21,7 @@ from noc.inv.models.resourcegroup import ResourceGroup
 class Command(BaseCommand):
     DEFAULT_LIMIT = 20
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         cli_parser = subparsers.add_parser("cli")
         cli_parser.add_argument("--limit", default=self.DEFAULT_LIMIT, help="Concurrency limit")

--- a/commands/script.py
+++ b/commands/script.py
@@ -49,7 +49,7 @@ Credentials = namedtuple(
 
 
 class Command(BaseCommand):
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         # Output options
         out_group = parser.add_mutually_exclusive_group()
         out_group.add_argument(

--- a/commands/segment.py
+++ b/commands/segment.py
@@ -39,7 +39,7 @@ class Command(BaseCommand):
     GROUP BY mac
     """
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         split_floating_parser = subparsers.add_parser("split-floating")
         split_floating_parser.add_argument("--profile", help="Floating segment profile id")

--- a/commands/service.py
+++ b/commands/service.py
@@ -15,7 +15,7 @@ from noc.core.text import format_table
 
 
 class Command(BaseCommand):
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument("services", nargs=argparse.REMAINDER, help="Service names")
 
     def handle(self, services=None, *args, **options):

--- a/commands/snmp.py
+++ b/commands/snmp.py
@@ -38,7 +38,7 @@ class Command(BaseCommand):
     DEFAULT_COMMUNITY = "public"
     VERSION_MAP = {"v1": SNMP_v1, "v2c": SNMP_v2c, "v3": SNMP_v3}
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         get = subparsers.add_parser("get")
         get.add_argument("--community", help="SNMP community")

--- a/commands/sync-mibs.py
+++ b/commands/sync-mibs.py
@@ -27,7 +27,7 @@ from noc.core.comp import smart_text
 class Command(BaseCommand):
     help = "Upload bundled MIBs"
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         (
             parser.add_argument(
                 "-f",

--- a/commands/tech-report.py
+++ b/commands/tech-report.py
@@ -1,17 +1,18 @@
 # ---------------------------------------------------------------------
 # Display system and dependencies information
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2025 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
-# Using:
-# ./noc tech-report system
-# ./noc tech-report dependencies
-# ./noc tech-report
-# ./noc tech-report --ansi-symbols system
-# and so on
+"""
+./noc tech-report system
+./noc tech-report dependencies
+./noc tech-report
+./noc tech-report --ansi-symbols system
+"""
 
 # Python modules
+import argparse
 from importlib import metadata
 import os
 from pathlib import Path
@@ -95,7 +96,7 @@ class Command(BaseCommand):
     help = "Display system and dependencies information"
     is_ansi = False
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd")
         parser.add_argument(
             "-a", "--ansi-symbols", action="store_true", help="Use ANSI instead of Unicode symbols"

--- a/commands/translation.py
+++ b/commands/translation.py
@@ -57,7 +57,7 @@ class Command(BaseCommand):
     PROJECT = "The NOC Project"
     COPYRIGHT = "The NOC Project"
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         extract_parser = subparsers.add_parser("extract")
         extract_parser.add_argument(

--- a/commands/user.py
+++ b/commands/user.py
@@ -1,12 +1,13 @@
 # ---------------------------------------------------------------------
 # Maintain users
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2013 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
 # Python modules
 import random
+import argparse
 
 # NOC modules
 from noc.core.management.base import BaseCommand, CommandError
@@ -17,7 +18,7 @@ from noc.aaa.models.permission import Permission
 class Command(BaseCommand):
     help = "Manage users"
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         # extract command
         user_create = subparsers.add_parser("add")

--- a/commands/verify-model.py
+++ b/commands/verify-model.py
@@ -1,9 +1,12 @@
 # ---------------------------------------------------------------------
 # Link management CLI interface
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2025 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
+
+# Python modules
+import argparse
 
 # NOC modules
 from noc.core.management.base import BaseCommand
@@ -15,7 +18,7 @@ from noc.inv.models.protocol import ProtocolVariant
 class Command(BaseCommand):
     help = "Verify models"
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument(
             "-r",
             "--rebuild",

--- a/commands/whois.py
+++ b/commands/whois.py
@@ -14,7 +14,7 @@ from noc.core.mongo.connection import connect
 
 
 class Command(BaseCommand):
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         subparsers.add_parser("update-cache")
         prefix_list_parser = subparsers.add_parser("prefix-list")

--- a/commands/wipe.py
+++ b/commands/wipe.py
@@ -26,7 +26,7 @@ class Command(BaseCommand):
 
     models = {"managed_object": "sa.ManagedObject", "user": "aaa.User"}
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         parser.add_argument("model", nargs=1, help="List of extractor names")
         parser.add_argument("--state", help="Filter by state (if model supported")
         parser.add_argument(

--- a/commands/workflow.py
+++ b/commands/workflow.py
@@ -39,7 +39,7 @@ class Command(BaseCommand):
 
     EXPIRE_MODELS = ["vc.VLAN", "ip.Address"]
 
-    def add_arguments(self, parser):
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         subparsers = parser.add_subparsers(dest="cmd", required=True)
         # extract command
         migrate_parser = subparsers.add_parser("migrate")

--- a/core/management/base.py
+++ b/core/management/base.py
@@ -7,15 +7,18 @@
 
 # Python modules
 import sys
-import os
 import argparse
-from typing import NoReturn, Sequence
+from typing import Sequence, Never, TextIO, Iterable, Iterator, TypeVar
+from pathlib import Path
+import resource
 
 # Third-party modules
 from gufo.loader import Loader
 
 # NOC modules
 from noc.config import config
+
+T = TypeVar("T")
 
 
 class CommandError(Exception):
@@ -26,34 +29,74 @@ class BaseCommand:
     LOG_FORMAT = config.log_format
     help = ""  # Help text (shows ./noc help)
 
-    def __init__(self, stdout=sys.stdout, stderr=sys.stderr) -> None:
+    def __init__(self, stdout: TextIO | None = None, stderr: TextIO | None = None) -> None:
         self.verbose_level = 0
-        self.stdout = stdout
-        self.stderr = stderr
+        self.stdout: TextIO = sys.stdout if stdout is None else stdout
+        self.stderr: TextIO = sys.stderr if stderr is None else stderr
 
-    def print(self, *args, **kwargs) -> None:
-        if "file" not in kwargs:
-            kwargs["file"] = self.stdout
-        if "flush" in kwargs and kwargs.pop("flush"):
-            self.stdout.flush()
-        print(*args, **kwargs)
+    def print(
+        self,
+        *args: object,
+        sep: str | None = " ",
+        end: str | None = "\n",
+        file: TextIO | None = None,
+        flush: bool = False,
+    ) -> None:
+        """Print values to the configured output stream.
 
-    def run(self):
+        This method behaves like the built-in ``print`` function, but uses
+        the instance configured output stream when ``file`` is not specified.
+
+        The output stream can be replaced for testing purposes by passing
+        a custom ``TextIO`` object to the constructor, allowing tests to
+        capture and verify printed output without redirecting process-wide
+        stdout.
+
+        Args:
+            *args: Values to print.
+            sep: String inserted between values.
+            end: String appended after the last value.
+            file: Output stream. Uses the configured output stream by default.
+            flush: Whether to forcibly flush the output stream.
         """
-        Execute command. Usually from script
+        print(*args, sep=sep, end=end, file=self.stdout if file is None else file, flush=flush)
 
+    def run(self) -> Never:
+        """
+        Execute the command using command-line arguments.
+
+        This method is intended to be called from a command-line entry point
+        or a script main block.
+
+        Example:
+
+        ```python
         if __name__ == "__main__":
             Command().run()
+        ```
+
+        The method terminates the process with the exit code returned by
+        `run_from_argv`.
         """
         sys.exit(self.run_from_argv(sys.argv[1:]))
 
     def run_from_argv(self, argv: Sequence[str]) -> int:
         """
-        Execute command. Usually from script
+        Execute the command using the provided command-line arguments.
 
+        This method parses and executes a command using the specified
+        argument list and returns the process exit code.
+
+        It can be used from a command-line entry point or a script main block.
+
+        Example:
+
+        ```python
         if __name__ == "__main__":
             import sys
-            sys.exit(Command.run_from_argv())
+
+            sys.exit(Command().run_from_argv(sys.argv[1:]))
+        ```
         """
         parser = self.create_parser()
         self.add_default_arguments(parser)
@@ -124,7 +167,16 @@ class BaseCommand:
                     self.print("%40s : %s" % (k, d[k]))
 
     def create_parser(self) -> argparse.ArgumentParser:
-        cmd = os.path.basename(sys.argv[0])
+        """Create the command-line argument parser.
+
+        The program name is derived from `sys.argv[0]`. For Python scripts,
+        the `.py` suffix is removed and the command name is prefixed with
+        `noc`.
+
+        Returns:
+            Configured argument parser instance.
+        """
+        cmd = Path(sys.argv[0]).name
         if cmd.endswith(".py"):
             cmd = f"noc {cmd[:-3]}"
         return argparse.ArgumentParser(prog=cmd)
@@ -135,8 +187,14 @@ class BaseCommand:
         """
 
     def add_default_arguments(self, parser: argparse.ArgumentParser) -> None:
-        """
-        Apply default parser arguments
+        """Add common command-line arguments to the parser.
+
+        Adds options shared by all commands, including logging configuration,
+        profiling, metrics output, progress bar control, and resource usage
+        reporting.
+
+        Args:
+            parser: Argument parser to extend with default command options.
         """
         group = parser.add_mutually_exclusive_group()
         group.add_argument(
@@ -164,28 +222,55 @@ class BaseCommand:
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
         """
-        Apply additional parser arguments
+        Add command-specific arguments to the parser.
+
+        This method can be overridden by subclasses to register additional
+        command-line options specific to the command implementation.
+
+        Args:
+            parser: Argument parser to extend with command-specific options.
         """
 
-    def die(self, msg: str) -> NoReturn:
+    def die(self, msg: str) -> Never:
+        """
+        Terminate command execution by raising a command error.
+
+        Args:
+            msg: Error message describing the command failure.
+
+        Raises:
+            CommandError: Always raised with the provided error message.
+        """
         raise CommandError(msg)
 
-    def progress(self, iter, max_value=None):
-        """
-        Yield iterable and show progressbar
-        :return:
+    def progress(self, iterable: Iterable[T], max_value: int | None = None) -> Iterator[T]:
+        """Wrap an iterable with a progress bar.
+
+        The progress bar can be disabled using the ``no_progressbar`` option.
+        When disabled, items are yielded directly from the original iterable.
+
+        Args:
+            iterable: Iterable to process while displaying progress.
+            max_value: Optional total number of items for the progress bar.
+
+        Yields:
+            Items from the input iterable.
         """
         if self.no_progressbar:
-            yield from iter
+            yield from iterable
         else:
             import progressbar
 
-            yield from progressbar.progressbar(iter, max_value=max_value)
+            yield from progressbar.progressbar(iterable, max_value=max_value)
 
-    def show_usage(self, start, stop):
-        """
-        Show resource usage
-        :return:
+    def show_usage(self, start: resource.struct_rusage, stop: resource.struct_rusage) -> None:
+        """Show resource usage statistics.
+
+        Displays the difference between two resource usage snapshots.
+
+        Args:
+            start: Resource usage snapshot taken before the operation.
+            stop: Resource usage snapshot taken after the operation.
         """
         r = [
             "Resource usage:",


### PR DESCRIPTION
Add consistent type annotations across all CLI command modules and the `BaseCommand` base class to improve static type checking coverage.

## Key Changes
- Add `parser: argparse.ArgumentParser -> None` signature to `add_arguments()` in 69 command modules
- Fully type `core/management/base.py`:
  - Annotate `__init__`, `print()`, `run()`, `run_from_argv()`, `create_parser()`, `add_default_arguments()`, `die()`, `progress()`, `show_usage()`
  - Replace shadowed builtin parameter name `iter` → `iterable` in `progress()` 
  - Add generics via `TypeVar`, `Iterable[T]`, `Iterator[T]`

## Notable Implementation Details
- Replaced `os.path.basename(sys.argv[0])` with `Path(sys.argv[0]).name` (also removes unused `import os`)
- Import `argparse` explicitly in files that were missing it but used `argparse.ArgumentParser` implicitly through the base class
- Updated docstrings to Google/NumPy style throughout the new signatures
