### PR TITLE
ugettext typing

### DIFF
--- a/core/translation.py
+++ b/core/translation.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # Translation utilities
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -33,9 +33,9 @@ def set_translation(service, lang):
             logger.info("No translation for language '%s'. Using 'en' instead", lang)
 
 
-def _ugettext(x):
+def _ugettext(x: str) -> str:
     return x
 
 
-def ugettext(x):
+def ugettext(x: str) -> str:
     return smart_text(_ugettext(x))


### PR DESCRIPTION
Add type annotations to translation utility functions.

**Key changes:**
- Add `(x: str) -> str` signature to `_ugettext` and `ugettext` in `core/translation.py`
- Update copyright year from 2020 to 2026

**Notable implementation details:**
- Both functions accept only string inputs — all callers use the standard pattern `_("literal string")`, so no runtime behavior changes
- `ugettext` wraps through `smart_text()` which returns `str`, making the return type annotation accurate
- The `_ugettext` global can be reassigned by `set_translation()` to GNUTranslations' gettext method, which is also compatible with `(x: str) -> str`
