### PR TITLE
@api.XXX decorator

### DIFF
--- a/services/web/base/application.py
+++ b/services/web/base/application.py
@@ -130,7 +130,13 @@ class ViewAPI:
             A view decorator.
         """
         return view(
-            url=url, method=["GET"], access=access, url_name=url_name, menu=menu, validate=validate
+            url=url,
+            method=["GET"],
+            access=access,
+            url_name=url_name,
+            menu=menu,
+            validate=validate,
+            api=True,
         )
 
     def post(
@@ -155,7 +161,13 @@ class ViewAPI:
             A view decorator.
         """
         return view(
-            url=url, method=["POST"], access=access, url_name=url_name, menu=menu, validate=validate
+            url=url,
+            method=["POST"],
+            access=access,
+            url_name=url_name,
+            menu=menu,
+            validate=validate,
+            api=True,
         )
 
     def put(
@@ -180,7 +192,13 @@ class ViewAPI:
             A view decorator.
         """
         return view(
-            url=url, method=["PUT"], access=access, url_name=url_name, menu=menu, validate=validate
+            url=url,
+            method=["PUT"],
+            access=access,
+            url_name=url_name,
+            menu=menu,
+            validate=validate,
+            api=True,
         )
 
     def delete(
@@ -211,6 +229,7 @@ class ViewAPI:
             url_name=url_name,
             menu=menu,
             validate=validate,
+            api=True,
         )
 
 

--- a/services/web/base/application.py
+++ b/services/web/base/application.py
@@ -92,6 +92,131 @@ def view(
     return decorate
 
 
+class ViewAPI:
+    """
+    API view decorator factory.
+
+    Provides HTTP method-specific decorators that create API endpoints
+    using the common :func:`view` decorator.
+
+    Example:
+        @api.get(
+            url="^brief_lookup/$",
+            access="lookup",
+        )
+        def api_brief(self, request: HttpRequest):
+            ...
+    """
+
+    def get(
+        self,
+        url: str,
+        access: str | bool | Permission,
+        url_name: str | None = None,
+        menu: list[str] | None = None,  # @todo: dead code?
+        validate: dict[str, Any] | None = None,
+    ):
+        """
+        Decorate a GET API endpoint.
+
+        Args:
+            url: URL pattern relative to the application root.
+            access: Access control rule.
+            url_name: Optional URL name.
+            menu: Optional menu entry metadata.
+            validate: Optional request parameter validation schema.
+
+        Returns:
+            A view decorator.
+        """
+        return view(
+            url=url, method=["GET"], access=access, url_name=url_name, menu=menu, validate=validate
+        )
+
+    def post(
+        self,
+        url: str,
+        access: str | bool | Permission,
+        url_name: str | None = None,
+        menu: list[str] | None = None,  # @todo: dead code?
+        validate: dict[str, Any] | None = None,
+    ):
+        """
+        Decorate a POST API endpoint.
+
+        Args:
+            url: URL pattern relative to the application root.
+            access: Access control rule.
+            url_name: Optional URL name.
+            menu: Optional menu entry metadata.
+            validate: Optional request parameter validation schema.
+
+        Returns:
+            A view decorator.
+        """
+        return view(
+            url=url, method=["POST"], access=access, url_name=url_name, menu=menu, validate=validate
+        )
+
+    def put(
+        self,
+        url: str,
+        access: str | bool | Permission,
+        url_name: str | None = None,
+        menu: list[str] | None = None,  # @todo: dead code?
+        validate: dict[str, Any] | None = None,
+    ):
+        """
+        Decorate a PUT endpoint.
+
+        Args:
+            url: URL pattern relative to the application root.
+            access: Access control rule.
+            url_name: Optional URL name.
+            menu: Optional menu entry metadata.
+            validate: Optional request parameter validation schema.
+
+        Returns:
+            A view decorator.
+        """
+        return view(
+            url=url, method=["PUT"], access=access, url_name=url_name, menu=menu, validate=validate
+        )
+
+    def delete(
+        self,
+        url: str,
+        access: str | bool | Permission,
+        url_name: str | None = None,
+        menu: list[str] | None = None,  # @todo: dead code?
+        validate: dict[str, Any] | None = None,
+    ):
+        """
+        Decorate a DELETE API endpoint.
+
+        Args:
+            url: URL pattern relative to the application root.
+            access: Access control rule.
+            url_name: Optional URL name.
+            menu: Optional menu entry metadata.
+            validate: Optional request parameter validation schema.
+
+        Returns:
+            A view decorator.
+        """
+        return view(
+            url=url,
+            method=["DELETE"],
+            access=access,
+            url_name=url_name,
+            menu=menu,
+            validate=validate,
+        )
+
+
+api = ViewAPI()
+
+
 class BoundView:
     """
     Callable wrapper for a bound method that prevents descriptor binding.


### PR DESCRIPTION
Introduce `ViewAPI` — a decorator factory that provides HTTP-method-specific decorators (`@api.get`, `@api.post`, `@api.put`, `@api.delete`) as syntactic sugar over the existing `@view()` decorator.

**Key changes:**
- Added `ViewAPI` class with `get`, `post`, `put`, `delete` methods
- Each method delegates to `view()` with the HTTP method pre-set
- Created a singleton instance `api = ViewAPI()` for import and use
- Example usage in docstring demonstrates intended API endpoint decoration pattern

**Notable implementation details:**
- All four methods accept the same signature: `url`, `access`, `url_name`, `menu`, `validate`
- The `method` parameter is not exposed — it's hardcoded to the HTTP method (e.g., `["GET"]`)
- This aligns with RESTful conventions and reduces boilerplate for API endpoints
