### PR TITLE
Application.render_json: complete typing

### DIFF
--- a/services/web/base/application.py
+++ b/services/web/base/application.py
@@ -350,7 +350,11 @@ class Application(metaclass=ApplicationBase):
 
     @classmethod
     def render_json(
-        cls, obj, *, status: int = HTTPStatus.OK.value, headers: dict[str, Any] | None = None
+        cls,
+        obj: object,
+        *,
+        status: int = HTTPStatus.OK.value,
+        headers: dict[str, Any] | None = None,
     ) -> HttpResponse:
         """
         Create serialized JSON-encoded response


### PR DESCRIPTION
Add explicit type annotation for the `obj` parameter in `Application.render_json`, completing the typing of this method signature.

**Key changes**
- Add `obj: object` annotation to `render_json()` in `services/web/base/application.py`

**Notable implementation details**
- All keyword-only parameters already had proper annotations (`status`, `headers`) — only the positional `obj` lacked one
- `object` is used intentionally (any JSON-serializable value: `dict`, `list`, `str`, etc.)
- No behavioral changes to `orjson.dumps()` call
