### PR TITLE
#150: Limit list of available segments for user

### DIFF
--- a/core/topology/map/segment.py
+++ b/core/topology/map/segment.py
@@ -320,7 +320,7 @@ class SegmentTopology(TopologyBase):
             qs["parent"] = parent
         user = User.get_current_user()
         if user and not user.is_superuser:
-            adm_domains = UserAccess.get_domains(users)
+            adm_domains = UserAccess.get_domains(user)
             if not adm_domains:
                 return
             qs["adm_domains__in"] = adm_domains

--- a/core/topology/map/segment.py
+++ b/core/topology/map/segment.py
@@ -17,6 +17,8 @@ import cachetools
 from bson import ObjectId
 
 # NOC modules
+from noc.aaa.models.user import User
+from noc.sa.models.useraccess import UserAccess
 from noc.core.log import PrefixLoggerAdapter
 from noc.core.ip import IP
 from noc.core.graph.nexthop import iter_next_hops
@@ -313,10 +315,16 @@ class SegmentTopology(TopologyBase):
         limit: int | None = None,
         start: int | None = None,
     ) -> Iterable[MapItem]:
+        qs = {}
         if parent is not None:
-            data = NetworkSegment.objects.filter(parent=parent).order_by("name")
-        else:
-            data = NetworkSegment.objects.filter().order_by("name")
+            qs["parent"] = parent
+        user = User.get_current_user()
+        if user and not user.is_superuser:
+            adm_domains = UserAccess.get_domains(users)
+            if not adm_domains:
+                return
+            qs["adm_domains__in"] = adm_domains
+        data = NetworkSegment.objects.filter(**qs).order_by("name")
         if query:
             data = data.filter(name__icontains=query)
         # Apply paging

--- a/services/web/apps/inv/map/views.py
+++ b/services/web/apps/inv/map/views.py
@@ -330,23 +330,24 @@ class MapApplication(ExtApplication):
             )
         # Search for maps
         r: list[dict[str, Any]] = []
-        for mi in gen.iter_maps(
-            parent=parent if parent not in ("0", gen.name) else None,
-            query=g.get(self.query_param, ""),
-            limit=int(g.get(self.limit_param, 500)),
-            start=int(g.get(self.start_param, 0)),
-        ):
-            r.append(
-                {
-                    "label": mi.title,
-                    "generator": mi.generator,
-                    "id": str(mi.id),
-                    "has_children": mi.has_children,
-                    "only_container": mi.only_container,
-                    "code": mi.code,
-                }
-            )
-        return r
+        with request.user.with_user():
+            for mi in gen.iter_maps(
+                parent=parent if parent not in ("0", gen.name) else None,
+                query=g.get(self.query_param, ""),
+                limit=int(g.get(self.limit_param, 500)),
+                start=int(g.get(self.start_param, 0)),
+            ):
+                r.append(
+                    {
+                        "label": mi.title,
+                        "generator": mi.generator,
+                        "id": str(mi.id),
+                        "has_children": mi.has_children,
+                        "only_container": mi.only_container,
+                        "code": mi.code,
+                    }
+                )
+            return r
 
     @view(
         method=["GET"], url=r"^(?P<gen_id>[0-9a-f]{24}|\d+)/get_path/$", access="lookup", api=True


### PR DESCRIPTION
Restrict the list of network segments visible to non-superuser accounts based on their administrative domain permissions. Previously, all authenticated users could see every segment in the topology tree regardless of access rights.

## Key Changes

- **`core/topology/map/segment.py`**: Added admin domain filtering inside `SegmentTopology.iter_maps()`. Non-superusers now only see segments within their administrative domains (including nested domains via `UserAccess.get_domains()`). If a user has no admin domains, the generator returns an empty iterator.
  
- **`services/web/apps/inv/map/views.py`**: Wrapped the `api_lookup_maps` view endpoint call to `gen.iter_maps()` inside `request.user.with_user()`, so the context variable established by PR #422 propagates correctly to `SegmentTopology.iter_maps()`.

## Implementation Details

- Uses `User.get_current_user()` (ContextVar-based, introduced in PR #422) instead of thread-local or request-passed user.
- Filters at the queryset level via `qs["adm_domains__in"] = admin_domain_ids` — efficient MongoDB `$in` query.
- Superusers bypass filtering entirely (`is_superuser` check).
- Only affects `SegmentTopology` (network segment maps). Other topology types remain unfiltered.
