### PR TITLE
TopologyMap: Remove unused `page` parameter from `iter_maps`

### DIFF
--- a/core/topology/base.py
+++ b/core/topology/base.py
@@ -414,11 +414,10 @@ class TopologyBase:
     @classmethod
     def iter_maps(
         cls,
-        parent: str = None,
+        parent: str | None = None,
         query: str | None = None,
         limit: int | None = None,
         start: int | None = None,
-        page: int | None = None,
     ) -> Iterable[MapItem]:
         """Iterate over available maps."""
 

--- a/core/topology/map/configured.py
+++ b/core/topology/map/configured.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # Configured Map class
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2024 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -68,7 +68,6 @@ class ConfiguredTopology(TopologyBase):
         query: str | None = None,
         limit: int | None = None,
         start: int | None = None,
-        page: int | None = None,
     ) -> Iterable[MapItem]:
         data = ConfiguredMap.objects.filter().order_by("name")
         if query:

--- a/core/topology/map/l2domain.py
+++ b/core/topology/map/l2domain.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # L2DomainTopology class
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2024 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -87,11 +87,10 @@ class L2DomainTopology(TopologyBase):
     @classmethod
     def iter_maps(
         cls,
-        parent: str = None,
+        parent: str | None = None,
         query: str | None = None,
         limit: int | None = None,
         start: int | None = None,
-        page: int | None = None,
     ) -> Iterable[MapItem]:
         data = L2Domain.objects.filter().order_by("name")
         if query:

--- a/core/topology/map/objectcontainer.py
+++ b/core/topology/map/objectcontainer.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # PoP Access Map class
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2024 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -46,11 +46,10 @@ class ObjectContainerTopology(TopologyBase):
     @classmethod
     def iter_maps(
         cls,
-        parent: str = None,
+        parent: str | None = None,
         query: str | None = None,
         limit: int | None = None,
         start: int | None = None,
-        page: int | None = None,
     ) -> Iterable[MapItem]:
         if parent == cls.name:
             parent = None

--- a/core/topology/map/objectgroup.py
+++ b/core/topology/map/objectgroup.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # ObjectGroupTopology class
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2024 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -91,11 +91,10 @@ class ObjectGroupTopology(TopologyBase):
     @classmethod
     def iter_maps(
         cls,
-        parent: str = None,
+        parent: str | None = None,
         query: str | None = None,
         limit: int | None = None,
         start: int | None = None,
-        page: int | None = None,
     ) -> Iterable[MapItem]:
         if parent is not None:
             data = ResourceGroup.objects.filter(parent=parent).order_by("name")

--- a/core/topology/map/objectlevelneighbor.py
+++ b/core/topology/map/objectlevelneighbor.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # ObjectGroupTopology class
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2024 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -110,11 +110,10 @@ class ObjectLevelNeighborTopology(TopologyBase):
     @classmethod
     def iter_maps(
         cls,
-        parent: str = None,
+        parent: str | None = None,
         query: str | None = None,
         limit: int | None = None,
         start: int | None = None,
-        page: int | None = None,
     ) -> Iterable[MapItem]:
         data = ManagedObject.objects.filter().order_by("name")
         if query:

--- a/core/topology/map/segment.py
+++ b/core/topology/map/segment.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # SegmentTopology class
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2024 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -308,11 +308,10 @@ class SegmentTopology(TopologyBase):
     @classmethod
     def iter_maps(
         cls,
-        parent: str = None,
+        parent: str | None = None,
         query: str | None = None,
         limit: int | None = None,
         start: int | None = None,
-        page: int | None = None,
     ) -> Iterable[MapItem]:
         if parent is not None:
             data = NetworkSegment.objects.filter(parent=parent).order_by("name")

--- a/services/web/apps/inv/map/views.py
+++ b/services/web/apps/inv/map/views.py
@@ -328,13 +328,12 @@ class MapApplication(ExtApplication):
                 status=self.NOT_FOUND,
             )
         # Search for maps
-        r = []
+        r: list[dict[str, Any]] = []
         for mi in gen.iter_maps(
             parent=parent if parent not in ("0", gen.name) else None,
             query=g.get(self.query_param, ""),
             limit=int(g.get(self.limit_param, 500)),
             start=int(g.get(self.start_param, 0)),
-            page=int(g.get(self.page_param, 1)),
         ):
             r.append(
                 {


### PR DESCRIPTION
**TopologyMap: Remove unused `page` parameter from `iter_maps`**

Remove the `page` parameter from the `iter_maps` method across all TopologyMap classes, as it has never been used in any implementation — paging is handled by `start` and `limit` instead.

**Key changes:**
- Remove `page: int | None = None` from `TopologyBase.iter_maps()` base class signature
- Remove `page` parameter from 6 concrete implementations (configured, l2domain, objectcontainer, objectgroup, objectlevelneighbor, segment)
- Remove the `page=int(g.get(self.page_param, 1))` call in the sole caller (`inv/map/views.py`)
- Fix `parent: str = None` → `parent: str | None = None` for type consistency where not already done
- Add explicit annotation `r: list[dict[str, Any]]` in views.py
