### PR TITLE
Add description field to UI grids

### DIFF
--- a/ui/web/dns/dnszoneprofile/Application.js
+++ b/ui/web/dns/dnszoneprofile/Application.js
@@ -20,27 +20,27 @@ Ext.define("NOC.dns.dnszoneprofile.Application", {
         {
             text: __("Name"),
             dataIndex: "name",
-            flex: 1
         },
         {
             text: __("TTL"),
             dataIndex: "zone_ttl",
-            flex: 1
         },
         {
             text: __("Notification Group"),
             dataIndex: "notification_group",
             renderer: NOC.render.Lookup("notification_group"),
-            flex: 1
         },
         {
             text: __("Masters"),
             dataIndex: "masterslabel",
-            flex: 1
         },
         {
             text: __("Slaves"),
             dataIndex: "slaveslabel",
+        },
+        {
+            text: __("Description"),
+            dataIndex: "description",
             flex: 1
         }
     ],

--- a/ui/web/fm/alarmdiagnosticconfig/Application.js
+++ b/ui/web/fm/alarmdiagnosticconfig/Application.js
@@ -34,8 +34,13 @@ Ext.define("NOC.fm.alarmdiagnosticconfig.Application", {
                 {
                     text: __("Alarm Class"),
                     dataIndex: "alarm_class",
-                    flex: 1,
+                    width: 250,
                     renderer: NOC.render.Lookup("alarm_class")
+                },
+                {
+                    text: __("Description"),
+                    dataIndex: "description",
+                    flex: 1,
                 }
             ],
 

--- a/ui/web/fm/alarmrule/Application.js
+++ b/ui/web/fm/alarmrule/Application.js
@@ -43,10 +43,26 @@ Ext.define("NOC.fm.alarmrule.Application", {
           align: "left",
         },
         {
+            text: __("TT Policy"),
+            dataIndex: "ttl_policy",
+            width: 100,
+            renderer: function(value, meta, record) {
+                var v = record.get("ttl_policy");
+                v += " " + NOC.render.Duration(record.get("clear_after_delay"));
+                return v;
+            },
+            align: "center"
+        },
+        {
           text: __("Escalation Profile"),
           dataIndex: "escalation_profile",
           width: 200,
           renderer: NOC.render.Lookup("escalation_profile"),
+        },
+        {
+          text: __("Description"),
+          dataIndex: "description",
+          flex: 1,
         },
       ],
 

--- a/ui/web/fm/alarmtrigger/Application.js
+++ b/ui/web/fm/alarmtrigger/Application.js
@@ -59,6 +59,10 @@ Ext.define("NOC.fm.alarmtrigger.Application", {
         {
             text: __("Handler"),
             dataIndex: "handler",
+        },
+        {
+            text: __("Description"),
+            dataIndex: "description",
             flex: 1
         }
     ],

--- a/ui/web/fm/eventtrigger/Application.js
+++ b/ui/web/fm/eventtrigger/Application.js
@@ -56,8 +56,12 @@ Ext.define("NOC.fm.eventtrigger.Application", {
         {
             text: __("Handler"),
             dataIndex: "handler",
+        },
+        {
+            text: __("Description"),
+            dataIndex: "description",
             flex: 1
-        }
+        },
     ],
     fields: [
         {

--- a/ui/web/fm/ignoreeventrule/Application.js
+++ b/ui/web/fm/ignoreeventrule/Application.js
@@ -13,7 +13,8 @@ Ext.define("NOC.fm.ignoreeventrule.Application", {
     columns: [
         {
             text: __("Name"),
-            dataIndex: "name"
+            dataIndex: "name",
+            width: 100,
         },
         {
             text: __("Active"),
@@ -24,11 +25,16 @@ Ext.define("NOC.fm.ignoreeventrule.Application", {
         {
             text: __("Left RE"),
             dataIndex: "left_re",
-            flex: 1
+            width: 200,
         },
         {
             text: __("Right RE"),
             dataIndex: "right_re",
+            width: 200,
+        },
+        {
+            text: __("Description"),
+            dataIndex: "description",
             flex: 1
         }
     ],

--- a/ui/web/fm/ignorepattern/Application.js
+++ b/ui/web/fm/ignorepattern/Application.js
@@ -32,7 +32,7 @@ Ext.define("NOC.fm.ignorepattern.Application", {
         {
           text: __("Pattern"),
           dataIndex: "pattern",
-          flex: 1,
+          width: 200,
         },
         {
           text: __("Description"),

--- a/ui/web/gis/layer/Application.js
+++ b/ui/web/gis/layer/Application.js
@@ -74,6 +74,11 @@ Ext.define("NOC.gis.layer.Application", {
           width: 50,
           renderer: me.renderStyle,
         },
+        {
+          text: __("Description"),
+          dataIndex: "description",
+          flex: 1,
+        },
       ],
       fields: [
         {

--- a/ui/web/inv/connectiontype/Application.js
+++ b/ui/web/inv/connectiontype/Application.js
@@ -49,25 +49,31 @@ Ext.define("NOC.inv.connectiontype.Application", {
       columns: [
         {
           text: __("Name"),
-          width: 300,
           dataIndex: "name",
+          width: 300,
         },
         {
           text: __("Builtin"),
-          width: 50,
           dataIndex: "is_builtin",
+          width: 50,
           renderer: NOC.render.Bool,
           sortable: false,
         },
         {
           text: __("Genders"),
-          width: 50,
           dataIndex: "genders",
+          width: 50,
+        },
+        {
+          text: __("Compatible groups"),
+          dataIndex: "c_group",
+          renderer: NOC.render.LabelField,
+          width: 200,
         },
         {
           text: __("Description"),
-          flex: 1,
           dataIndex: "description",
+          flex: 1,
         },
       ],
       fields: [

--- a/ui/web/inv/cpeprofile/Application.js
+++ b/ui/web/inv/cpeprofile/Application.js
@@ -33,13 +33,17 @@ Ext.define("NOC.inv.cpeprofile.Application", {
         {
           text: __("Name"),
           dataIndex: "name",
-          flex: 1
         },
         {
           text: __("Labels"),
           dataIndex: "labels",
           renderer: NOC.render.LabelField,
           width: 100
+        },
+        {
+          text: __("Description"),
+          dataIndex: "description",
+          flex: 1
         }
       ],
 

--- a/ui/web/inv/firmware/Application.js
+++ b/ui/web/inv/firmware/Application.js
@@ -51,14 +51,19 @@ Ext.define("NOC.inv.firmware.Application", {
         {
           text: __("Version"),
           dataIndex: "version",
-          flex: 1,
+          width: 100,
         },
         {
           text: __("Builtin"),
           dataIndex: "is_builtin",
-          width: 30,
+          width: 50,
           renderer: NOC.render.Bool,
           sortable: false,
+        },
+        {
+          text: __("Description"),
+          dataIndex: "description",
+          flex: 1,
         },
       ],
 

--- a/ui/web/inv/firmwarepolicy/Application.js
+++ b/ui/web/inv/firmwarepolicy/Application.js
@@ -7,182 +7,186 @@
 console.debug("Defining NOC.inv.firmwarepolicy.Application");
 
 Ext.define("NOC.inv.firmwarepolicy.Application", {
-    extend: "NOC.core.ModelApplication",
-    requires: [
-        "NOC.core.label.LabelField",
-        "NOC.inv.firmwarepolicy.Model",
-        "NOC.inv.firmware.LookupField",
-        "NOC.inv.platform.LookupField",
-        "Ext.ux.form.GridField"
-    ],
-    model: "NOC.inv.firmwarepolicy.Model",
-    initComponent: function() {
-        var me = this;
-        Ext.apply(me, {
-            columns: [
-                {
-                    text: __("Platform"),
-                    dataIndex: "platform",
-                    renderer: NOC.render.Lookup("platform"),
-                    width: 200
-                },
-                {
-                    text: __("Firmware"),
-                    dataIndex: "firmware",
-                    renderer: NOC.render.Lookup("firmware"),
-                    width: 200
-                },
-                {
-                    text: __("Condition"),
-                    dataIndex: "condition",
-                    width: 50
-                },
-                {
-                    text: __("Status"),
-                    dataIndex: "status",
-                    width: 100,
-                    renderer: NOC.render.Choices({
-                        r: "Recommended",
-                        a: "Acceptable",
-                        n: "Not recommended",
-                        d: "Denied"
-                    })
-                },
-                {
-                    text: __("Management"),
-                    dataIndex: "management",
-                    flex: 1,
-                    renderer: function(v) {
-                        return map((v || []).map(function(x) {return x.protocol;})).join(", ")
-                    }
-                }
-            ],
+  extend: "NOC.core.ModelApplication",
+  requires: [
+    "NOC.core.label.LabelField",
+    "NOC.inv.firmwarepolicy.Model",
+    "NOC.inv.firmware.LookupField",
+    "NOC.inv.platform.LookupField",
+    "Ext.ux.form.GridField",
+  ],
+  model: "NOC.inv.firmwarepolicy.Model",
+  initComponent: function(){
+    var me = this;
+    Ext.apply(me, {
+      columns: [
+        {
+          text: __("Platform"),
+          dataIndex: "platform",
+          renderer: NOC.render.Lookup("platform"),
+          width: 200,
+        },
+        {
+          text: __("Firmware"),
+          dataIndex: "firmware",
+          renderer: NOC.render.Lookup("firmware"),
+          width: 200,
+        },
+        {
+          text: __("Condition"),
+          dataIndex: "condition",
+          width: 100,
+        },
+        {
+          text: __("Status"),
+          dataIndex: "status",
+          width: 100,
+          renderer: NOC.render.Choices({
+            r: "Recommended",
+            a: "Acceptable",
+            n: "Not recommended",
+            d: "Denied",
+          }),
+        },
+        {
+          text: __("Management"),
+          dataIndex: "management",
+          renderer: function(v){
+            return (v || []).map(function(x){ return x.protocol; }).join(", ");
+          },
+        },
+        {
+          text: __("Description"),
+          dataIndex: "description",
+          flex: 1,
+        },
+      ],
 
-            fields: [
-                {
-                    name: "platform",
-                    xtype: "inv.platform.LookupField",
-                    fieldLabel: __("Platform"),
-                    allowBlank: true,
-                    uiStyle: "large"
-                },
-                {
-                    name: "firmware",
-                    xtype: "inv.firmware.LookupField",
-                    fieldLabel: __("Firmware"),
-                    allowBlank: false,
-                    uiStyle: "large"
-                },
-                {
-                    name: "condition",
-                    xtype: "combobox",
-                    fieldLabel: __("Condition"),
-                    store: [
-                        ["<", "<"],
-                        ["<=", "<="],
-                        [">=", ">="],
-                        [">", ">"],
-                        ["=", "="],
-                    ],
-                    value: "=",
-                    allowBlank: false,
-                    uiStyle: "small"
-                },
-                {
-                    name: "status",
-                    xtype: "combobox",
-                    fieldLabel: __("Status"),
-                    allowBlank: false,
-                    store: [
-                        ["r", "Recommended"],
-                        ["a", "Acceptable"],
-                        ["n", "Not recommended"],
-                        ["d", "Denied"]
-                    ],
-                    value: "a",
-                    uiStyle: "medium"
-                },
-                {
-                    name: "description",
-                    xtype: "textarea",
-                    fieldLabel: __("Description"),
-                    uiStyle: "large",
-                    allowBlank: true
-                },
-                {
-                    name: "access_preference",
-                    xtype: "combobox",
-                    fieldLabel: __("Access Preference"),
-                    tooltip: __(
-                        "Preference mode with worked profile script. <br/>" +
+      fields: [
+        {
+          name: "platform",
+          xtype: "inv.platform.LookupField",
+          fieldLabel: __("Platform"),
+          allowBlank: true,
+          uiStyle: "large",
+        },
+        {
+          name: "firmware",
+          xtype: "inv.firmware.LookupField",
+          fieldLabel: __("Firmware"),
+          allowBlank: false,
+          uiStyle: "large",
+        },
+        {
+          name: "condition",
+          xtype: "combobox",
+          fieldLabel: __("Condition"),
+          store: [
+            ["<", "<"],
+            ["<=", "<="],
+            [">=", ">="],
+            [">", ">"],
+            ["=", "="],
+          ],
+          value: "=",
+          allowBlank: false,
+          uiStyle: "small",
+        },
+        {
+          name: "status",
+          xtype: "combobox",
+          fieldLabel: __("Status"),
+          allowBlank: false,
+          store: [
+            ["r", "Recommended"],
+            ["a", "Acceptable"],
+            ["n", "Not recommended"],
+            ["d", "Denied"],
+          ],
+          value: "a",
+          uiStyle: "medium",
+        },
+        {
+          name: "description",
+          xtype: "textarea",
+          fieldLabel: __("Description"),
+          uiStyle: "large",
+          allowBlank: true,
+        },
+        {
+          name: "access_preference",
+          xtype: "combobox",
+          fieldLabel: __("Access Preference"),
+          tooltip: __(
+            "Preference mode with worked profile script. <br/>" +
                         "!! Work if Device Profile supported. <br/>" +
                         "Profile (default) - use Object Profile settings <br/>" +
                         "S - Use only SNMP when access to device" +
                         "CLI Only - Use only CLI when access to device" +
                         "SNMP, CLI - Use SNMP, if not avail swithc to CLI" +
-                        "CLI, SNMP - Use CLI, if not avail swithc to SNMP"
-                    ),
-                    allowBlank: true,
-                    uiStyle: "medium",
-                    store: [
-                        ["S", __("SNMP Only")],
-                        ["C", __("CLI Only")],
-                        ["SC", __("SNMP, CLI")],
-                        ["CS", __("CLI, SNMP")]
-                    ],
-                    listeners: {
-                        render: me.addTooltip
-                    }
-                },
-                {
-                    name: "snmp_rate_limit",
-                    xtype: "numberfield",
-                    fieldLabel: __("SNMP Rate limit"),
-                    tooltip: __(
-                        'Limit SNMP (Query per second).'
-                    ),
-                    allowBlank: true,
-                    hideTrigger: true,
-                    uiStyle: "medium",
-                    minValue: 0,
-                    maxValue: 99,
-                    listeners: {
-                        render: me.addTooltip
-                    }
-                },
-                {
-                    name: "labels",
-                    xtype: "labelfield",
-                    fieldLabel: __("Labels"),
-                    allowBlank: true,
-                    uiStyle: "large",
-                    query: {
-                        "allow_models": ["inv.FirmwarePolicy"]
-                    }
-                },
-                {
-                    name: "management",
-                    xtype: "gridfield",
-                    uiStyle: "medium",
-                    fieldLabel: __("Management"),
-                    columns: [
-                        {
-                            text: __("Protocol"),
-                            dataIndex: "protocol",
-                            flex: 1,
-                            editor: {
-                                xtype: "combobox",
-                                store: [
-                                    ["cli", "CLI"],
-                                    ["snmp", "SNMP"],
-                                    ["http", "HTTP"]
-                                ]
-                            }
-                        }
-                    ]
-                }
-            ]
-        });
-        me.callParent();
-    }
+                        "CLI, SNMP - Use CLI, if not avail swithc to SNMP",
+          ),
+          allowBlank: true,
+          uiStyle: "medium",
+          store: [
+            ["S", __("SNMP Only")],
+            ["C", __("CLI Only")],
+            ["SC", __("SNMP, CLI")],
+            ["CS", __("CLI, SNMP")],
+          ],
+          listeners: {
+            render: me.addTooltip,
+          },
+        },
+        {
+          name: "snmp_rate_limit",
+          xtype: "numberfield",
+          fieldLabel: __("SNMP Rate limit"),
+          tooltip: __(
+            "Limit SNMP (Query per second).",
+          ),
+          allowBlank: true,
+          hideTrigger: true,
+          uiStyle: "medium",
+          minValue: 0,
+          maxValue: 99,
+          listeners: {
+            render: me.addTooltip,
+          },
+        },
+        {
+          name: "labels",
+          xtype: "labelfield",
+          fieldLabel: __("Labels"),
+          allowBlank: true,
+          uiStyle: "large",
+          query: {
+            "allow_models": ["inv.FirmwarePolicy"],
+          },
+        },
+        {
+          name: "management",
+          xtype: "gridfield",
+          uiStyle: "medium",
+          fieldLabel: __("Management"),
+          columns: [
+            {
+              text: __("Protocol"),
+              dataIndex: "protocol",
+              flex: 1,
+              editor: {
+                xtype: "combobox",
+                store: [
+                  ["cli", "CLI"],
+                  ["snmp", "SNMP"],
+                  ["http", "HTTP"],
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    });
+    me.callParent();
+  },
 });

--- a/ui/web/inv/firmwarepolicy/Application.js
+++ b/ui/web/inv/firmwarepolicy/Application.js
@@ -7,186 +7,186 @@
 console.debug("Defining NOC.inv.firmwarepolicy.Application");
 
 Ext.define("NOC.inv.firmwarepolicy.Application", {
-  extend: "NOC.core.ModelApplication",
-  requires: [
-    "NOC.core.label.LabelField",
-    "NOC.inv.firmwarepolicy.Model",
-    "NOC.inv.firmware.LookupField",
-    "NOC.inv.platform.LookupField",
-    "Ext.ux.form.GridField",
-  ],
-  model: "NOC.inv.firmwarepolicy.Model",
-  initComponent: function(){
-    var me = this;
-    Ext.apply(me, {
-      columns: [
-        {
-          text: __("Platform"),
-          dataIndex: "platform",
-          renderer: NOC.render.Lookup("platform"),
-          width: 200,
-        },
-        {
-          text: __("Firmware"),
-          dataIndex: "firmware",
-          renderer: NOC.render.Lookup("firmware"),
-          width: 200,
-        },
-        {
-          text: __("Condition"),
-          dataIndex: "condition",
-          width: 100,
-        },
-        {
-          text: __("Status"),
-          dataIndex: "status",
-          width: 100,
-          renderer: NOC.render.Choices({
-            r: "Recommended",
-            a: "Acceptable",
-            n: "Not recommended",
-            d: "Denied",
-          }),
-        },
-        {
-          text: __("Management"),
-          dataIndex: "management",
-          renderer: function(v){
-            return (v || []).map(function(x){ return x.protocol; }).join(", ");
-          },
-        },
-        {
-          text: __("Description"),
-          dataIndex: "description",
-          flex: 1,
-        },
-      ],
+    extend: "NOC.core.ModelApplication",
+    requires: [
+        "NOC.core.label.LabelField",
+        "NOC.inv.firmwarepolicy.Model",
+        "NOC.inv.firmware.LookupField",
+        "NOC.inv.platform.LookupField",
+        "Ext.ux.form.GridField"
+    ],
+    model: "NOC.inv.firmwarepolicy.Model",
+    initComponent: function() {
+        var me = this;
+        Ext.apply(me, {
+            columns: [
+                {
+                    text: __("Platform"),
+                    dataIndex: "platform",
+                    renderer: NOC.render.Lookup("platform"),
+                    width: 200
+                },
+                {
+                    text: __("Firmware"),
+                    dataIndex: "firmware",
+                    renderer: NOC.render.Lookup("firmware"),
+                    width: 200
+                },
+                {
+                    text: __("Condition"),
+                    dataIndex: "condition",
+                    width: 50
+                },
+                {
+                    text: __("Status"),
+                    dataIndex: "status",
+                    width: 100,
+                    renderer: NOC.render.Choices({
+                        r: "Recommended",
+                        a: "Acceptable",
+                        n: "Not recommended",
+                        d: "Denied"
+                    })
+                },
+                {
+                    text: __("Management"),
+                    dataIndex: "management",
+                    renderer: function(v) {
+                        return map((v || []).map(function(x) {return x.protocol;})).join(", ")
+                    }
+                },
+                {
+                    text: __("Description"),
+                    dataIndex: "description",
+                    flex: 1,
+                }
+            ],
 
-      fields: [
-        {
-          name: "platform",
-          xtype: "inv.platform.LookupField",
-          fieldLabel: __("Platform"),
-          allowBlank: true,
-          uiStyle: "large",
-        },
-        {
-          name: "firmware",
-          xtype: "inv.firmware.LookupField",
-          fieldLabel: __("Firmware"),
-          allowBlank: false,
-          uiStyle: "large",
-        },
-        {
-          name: "condition",
-          xtype: "combobox",
-          fieldLabel: __("Condition"),
-          store: [
-            ["<", "<"],
-            ["<=", "<="],
-            [">=", ">="],
-            [">", ">"],
-            ["=", "="],
-          ],
-          value: "=",
-          allowBlank: false,
-          uiStyle: "small",
-        },
-        {
-          name: "status",
-          xtype: "combobox",
-          fieldLabel: __("Status"),
-          allowBlank: false,
-          store: [
-            ["r", "Recommended"],
-            ["a", "Acceptable"],
-            ["n", "Not recommended"],
-            ["d", "Denied"],
-          ],
-          value: "a",
-          uiStyle: "medium",
-        },
-        {
-          name: "description",
-          xtype: "textarea",
-          fieldLabel: __("Description"),
-          uiStyle: "large",
-          allowBlank: true,
-        },
-        {
-          name: "access_preference",
-          xtype: "combobox",
-          fieldLabel: __("Access Preference"),
-          tooltip: __(
-            "Preference mode with worked profile script. <br/>" +
+            fields: [
+                {
+                    name: "platform",
+                    xtype: "inv.platform.LookupField",
+                    fieldLabel: __("Platform"),
+                    allowBlank: true,
+                    uiStyle: "large"
+                },
+                {
+                    name: "firmware",
+                    xtype: "inv.firmware.LookupField",
+                    fieldLabel: __("Firmware"),
+                    allowBlank: false,
+                    uiStyle: "large"
+                },
+                {
+                    name: "condition",
+                    xtype: "combobox",
+                    fieldLabel: __("Condition"),
+                    store: [
+                        ["<", "<"],
+                        ["<=", "<="],
+                        [">=", ">="],
+                        [">", ">"],
+                        ["=", "="],
+                    ],
+                    value: "=",
+                    allowBlank: false,
+                    uiStyle: "small"
+                },
+                {
+                    name: "status",
+                    xtype: "combobox",
+                    fieldLabel: __("Status"),
+                    allowBlank: false,
+                    store: [
+                        ["r", "Recommended"],
+                        ["a", "Acceptable"],
+                        ["n", "Not recommended"],
+                        ["d", "Denied"]
+                    ],
+                    value: "a",
+                    uiStyle: "medium"
+                },
+                {
+                    name: "description",
+                    xtype: "textarea",
+                    fieldLabel: __("Description"),
+                    uiStyle: "large",
+                    allowBlank: true
+                },
+                {
+                    name: "access_preference",
+                    xtype: "combobox",
+                    fieldLabel: __("Access Preference"),
+                    tooltip: __(
+                        "Preference mode with worked profile script. <br/>" +
                         "!! Work if Device Profile supported. <br/>" +
                         "Profile (default) - use Object Profile settings <br/>" +
                         "S - Use only SNMP when access to device" +
                         "CLI Only - Use only CLI when access to device" +
                         "SNMP, CLI - Use SNMP, if not avail swithc to CLI" +
-                        "CLI, SNMP - Use CLI, if not avail swithc to SNMP",
-          ),
-          allowBlank: true,
-          uiStyle: "medium",
-          store: [
-            ["S", __("SNMP Only")],
-            ["C", __("CLI Only")],
-            ["SC", __("SNMP, CLI")],
-            ["CS", __("CLI, SNMP")],
-          ],
-          listeners: {
-            render: me.addTooltip,
-          },
-        },
-        {
-          name: "snmp_rate_limit",
-          xtype: "numberfield",
-          fieldLabel: __("SNMP Rate limit"),
-          tooltip: __(
-            "Limit SNMP (Query per second).",
-          ),
-          allowBlank: true,
-          hideTrigger: true,
-          uiStyle: "medium",
-          minValue: 0,
-          maxValue: 99,
-          listeners: {
-            render: me.addTooltip,
-          },
-        },
-        {
-          name: "labels",
-          xtype: "labelfield",
-          fieldLabel: __("Labels"),
-          allowBlank: true,
-          uiStyle: "large",
-          query: {
-            "allow_models": ["inv.FirmwarePolicy"],
-          },
-        },
-        {
-          name: "management",
-          xtype: "gridfield",
-          uiStyle: "medium",
-          fieldLabel: __("Management"),
-          columns: [
-            {
-              text: __("Protocol"),
-              dataIndex: "protocol",
-              flex: 1,
-              editor: {
-                xtype: "combobox",
-                store: [
-                  ["cli", "CLI"],
-                  ["snmp", "SNMP"],
-                  ["http", "HTTP"],
-                ],
-              },
-            },
-          ],
-        },
-      ],
-    });
-    me.callParent();
-  },
+                        "CLI, SNMP - Use CLI, if not avail swithc to SNMP"
+                    ),
+                    allowBlank: true,
+                    uiStyle: "medium",
+                    store: [
+                        ["S", __("SNMP Only")],
+                        ["C", __("CLI Only")],
+                        ["SC", __("SNMP, CLI")],
+                        ["CS", __("CLI, SNMP")]
+                    ],
+                    listeners: {
+                        render: me.addTooltip
+                    }
+                },
+                {
+                    name: "snmp_rate_limit",
+                    xtype: "numberfield",
+                    fieldLabel: __("SNMP Rate limit"),
+                    tooltip: __(
+                        'Limit SNMP (Query per second).'
+                    ),
+                    allowBlank: true,
+                    hideTrigger: true,
+                    uiStyle: "medium",
+                    minValue: 0,
+                    maxValue: 99,
+                    listeners: {
+                        render: me.addTooltip
+                    }
+                },
+                {
+                    name: "labels",
+                    xtype: "labelfield",
+                    fieldLabel: __("Labels"),
+                    allowBlank: true,
+                    uiStyle: "large",
+                    query: {
+                        "allow_models": ["inv.FirmwarePolicy"]
+                    }
+                },
+                {
+                    name: "management",
+                    xtype: "gridfield",
+                    uiStyle: "medium",
+                    fieldLabel: __("Management"),
+                    columns: [
+                        {
+                            text: __("Protocol"),
+                            dataIndex: "protocol",
+                            flex: 1,
+                            editor: {
+                                xtype: "combobox",
+                                store: [
+                                    ["cli", "CLI"],
+                                    ["snmp", "SNMP"],
+                                    ["http", "HTTP"]
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        });
+        me.callParent();
+    }
 });

--- a/ui/web/inv/macblacklist/Application.js
+++ b/ui/web/inv/macblacklist/Application.js
@@ -45,10 +45,23 @@ Ext.define("NOC.inv.macblacklist.Application", {
           width: 150,
         },
         {
-          text: __("Duplicate"),
+          text: __("Duplicated"),
           dataIndex: "is_duplicated",
-          width: 50,
+          width: 100,
           renderer: NOC.render.Bool,
+          align: "center",
+        },
+        {
+          text: __("Ignored"),
+          dataIndex: "is_ignored",
+          width: 100,
+          renderer: NOC.render.Bool,
+          align: "center",
+        },
+        {
+          text: __("Description"),
+          dataIndex: "description",
+          flex: 1,
         },
       ],
 

--- a/ui/web/inv/networksegment/Application.js
+++ b/ui/web/inv/networksegment/Application.js
@@ -70,11 +70,6 @@ Ext.define("NOC.inv.networksegment.Application", {
                     width: 200
                 },
                 {
-                    text: __("Description"),
-                    dataIndex: "description",
-                    flex: 1
-                },
-                {
                     text: __("Labels"),
                     dataIndex: "labels",
                     width: 100,
@@ -103,6 +98,11 @@ Ext.define("NOC.inv.networksegment.Application", {
                     text: __("Max Objects"),
                     dataIndex: "max_objects",
                     width: 70
+                },
+                {
+                    text: __("Description"),
+                    dataIndex: "description",
+                    flex: 1
                 }
             ],
 

--- a/ui/web/inv/networksegmentprofile/Application.js
+++ b/ui/web/inv/networksegmentprofile/Application.js
@@ -40,6 +40,10 @@ Ext.define("NOC.inv.networksegmentprofile.Application", {
                     text: __("Style"),
                     dataIndex: "style",
                     renderer: NOC.render.Lookup("style"),
+                },
+                {
+                    text: __("Description"),
+                    dataIndex: "description",
                     flex: 1
                 }
             ],

--- a/ui/web/inv/protocol/Application.js
+++ b/ui/web/inv/protocol/Application.js
@@ -68,6 +68,11 @@ Ext.define("NOC.inv.protocol.Application", {
           dataIndex: "connection_schema",
           width: 100,
         },
+        {
+          text: __("Description"),
+          dataIndex: "description",
+          flex: 1,
+        },
       ],
 
       fields: [

--- a/ui/web/inv/resourcepool/Application.js
+++ b/ui/web/inv/resourcepool/Application.js
@@ -28,14 +28,32 @@ Ext.define("NOC.inv.resourcepool.Application", {
         Ext.apply(me, {
             columns: [
                 {
-                    text: "Name",
+                    text: __("Name"),
                     dataIndex: "name",
-                    flex: 150
+                    width: 150
                 },
                 {
-                    text: "Type",
+                    text: __("Type"),
                     dataIndex: "type",
-                    flex: 100
+                    width: 100
+                },
+                {
+                    text: __("Unique"),
+                    dataIndex: "is_unique",
+                    width: 100,
+                    renderer: NOC.render.Bool,
+                    align: "center",
+                },
+                {
+                    text: __("Allocate Strategy"),
+                    dataIndex: "strategy",
+                    width: 100,
+                    align: "center",
+                },
+                {
+                    text: __("Description"),
+                    dataIndex: "description",
+                    flex: 1
                 }
             ],
 

--- a/ui/web/inv/technology/Application.js
+++ b/ui/web/inv/technology/Application.js
@@ -55,20 +55,28 @@ Ext.define("NOC.inv.technology.Application", {
         {
           text: __("Single Service"),
           dataIndex: "single_service",
-          width: 50,
+          width: 80,
           renderer: NOC.render.Bool,
+          align: "center"
         },
         {
           text: __("Single Client"),
           dataIndex: "single_client",
-          width: 50,
+          width: 80,
           renderer: NOC.render.Bool,
+          align: "center"
         },
         {
           text: __("Allow Children"),
           dataIndex: "allow_children",
-          width: 50,
+          width: 80,
           renderer: NOC.render.Bool,
+          align: "center"
+        },
+        {
+          text: __("Description"),
+          dataIndex: "description",
+          flex: 1,
         },
       ],
       fields: [

--- a/ui/web/inv/vendor/Application.js
+++ b/ui/web/inv/vendor/Application.js
@@ -33,17 +33,18 @@ Ext.define("NOC.inv.vendor.Application", {
       width: 200,
     },
     {
+      text: __("Builtin"),
+      dataIndex: "is_builtin",
+      width: 50,
+      renderer: NOC.render.Bool,
+      sortable: false,
+      align: "center",
+    },
+    {
       text: __("Site"),
       dataIndex: "site",
       flex: 1,
       renderer: NOC.render.URL,
-    },
-    {
-      text: __("Builtin"),
-      dataIndex: "is_builtin",
-      width: 30,
-      renderer: NOC.render.Bool,
-      sortable: false,
     },
   ],
   fields: [

--- a/ui/web/ip/addressprofile/Application.js
+++ b/ui/web/ip/addressprofile/Application.js
@@ -34,6 +34,11 @@ Ext.define("NOC.ip.addressprofile.Application", {
                     dataIndex: "workflow",
                     width: 100,
                     renderer: NOC.render.Lookup("workflow")
+                },
+                {
+                    text: __("Description"),
+                    dataIndex: "description",
+                    flex: 1
                 }
             ],
 

--- a/ui/web/ip/addressrange/Application.js
+++ b/ui/web/ip/addressrange/Application.js
@@ -20,7 +20,7 @@ Ext.define("NOC.ip.addressrange.Application", {
         {
             text: __("Name"),
             dataIndex: "name",
-            flex: 1
+            width: 100
         },
         {
             dataIndex: "is_active",
@@ -65,14 +65,15 @@ Ext.define("NOC.ip.addressrange.Application", {
             }
         },
         {
-            text: __("Description"),
-            dataIndex: "description"
-        },
-        {
             text: __("Labels"),
             dataIndex: "labels",
             renderer: NOC.render.LabelField
-        }
+        },
+        {
+            text: __("Description"),
+            dataIndex: "description",
+            flex: 1
+        },
     ],
     fields: [
         {

--- a/ui/web/ip/prefixprofile/Application.js
+++ b/ui/web/ip/prefixprofile/Application.js
@@ -55,6 +55,11 @@ Ext.define("NOC.ip.prefixprofile.Application", {
                         E: __("Enabled"),
                         D: __("Disabled")
                     })
+                },
+                {
+                    text: __("Description"),
+                    dataIndex: "description",
+                    flex: 1
                 }
             ],
 

--- a/ui/web/ip/vrf/Application.js
+++ b/ui/web/ip/vrf/Application.js
@@ -79,14 +79,14 @@ Ext.define("NOC.ip.vrf.Application", {
                     width: 50
                 },
                 {
-                    text: __("Description"),
-                    dataIndex: "description",
-                    flex: 1
-                },
-                {
                     text: __("Labels"),
                     dataIndex: "labels",
                     renderer: NOC.render.LabelField
+                },
+                {
+                    text: __("Description"),
+                    dataIndex: "description",
+                    flex: 1
                 }
             ],
             fields: [

--- a/ui/web/ip/vrfgroup/Application.js
+++ b/ui/web/ip/vrfgroup/Application.js
@@ -38,14 +38,14 @@ Ext.define("NOC.ip.vrfgroup.Application", {
             width: 50
         },
         {
+            text: __("Labels"),
+            dataIndex: "labels",
+            renderer: NOC.render.LabelField
+        },
+        {
             text: __("Description"),
             dataIndex: "description",
             flex: 1
-        },
-        {
-            text: __("Tags"),
-            dataIndex: "tags",
-            renderer: "NOC.render.Tags"
         }
     ],
     fields: [

--- a/ui/web/peer/as/Application.js
+++ b/ui/web/peer/as/Application.js
@@ -34,15 +34,15 @@ Ext.define("NOC.peer.as.Application", {
       renderer: NOC.render.Lookup("profile"),
     },
     {
-      text: __("Description"),
-      dataIndex: "description",
-      flex: 1,
-    },
-    {
       text: __("RIR"),
       dataIndex: "rir",
       renderer: NOC.render.Lookup("rir"),
       width: 100,
+    },
+    {
+      text: __("Description"),
+      dataIndex: "description",
+      flex: 1,
     },
   ],
   fields: [

--- a/ui/web/peer/asset/Application.js
+++ b/ui/web/peer/asset/Application.js
@@ -19,25 +19,26 @@ Ext.define("NOC.peer.asset.Application", {
   columns: [
     {
       text: __("Name"),
-      flex: 1,
       dataIndex: "name",
     },
     {
       text: __("Description"),
-      flex: 1,
       dataIndex: "description",
     },
     {
       text: __("Members"),
-      flex: 1,
       dataIndex: "members",
       renderer: NOC.render.WrapColumn,
     },
     {
       text: __("Labels"),
-      flex: 1,
       dataIndex: "labels",
       renderer: NOC.render.LabelField,
+    },
+    {
+      text: __("Description"),
+      dataIndex: "description",
+      flex: 1,
     },
   ],
   fields: [

--- a/ui/web/peer/asset/Application.js
+++ b/ui/web/peer/asset/Application.js
@@ -22,10 +22,6 @@ Ext.define("NOC.peer.asset.Application", {
       dataIndex: "name",
     },
     {
-      text: __("Description"),
-      dataIndex: "description",
-    },
-    {
       text: __("Members"),
       dataIndex: "members",
       renderer: NOC.render.WrapColumn,

--- a/ui/web/peer/peer/Application.js
+++ b/ui/web/peer/peer/Application.js
@@ -82,13 +82,11 @@ Ext.define("NOC.peer.peer.Application", {
     },
     {
       text: __("Peering Point"),
-      flex: 1,
       dataIndex: "peering_point",
       renderer: NOC.render.Lookup("peering_point"),
     },
     {
       text: __("Peer Profile"),
-      flex: 1,
       dataIndex: "profile",
       renderer: NOC.render.Lookup("profile"),
     },
@@ -99,13 +97,11 @@ Ext.define("NOC.peer.peer.Application", {
     },
     {
       text: __("Local AS"),
-      flex: 1,
       dataIndex: "local_asn",
       renderer: NOC.render.Lookup("local_asn"),
     },
     {
       text: __("Remote AS"),
-      flex: 1,
       dataIndex: "remote_asn",
     },
     {
@@ -116,44 +112,37 @@ Ext.define("NOC.peer.peer.Application", {
     },
     {
       text: __("Import Filter"),
-      flex: 1,
       dataIndex: "import_filter",
     },
     {
       text: __("Export Filter"),
-      flex: 1,
       dataIndex: "export_filter",
     },
     {
       text: __("Local Address"),
-      flex: 1,
       dataIndex: "local_ip",
     },
     {
       text: __("Remote Address"),
-      flex: 1,
       dataIndex: "remote_ip",
     },
     {
       text: __("TT"),
-      flex: 1,
       dataIndex: "tt",
     },
     {
-      text: __("Description"),
-      flex: 1,
-      dataIndex: "description",
-    },
-    {
       text: __("Import Communities"),
-      flex: 1,
       dataIndex: "communities",
     },
     {
       text: __("Labels"),
-      flex: 1,
       dataIndex: "labels",
       renderer: NOC.render.LabelField,
+    },
+    {
+      text: __("Description"),
+      dataIndex: "description",
+      flex: 1,
     },
   ],
   fields: [

--- a/ui/web/pm/agentprofile/Application.js
+++ b/ui/web/pm/agentprofile/Application.js
@@ -21,6 +21,28 @@ Ext.define("NOC.pm.agentprofile.Application", {
                 {
                     text: __("Name"),
                     dataIndex: "name",
+                },
+                {
+                    text: __("Check Interval"),
+                    dataIndex: "zk_check_interval",
+                    align: "right",
+                },
+                {
+                    text: __("Update Addresses"),
+                    dataIndex: "update_addresses",
+                    width: 100,
+                    renderer: NOC.render.Bool,
+                    align: "center",
+                },
+                {
+                    text: __("Workflow"),
+                    dataIndex: "workflow",
+                    width: 250,
+                    renderer: NOC.render.Lookup("workflow"),
+                },
+                {
+                    text: __("Description"),
+                    dataIndex: "description",
                     flex: 1
                 }
             ],

--- a/ui/web/pm/metricscope/Application.js
+++ b/ui/web/pm/metricscope/Application.js
@@ -29,12 +29,15 @@ Ext.define("NOC.pm.metricscope.Application", {
     Ext.apply(me, {
       columns: [
         {
-          text: "Name",
+          text: __("Name"),
           dataIndex: "name",
+        },
+        {
+          text: __("Description"),
+          dataIndex: "description",
           flex: 1,
         },
       ],
-
       fields: [
         {
           name: "name",

--- a/ui/web/sa/actioncommands/Application.js
+++ b/ui/web/sa/actioncommands/Application.js
@@ -56,6 +56,11 @@ Ext.define("NOC.sa.actioncommands.Application", {
           width: 100,
           align: "right",
         },
+        {
+          text: __("Description"),
+          dataIndex: "description",
+          flex: 1,
+        },
       ],
 
       fields: [

--- a/ui/web/sa/capsprofile/Application.js
+++ b/ui/web/sa/capsprofile/Application.js
@@ -34,7 +34,7 @@ Ext.define("NOC.sa.capsprofile.Application", {
     Ext.apply(me, {
       columns: [
         {
-          text: "Name",
+          text: __("Name"),
           dataIndex: "name",
         },
         {

--- a/ui/web/sa/capsprofile/Application.js
+++ b/ui/web/sa/capsprofile/Application.js
@@ -37,6 +37,32 @@ Ext.define("NOC.sa.capsprofile.Application", {
           text: "Name",
           dataIndex: "name",
         },
+        {
+          text: __("SNMP"),
+          dataIndex: "enable_snmp",
+          width: 50,
+          renderer: NOC.render.Bool,
+          align: "center",
+        },
+        {
+          text: __("L2"),
+          dataIndex: "enable_l2",
+          width: 50,
+          renderer: NOC.render.Bool,
+          align: "center",
+        },
+        {
+          text: __("L3"),
+          dataIndex: "enable_l3",
+          width: 50,
+          renderer: NOC.render.Bool,
+          align: "center",
+        },
+        {
+          text: __("Description"),
+          dataIndex: "description",
+          flex: 1,
+        },
       ],
 
       fields: [

--- a/ui/web/sa/commandsnippet/Application.js
+++ b/ui/web/sa/commandsnippet/Application.js
@@ -21,8 +21,8 @@ Ext.define("NOC.sa.commandsnippet.Application", {
             dataIndex: "name"
         },
         {
-            dataIndex: "is_enabled",
             text: __("Enabled"),
+            dataIndex: "is_enabled",
             renderer: NOC.render.Bool
         },
         {
@@ -32,32 +32,33 @@ Ext.define("NOC.sa.commandsnippet.Application", {
             width: 200
         },
         {
-            text: __("Description"),
-            dataIndex: "description"
-        },
-        {
-            dataIndex: "require_confirmation",
             text: __("Require Confirmation"),
+            dataIndex: "require_confirmation",
             renderer: NOC.render.Bool
         },
         {
-            dataIndex: "ignore_cli_errors",
             text: __("Ignore CLI Errors"),
-            renderer: NOC.render.Bool 
+            dataIndex: "ignore_cli_errors",
+            renderer: NOC.render.Bool
         },
         {
-            text: __("Permission"),    
+            text: __("Permission"),
             dataIndex: "permission_name"
         },
-        {   
-            dataIndex: "display_in_menu",   
-            text: __("Show in menu"), 
+        {
+            text: __("Show in menu"),
+            dataIndex: "display_in_menu",
             renderer: NOC.render.Bool
         },
         {
-            text: __("Tags"),
-            dataIndex: "tags",
-            renderer: NOC.render.Tags
+            text: __("Labels"),
+            dataIndex: "labels",
+            renderer: NOC.render.LabelField
+        },
+        {
+            text: __("Description"),
+            dataIndex: "description",
+            flex: 1
         }
     ],
     fields: [

--- a/ui/web/sa/managedobjectprofile/Application.js
+++ b/ui/web/sa/managedobjectprofile/Application.js
@@ -174,7 +174,7 @@ Ext.define("NOC.sa.managedobjectprofile.Application", {
                 {
                     text: __("Description"),
                     dataIndex: "description",
-                    width: 300,
+                    flex: 1,
                     sortable: false,
                     renderer: function(value, meta) {
                         meta.tdAttr = 'data-qtip="' + value + '"';

--- a/ui/web/sa/objectdiscoveryrule/Application.js
+++ b/ui/web/sa/objectdiscoveryrule/Application.js
@@ -40,8 +40,14 @@ Ext.define("NOC.sa.objectdiscoveryrule.Application", {
         {
           text: __("Name"),
           dataIndex: "name",
-          width: 100,
+          width: 250,
           align: "left",
+        },
+        {
+          text: __("WorkFlow"),
+          dataIndex: "workflow",
+          width: 250,
+          renderer: NOC.render.Lookup("workflow"),
         },
         {
           text: __("Builtin"),
@@ -49,13 +55,14 @@ Ext.define("NOC.sa.objectdiscoveryrule.Application", {
           width: 50,
           renderer: NOC.render.Bool,
           sortable: false,
+          align: "center",
         },
         {
           text: __("Active"),
           dataIndex: "is_active",
           renderer: NOC.render.Bool,
           width: 50,
-          align: "left",
+          align: "center",
         },
         {
           text: __("Pref."),
@@ -75,7 +82,12 @@ Ext.define("NOC.sa.objectdiscoveryrule.Application", {
           dataIndex: "enable_ip_scan_discovery",
           renderer: NOC.render.Bool,
           width: 100,
-          align: "left",
+          align: "center",
+        },
+        {
+          text: __("Description"),
+          dataIndex: "description",
+          flex: 1,
         },
       ],
 

--- a/ui/web/sa/profile/Application.js
+++ b/ui/web/sa/profile/Application.js
@@ -31,14 +31,19 @@ Ext.define("NOC.sa.profile.Application", {
         {
           text: "Name",
           dataIndex: "name",
-          flex: 1,
+          width: 200,
         },
         {
           text: __("Builtin"),
           dataIndex: "is_builtin",
-          width: 30,
+          width: 50,
           renderer: NOC.render.Bool,
           sortable: false,
+        },
+        {
+          text: __("Description"),
+          dataIndex: "description",
+          flex: 1,
         },
       ],
 

--- a/ui/web/sa/profilecheckrule/Application.js
+++ b/ui/web/sa/profilecheckrule/Application.js
@@ -76,9 +76,13 @@ Ext.define("NOC.sa.profilecheckrule.Application", {
         {
           text: __("Profile"),
           dataIndex: "profile",
-          flex: 1,
           width: 150,
           renderer: NOC.render.Lookup("profile"),
+        },
+        {
+          text: __("Description"),
+          dataIndex: "description",
+          flex: 1,
         },
       ],
 

--- a/ui/web/sa/reactionrule/Application.js
+++ b/ui/web/sa/reactionrule/Application.js
@@ -48,13 +48,17 @@ Ext.define("NOC.sa.reactionrule.Application", {
     {
       text: __("Alarm Disposition"),
       dataIndex: "alarm_disposition",
-      flex: 1,
       renderer: NOC.render.Lookup("alarm_disposition"),
     },
     {
       text: __("Pref"),
       dataIndex: "preference",
       width: 50,
+    },
+    {
+      text: __("Description"),
+      dataIndex: "description",
+      flex: 1,
     },
   ],
 

--- a/ui/web/sa/service/Application.js
+++ b/ui/web/sa/service/Application.js
@@ -115,7 +115,7 @@ Ext.define("NOC.sa.service.Application", {
         {
           text: __("Label"),
           dataIndex: "label",
-          width: 260,
+          width: 200,
         },
         {
           text: __("Subscriber"),
@@ -132,6 +132,11 @@ Ext.define("NOC.sa.service.Application", {
         {
           text: __("Parent"),
           dataIndex: "parent",
+          width: 200,
+        },
+        {
+          text: __("Description"),
+          dataIndex: "description",
           flex: 1,
         },
       ],

--- a/ui/web/sla/slaprobe/Application.js
+++ b/ui/web/sla/slaprobe/Application.js
@@ -63,15 +63,15 @@ Ext.define("NOC.sla.slaprobe.Application", {
                     renderer: NOC.render.Lookup("managed_object")
                 },
                 {
-                    text: __("Description"),
-                    dataIndex: "description",
-                    flex: 1
-                },
-                {
                     text: __("Labels"),
                     dataIndex: "labels",
                     renderer: NOC.render.LabelField,
                     width: 100
+                },
+                {
+                    text: __("Description"),
+                    dataIndex: "description",
+                    flex: 1
                 }
             ],
 

--- a/ui/web/sla/slaprofile/Application.js
+++ b/ui/web/sla/slaprofile/Application.js
@@ -27,13 +27,30 @@ Ext.define("NOC.sla.slaprofile.Application", {
         {
           text: __("Name"),
           dataIndex: "name",
-          flex: 1,
+          width: 200,
         },
         {
           text: __("Labels"),
           dataIndex: "labels",
           renderer: NOC.render.LabelField,
           width: 100,
+        },
+        {
+          text: __("Raise Alarm to target"),
+          dataIndex: "raise_alarm_to_target",
+          width: 50,
+          renderer: NOC.render.Bool,
+          align: "center",
+        },
+        {
+          text: __("Workflow"),
+          dataIndex: "workflow",
+          renderer: NOC.render.Lookup("workflow")
+        },
+        {
+          text: __("Description"),
+          dataIndex: "description",
+          flex: 1,
         },
       ],
 

--- a/ui/web/vc/l2domainprofile/Application.js
+++ b/ui/web/vc/l2domainprofile/Application.js
@@ -38,6 +38,11 @@ Ext.define("NOC.vc.l2domainprofile.Application", {
           width: 100,
           renderer: NOC.render.Lookup("workflow"),
         },
+        {
+          text: __("Description"),
+          dataIndex: "description",
+          flex: 1,
+        },
       ],
 
       fields: [

--- a/ui/web/vc/vlanfilter/Application.js
+++ b/ui/web/vc/vlanfilter/Application.js
@@ -25,11 +25,16 @@ Ext.define("NOC.vc.vlanfilter.Application", {
         {
             text: __("Include Expression"),
             dataIndex: "include_expression",
-            flex: 1
+            width: 250
         },
         {
             text: __("Exclude Expression"),
             dataIndex: "exclude_expression",
+            width: 250
+        },
+        {
+            text: __("Description"),
+            dataIndex: "description",
             flex: 1
         }
     ],

--- a/ui/web/vc/vlanprofile/Application.js
+++ b/ui/web/vc/vlanprofile/Application.js
@@ -41,6 +41,11 @@ Ext.define("NOC.vc.vlanprofile.Application", {
                     dataIndex: "enable_provisioning",
                     width: 50,
                     renderer: NOC.render.Bool
+                },
+                {
+                    text: __("Description"),
+                    dataIndex: "description",
+                    flex: 1
                 }
             ],
 

--- a/ui/web/vc/vlantemplate/Application.js
+++ b/ui/web/vc/vlantemplate/Application.js
@@ -22,14 +22,19 @@ Ext.define("NOC.vc.vlantemplate.Application", {
         Ext.apply(me, {
             columns: [
                 {
-                    text: "Name",
+                    text: __("Name"),
                     dataIndex: "name",
-                    flex: 150
+                    width: 150
                 },
                 {
-                    text: "Type",
+                    text: __("Type"),
                     dataIndex: "type",
-                    flex: 100
+                    width: 100
+                },
+                {
+                    text: __("Description"),
+                    dataIndex: "description",
+                    flex: 1
                 }
             ],
 

--- a/ui/web/vc/vpn/Application.js
+++ b/ui/web/vc/vpn/Application.js
@@ -50,6 +50,11 @@ Ext.define("NOC.vc.vpn.Application", {
                     dataIndex: "project",
                     width: 150,
                     renderer: NOC.render.Lookup("project")
+                },
+                {
+                    text: __("Description"),
+                    dataIndex: "description",
+                    flex: 1
                 }
             ],
 

--- a/ui/web/vc/vpnprofile/Application.js
+++ b/ui/web/vc/vpnprofile/Application.js
@@ -56,6 +56,11 @@ Ext.define("NOC.vc.vpnprofile.Application", {
                     dataIndex: "workflow",
                     width: 150,
                     renderer: NOC.render.Lookup("workflow")
+                },
+                {
+                    text: __("Description"),
+                    dataIndex: "description",
+                    flex: 1
                 }
             ],
 

--- a/ui/web/wf/state/Application.js
+++ b/ui/web/wf/state/Application.js
@@ -90,6 +90,11 @@ Ext.define("NOC.wf.state.Application", {
           width: 200,
           renderer: NOC.render.LabelField,
         },
+        {
+          text: __("Description"),
+          dataIndex: "description",
+          flex: 1,
+        },
       ],
 
       fields: [

--- a/ui/web/wf/transition/Application.js
+++ b/ui/web/wf/transition/Application.js
@@ -69,6 +69,11 @@ Ext.define("NOC.wf.transition.Application", {
         {
           text: __("Label"),
           dataIndex: "label",
+          width: 100,
+        },
+        {
+          text: __("Description"),
+          dataIndex: "description",
           flex: 1,
         },
       ],

--- a/ui/web/wf/workflow/Application.js
+++ b/ui/web/wf/workflow/Application.js
@@ -37,13 +37,19 @@ Ext.define("NOC.wf.workflow.Application", {
         {
           text: __("Name"),
           dataIndex: "name",
-          flex: 1,
+          width: 250,
         },
         {
           text: __("Active"),
           dataIndex: "is_active",
-          width: 25,
+          width: 50,
           renderer: NOC.render.Bool,
+          align: "center",
+        },
+        {
+          text: __("Description"),
+          dataIndex: "description",
+          flex: 1,
         },
       ],
 


### PR DESCRIPTION
Add a \"Description\" field column to every grid table across the NOC UI and normalize column dimensions, alignment, and i18n wrapper usage.

**Key changes:**
- Add `dataIndex: "description"` column with `flex: 1` to 48 ExtJS grid applications (dns, fm, gis, inv, ip, peer, pm, sa, sla, vc, wf)
- Replace implicit `flex` values on text columns with explicit `width` properties where logical
- Add `textAlign: "center"` alignment to boolean/numeric columns
- Fix i18n wrapper (`__()`) usage on column headers in `resourcepool`, `vlantemplate`, `metricscope`, `capsprofile`
- Move description column to the end of each grid for consistent UX

**Notable implementation details:**
- Where grids already had partial description support, update flex settings and reposition
- Replace hardcoded `"Name"`/`"Type"` with `__("Name")`/`__("Type")` in 4 files

**Behavioral changes (intentional):**
- `ip/vrfgroup`: `Tags` column → `Labels` column
- `sa/commandsnippet`: `Tags` column → `Labels` column
- `inv/firmwarepolicy`: pure indentation normalization (no behavioral change)
