### PR TITLE
TopologyBase: Make ABC, additional typing

### DIFF
--- a/core/topology/base.py
+++ b/core/topology/base.py
@@ -10,6 +10,7 @@ import operator
 from typing import Any, Iterable
 from collections import defaultdict
 from dataclasses import asdict
+from abc import ABC, abstractmethod
 
 # Third-Party modules
 import networkx as nx
@@ -26,7 +27,7 @@ from .layout.tree import TreeLayout
 from .types import TopologyNode, MapMeta, MapItem, PathItem
 
 
-class TopologyBase:
+class TopologyBase(ABC):
     """
     Base Class for Map generators. Loaded by name
     """
@@ -412,6 +413,7 @@ class TopologyBase:
         """Check if topology is empty."""
         return False
 
+    @abstractmethod
     @classmethod
     def iter_maps(
         cls,
@@ -422,8 +424,9 @@ class TopologyBase:
     ) -> Iterable[MapItem]:
         """Iterate over available maps."""
 
+    @abstractmethod
     @classmethod
-    def iter_path(cls, gen_id) -> Iterable[PathItem]:
+    def iter_path(cls, gen_id: str) -> Iterable[PathItem]:
         """Return map by hierarchy path."""
 
 

--- a/core/topology/base.py
+++ b/core/topology/base.py
@@ -413,8 +413,8 @@ class TopologyBase(ABC):
         """Check if topology is empty."""
         return False
 
-    @abstractmethod
     @classmethod
+    @abstractmethod
     def iter_maps(
         cls,
         parent: str | None = None,
@@ -424,8 +424,8 @@ class TopologyBase(ABC):
     ) -> Iterable[MapItem]:
         """Iterate over available maps."""
 
-    @abstractmethod
     @classmethod
+    @abstractmethod
     def iter_path(cls, gen_id: str) -> Iterable[PathItem]:
         """Return map by hierarchy path."""
 

--- a/core/topology/map/configured.py
+++ b/core/topology/map/configured.py
@@ -84,7 +84,7 @@ class ConfiguredTopology(TopologyBase):
             )
 
     @classmethod
-    def iter_path(cls, gen_id) -> Iterable[PathItem]:
+    def iter_path(cls, gen_id: str) -> Iterable[PathItem]:
         cfg = ConfiguredMap.get_by_id(gen_id)
         yield PathItem(title=str(cfg.name), id=str(cfg.id), level=1)
 

--- a/core/topology/map/l2domain.py
+++ b/core/topology/map/l2domain.py
@@ -107,7 +107,7 @@ class L2DomainTopology(TopologyBase):
             )
 
     @classmethod
-    def iter_path(cls, gen_id) -> Iterable[PathItem]:
+    def iter_path(cls, gen_id: str) -> Iterable[PathItem]:
         o = L2Domain.get_by_id(gen_id)
         if not o:
             return

--- a/core/topology/map/objectcontainer.py
+++ b/core/topology/map/objectcontainer.py
@@ -77,7 +77,7 @@ class ObjectContainerTopology(TopologyBase):
             )
 
     @classmethod
-    def iter_path(cls, gen_id) -> Iterable[PathItem]:
+    def iter_path(cls, gen_id: str) -> Iterable[PathItem]:
         o = Object.get_by_id(gen_id)
         if not o:
             return

--- a/core/topology/map/objectgroup.py
+++ b/core/topology/map/objectgroup.py
@@ -114,7 +114,7 @@ class ObjectGroupTopology(TopologyBase):
             )
 
     @classmethod
-    def iter_path(cls, gen_id) -> Iterable[PathItem]:
+    def iter_path(cls, gen_id: str) -> Iterable[PathItem]:
         o = ResourceGroup.get_by_id(gen_id)
         if not o:
             return

--- a/core/topology/map/objectlevelneighbor.py
+++ b/core/topology/map/objectlevelneighbor.py
@@ -130,7 +130,7 @@ class ObjectLevelNeighborTopology(TopologyBase):
             )
 
     @classmethod
-    def iter_path(cls, gen_id) -> Iterable[PathItem]:
+    def iter_path(cls, gen_id: str) -> Iterable[PathItem]:
         o = ManagedObject.get_by_id(gen_id)
         if not o:
             return

--- a/core/topology/map/segment.py
+++ b/core/topology/map/segment.py
@@ -331,7 +331,7 @@ class SegmentTopology(TopologyBase):
             )
 
     @classmethod
-    def iter_path(cls, gen_id) -> Iterable[PathItem]:
+    def iter_path(cls, gen_id: str) -> Iterable[PathItem]:
         o = NetworkSegment.get_by_id(gen_id)
         if not o:
             return


### PR DESCRIPTION
Make `TopologyBase` an Abstract Base Class and properly type the `iter_maps()` and `iter_path()` abstract methods. Enforces that all concrete topology map implementations override these methods rather than relying on the empty base stubs.

### Key changes
- `core/topology/base.py`: Extend from `ABC`, add `@abstractmethod` to `iter_maps` and `iter_path`, type `gen_id: str` parameter
- `core/topology/map/{configured,l2domain,objectcontainer,objectgroup}.py`: Add `gen_id: str` type annotation to match base class signature
