### PR TITLE
SENTINEL object

### DIFF
--- a/core/typing.py
+++ b/core/typing.py
@@ -4,12 +4,32 @@
 # Copyright (C) 2007-2024 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
+"""
+Attributes:
+    SENTINEL: A unique sentinel object used to distinguish missing values
+        from values explicitly stored as None or other valid values.
+"""
 
 # Python modules
 from typing import Any, Protocol
 
 # Third-party modules
 from bson import ObjectId
+
+
+class _Sentinel:
+    """Sentinel object implementation."""
+
+    def __repr__(self) -> str:
+        """Return the sentinel representation.
+
+        Returns:
+            String representation of the sentinel object.
+        """
+        return "SENTINEL"
+
+
+SENTINEL = _Sentinel()
 
 
 class SupportsGetById(Protocol):

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,0 +1,23 @@
+# ----------------------------------------------------------------------
+# noc.core.typing tests
+# ----------------------------------------------------------------------
+# Copyright (C) 2007-2026 The NOC Project
+# See LICENSE for details
+# ----------------------------------------------------------------------
+
+# NOC modules
+from noc.core.typing import SENTINEL
+
+
+def test_sentinel_get() -> None:
+    data = {
+        "none": None,
+        "false": False,
+        "zero": 0,
+    }
+
+    assert data.get("missing", SENTINEL) is SENTINEL
+
+    assert data.get("none", SENTINEL) is None
+    assert data.get("false", SENTINEL) is False
+    assert data.get("zero", SENTINEL) == 0


### PR DESCRIPTION
Add a SENTINEL singleton object for distinguishing missing values from explicitly stored falsy values (None, False, 0).

**Key changes:**
- New `_Sentinel` class with proper `__repr__` returning `"SENTINEL"` for debugging clarity
- Module-level `SENTINEL` instance in `core/typing.py`
- Dedicated test module `tests/test_typing.py` covering the core use pattern (`dict.get(key, SENTINEL)`)

**Notable implementation details:**
- Uses a custom class (not bare `object()`) to enable meaningful `__repr__` output
- Singleton created at module level — identity comparison (`is SENTINEL`) works reliably
- Test covers edge cases: missing key returns SENTINEL, while keys with None/False/0 values return those actual values
