### PR TITLE
User.with_user, User.get_current_user

### DIFF
--- a/aaa/models/user.py
+++ b/aaa/models/user.py
@@ -6,10 +6,14 @@
 # ----------------------------------------------------------------------
 
 # Python modules
+from __future__ import annotations
+
 import datetime
+from contextvars import ContextVar
+from contextlib import contextmanager
 import operator
 from threading import Lock
-from typing import Optional
+from typing import Iterator
 import logging
 
 # Third-party modules
@@ -129,25 +133,25 @@ class User(NOCModel):
 
     @classmethod
     @cachetools.cachedmethod(operator.attrgetter("_id_cache"), lock=lambda _: id_lock)
-    def get_by_id(cls, oid: int) -> Optional["User"]:
+    def get_by_id(cls, oid: int) -> "User" | None:
         return User.objects.filter(id=oid).first()
 
     @classmethod
-    def get_by_id_uncached(cls, oid: int) -> Optional["User"]:
+    def get_by_id_uncached(cls, oid: int) -> "User" | None:
         return User.objects.filter(id=oid).first()
 
     @classmethod
     @cachetools.cachedmethod(operator.attrgetter("_name_cache"), lock=lambda _: id_lock)
-    def get_by_username(cls, name: str) -> Optional["User"]:
+    def get_by_username(cls, name: str) -> "User" | None:
         return User.objects.filter(username=name).first()
 
     @classmethod
-    def get_by_username_uncached(cls, name: str) -> Optional["User"]:
+    def get_by_username_uncached(cls, name: str) -> "User" | None:
         return User.objects.filter(username=name).first()
 
     @classmethod
     @cachetools.cachedmethod(operator.attrgetter("_contact_cache"), lock=lambda _: id_lock)
-    def get_by_contact(cls, contact) -> Optional["User"]:
+    def get_by_contact(cls, contact) -> "User" | None:
         from .usercontact import UserContact
 
         uc = UserContact.objects.filter(params=contact).first()
@@ -397,3 +401,33 @@ class User(NOCModel):
         # Finally save
         user.save()
         return user.blocked_till
+
+    @contextmanager
+    def with_user(self) -> Iterator["User"]:
+        """
+        Set this user as the current execution context user.
+
+        The previous current user is restored automatically when leaving
+        the context, including when an exception is raised.
+
+        Yields:
+            The user instance active within the context.
+        """
+        token = _current_user.set(self)
+        try:
+            yield self
+        finally:
+            _current_user.reset(token)
+
+    @classmethod
+    def get_current_user(cls) -> User | None:
+        """
+        Return the user associated with the current execution context.
+
+        Returns:
+            The current user instance, or ``None`` if no user is set.
+        """
+        return _current_user.get()
+
+
+_current_user = ContextVar[User | None]("current_user", default=None)

--- a/tests/models/test_signatures.py
+++ b/tests/models/test_signatures.py
@@ -49,7 +49,7 @@ def int_or_oid(x) -> str:
     ],
 )
 @pytest.mark.parametrize("model", get_all_models(), ids=lambda x: x.__name__)
-def test_signatures(name: str, is_classmethod: bool, args, return_type, model) -> None:
+def test_get_by_signatures(name: str, is_classmethod: bool, args, return_type, model) -> None:
     method = getattr(model, name, None)
     if not method:
         pytest.skip(f"No {name} method")
@@ -74,7 +74,11 @@ def test_signatures(name: str, is_classmethod: bool, args, return_type, model) -
             f"Parameter `{param_name}` must be `{param_type!s}`. Current is `{pa}`"
         )
     # Check return type signature
-    expanded_type = return_type.replace("{model}", model.__name__)
-    assert str(sig.return_annotation) == expanded_type, (
-        f"Return type must be {expanded_type} (has {sig.return_annotation!s})"
+    expected_types = [
+        "typing.Optional[ForwardRef('{model}')]".replace("{model}", model.__name__),
+        f"{model.__name__} | None",
+        f"'{model.__name__}' | None",
+    ]
+    assert str(sig.return_annotation) in expected_types, (
+        f"Return type must in {expected_types!r} (has {sig.return_annotation!s})"
     )


### PR DESCRIPTION
Introduce a synchronous execution-context user mechanism (`User.with_user` / `User.get_current_user`) for background workers, callbacks, and non-HTTP code paths that need a current user but don't have access to FastAPI's async dependency injector.

### Key changes
- **New**: `User.with_user()` — contextmanager that sets the current user in a thread-safe ContextVar and restores the previous user on exit (including exceptions)
- **New**: `User.get_current_user()` — classmethod returning the current context user or `None`
- **Refactor**: All existing `get_by_*` signatures now use PEP 604 (`X | None`) instead of `Optional[X]`
- **Refactor**: Added `from __future__ import annotations` for forward reference support

### Implementation details
- ContextVar: `_current_user = ContextVar[User | None]`, default `None` — ensures no leakage across threads
- The existing async `core.service.deps.user.get_current_user` (FastAPI) remains unchanged; this PR adds a separate synchronous mechanism
