### PR TITLE
update-copyright-year script

### DIFF
--- a/scripts/update-copyright-year.py
+++ b/scripts/update-copyright-year.py
@@ -27,7 +27,7 @@ from pathlib import Path
 
 CURRENT_YEAR = datetime.date.today().year
 
-COPYRIGHT_RE = re.compile(r"(#\s*Copyright\s+\(C\)\s+\d{4}-)(\d{4})")
+COPYRIGHT_RE = re.compile(r"(# Copyright \(C\) \d{4}-)(\d{4})")
 
 
 def iter_changed_files() -> list[Path]:

--- a/scripts/update-copyright-year.py
+++ b/scripts/update-copyright-year.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# ----------------------------------------------------------------------
+# Update copyright year
+# ----------------------------------------------------------------------
+# Copyright (C) 2007-2026 The NOC Project
+# See LICENSE for details
+# ----------------------------------------------------------------------
+
+"""
+Update copyright year in modified git files.
+
+Looks for lines like:
+
+    # Copyright (C) 2007-2026
+
+and replaces the ending year with the current one.
+Only Added (A) and Modified (M) files are processed.
+"""
+
+# Python modules
+from __future__ import annotations
+
+import datetime
+import re
+import subprocess
+from pathlib import Path
+
+CURRENT_YEAR = datetime.date.today().year
+
+COPYRIGHT_RE = re.compile(r"(#\s*Copyright\s+\(C\)\s+\d{4}-)(\d{4})")
+
+
+def iter_changed_files() -> list[Path]:
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--name-only", "--diff-filter=AM"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [Path(name) for name in result.stdout.splitlines() if name]
+
+
+def update_file(path: Path) -> bool:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, FileNotFoundError):
+        return False
+
+    changed = False
+
+    def repl(match: re.Match[str]) -> str:
+        nonlocal changed
+        if match.group(2) == str(CURRENT_YEAR):
+            return match.group(0)
+        changed = True
+        return f"{match.group(1)}{CURRENT_YEAR}"
+
+    new_text = COPYRIGHT_RE.sub(repl, text)
+
+    if changed:
+        path.write_text(new_text, encoding="utf-8")
+        print(f"Updated {path}")
+
+    return changed
+
+
+def main() -> None:
+    updated = 0
+    for path in iter_changed_files():
+        if update_file(path):
+            updated += 1
+    print(f"Updated {updated} file(s).")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add a CLI script to bulk-update copyright years in staged git files. Intended as a pre-commit hook or manual utility for keeping license headers current.

## Key changes
- `scripts/update-copyright-year.py` — new executable Python script (76 lines) that:
  - Queries `git diff --cached --name-only --diff-filter=AM` for staged files
  - Scans each file for `# Copyright (C) YEAR-YEAR` patterns
  - Replaces the ending year with the current year
  - Reports updated files and total count

## Notable implementation details
- Uses `re.sub()` with a callable replacement to avoid rewriting unchanged files unnecessarily
- Handles `UnicodeDecodeError` and `FileNotFoundError` gracefully (returns `False`)
- Only processes Added/Modified files in the staging area
- Regex tightened in commit #2 to match the project's standard copyright format
