### PR TITLE
move @view and @api definition to separate modules. Make @api.xxx url…

### DIFF
--- a/services/web/base/api.py
+++ b/services/web/base/api.py
@@ -1,0 +1,231 @@
+# ---------------------------------------------------------------------
+# API decorators
+# ---------------------------------------------------------------------
+# Copyright (C) 2007-2026 The NOC Project
+# See LICENSE for details
+# ---------------------------------------------------------------------
+
+# Python modules
+from collections.abc import Callable
+from typing import TypeVar, Any, Concatenate, ParamSpec
+
+# Third-party modules
+from django.http import HttpRequest
+
+# NOC modules
+from noc.sa.interfaces.base import DictParameter
+from .access import HasPerm, Permit, Deny, Permission
+
+P = ParamSpec("P")
+R = TypeVar("R")
+T = TypeVar("T")
+Self = TypeVar("Self")
+
+
+def view(
+    url: str,
+    access: str | bool | Permission,
+    url_name: str | None = None,
+    menu: list[str] | None = None,  # @todo: dead code?
+    method: list[str] | None = None,
+    validate: dict[str, Any] | None = None,
+    api: bool = False,
+) -> Callable[
+    [Callable[Concatenate[Self, HttpRequest, P], R]], Callable[Concatenate[Self, HttpRequest, P], R]
+]:
+    """
+    Register a method as an application view.
+
+    The decorator attaches routing, access control, request validation,
+    and other view metadata to the decorated method. The collected metadata
+    is later used by the application to build URL mappings and process
+    incoming requests.
+
+    Args:
+        url: URL path relative to the application root.
+        access: Access policy. May be a permission name, a boolean allowing
+            or denying access, or a custom permission object.
+        url_name: Optional URL name for reverse URL resolution.
+        menu: Optional menu path associated with the view.
+        method: Allowed HTTP methods. If omitted, all methods are accepted.
+        validate: Optional request validation schema.
+        api: Whether the view is exposed as an API endpoint.
+
+    Returns:
+        A decorator that configures the decorated view method.
+    """
+
+    def decorate(
+        f: Callable[Concatenate[Self, HttpRequest, P], R],
+    ) -> Callable[Concatenate[Self, HttpRequest, P], R]:
+        f.url = url
+        f.url_name = url_name
+        # Process access
+        if isinstance(access, bool):
+            f.access = Permit() if access else Deny()
+        elif isinstance(access, str):
+            f.access = HasPerm(access)
+        else:
+            f.access = access
+        f.menu = menu
+        f.method = method
+        f.api = api
+        if isinstance(validate, dict):
+            f.validate = DictParameter(attrs=validate)
+        else:
+            f.validate = validate
+        return f
+
+    return decorate
+
+
+class ViewAPI:
+    """
+    API view decorator factory.
+
+    Provides HTTP method-specific decorators that create API endpoints
+    using the common :func:`view` decorator.
+
+    Example:
+        @api.get(
+            url="^brief_lookup/$",
+            access="lookup",
+        )
+        def api_brief(self, request: HttpRequest):
+            ...
+    """
+
+    def get(
+        self,
+        url: str,
+        /,
+        *,
+        access: str | bool | Permission,
+        url_name: str | None = None,
+        menu: list[str] | None = None,  # @todo: dead code?
+        validate: dict[str, Any] | None = None,
+    ):
+        """
+        Decorate a GET API endpoint.
+
+        Args:
+            url: URL pattern relative to the application root.
+            access: Access control rule.
+            url_name: Optional URL name.
+            menu: Optional menu entry metadata.
+            validate: Optional request parameter validation schema.
+
+        Returns:
+            A view decorator.
+        """
+        return view(
+            url=url,
+            method=["GET"],
+            access=access,
+            url_name=url_name,
+            menu=menu,
+            validate=validate,
+            api=True,
+        )
+
+    def post(
+        self,
+        url: str,
+        /,
+        *,
+        access: str | bool | Permission,
+        url_name: str | None = None,
+        menu: list[str] | None = None,  # @todo: dead code?
+        validate: dict[str, Any] | None = None,
+    ):
+        """
+        Decorate a POST API endpoint.
+
+        Args:
+            url: URL pattern relative to the application root.
+            access: Access control rule.
+            url_name: Optional URL name.
+            menu: Optional menu entry metadata.
+            validate: Optional request parameter validation schema.
+
+        Returns:
+            A view decorator.
+        """
+        return view(
+            url=url,
+            method=["POST"],
+            access=access,
+            url_name=url_name,
+            menu=menu,
+            validate=validate,
+            api=True,
+        )
+
+    def put(
+        self,
+        url: str,
+        /,
+        *,
+        access: str | bool | Permission,
+        url_name: str | None = None,
+        menu: list[str] | None = None,  # @todo: dead code?
+        validate: dict[str, Any] | None = None,
+    ):
+        """
+        Decorate a PUT endpoint.
+
+        Args:
+            url: URL pattern relative to the application root.
+            access: Access control rule.
+            url_name: Optional URL name.
+            menu: Optional menu entry metadata.
+            validate: Optional request parameter validation schema.
+
+        Returns:
+            A view decorator.
+        """
+        return view(
+            url=url,
+            method=["PUT"],
+            access=access,
+            url_name=url_name,
+            menu=menu,
+            validate=validate,
+            api=True,
+        )
+
+    def delete(
+        self,
+        url: str,
+        /,
+        *,
+        access: str | bool | Permission,
+        url_name: str | None = None,
+        menu: list[str] | None = None,  # @todo: dead code?
+        validate: dict[str, Any] | None = None,
+    ):
+        """
+        Decorate a DELETE API endpoint.
+
+        Args:
+            url: URL pattern relative to the application root.
+            access: Access control rule.
+            url_name: Optional URL name.
+            menu: Optional menu entry metadata.
+            validate: Optional request parameter validation schema.
+
+        Returns:
+            A view decorator.
+        """
+        return view(
+            url=url,
+            method=["DELETE"],
+            access=access,
+            url_name=url_name,
+            menu=menu,
+            validate=validate,
+            api=True,
+        )
+
+
+api = ViewAPI()

--- a/services/web/base/application.py
+++ b/services/web/base/application.py
@@ -12,8 +12,7 @@ import os
 import datetime
 import functools
 from collections import OrderedDict
-from collections.abc import Callable
-from typing import TypeVar, Any, ParamSpec, Concatenate
+from typing import TypeVar, Any
 from http import HTTPStatus
 
 # Third-party modules
@@ -38,202 +37,13 @@ import jinja2
 # NOC modules
 from noc.core.forms import NOCForm
 from noc import settings
-from noc.sa.interfaces.base import DictParameter
 from noc.core.feature import Feature
 from noc.models import is_document
-from .access import HasPerm, Permit, Deny, Permission
+from .access import HasPerm
+from .api import view, api  # noqa: F401 @todo: remove
 from .site import site
 
-P = ParamSpec("P")
-R = TypeVar("R")
 T = TypeVar("T")
-Self = TypeVar("Self")
-
-
-def view(
-    url: str,
-    access: str | bool | Permission,
-    url_name: str | None = None,
-    menu: list[str] | None = None,  # @todo: dead code?
-    method: list[str] | None = None,
-    validate: dict[str, Any] | None = None,
-    api: bool = False,
-) -> Callable[
-    [Callable[Concatenate[Self, HttpRequest, P], R]], Callable[Concatenate[Self, HttpRequest, P], R]
-]:
-    """
-    @view decorator
-    :param url: URL relative to application root
-    :param validate: Form class or callable to check input
-    :param api: Does the view exposed as API function
-    """
-
-    def decorate(
-        f: Callable[Concatenate[Self, HttpRequest, P], R],
-    ) -> Callable[Concatenate[Self, HttpRequest, P], R]:
-        f.url = url
-        f.url_name = url_name
-        # Process access
-        if isinstance(access, bool):
-            f.access = Permit() if access else Deny()
-        elif isinstance(access, str):
-            f.access = HasPerm(access)
-        else:
-            f.access = access
-        f.menu = menu
-        f.method = method
-        f.api = api
-        if isinstance(validate, dict):
-            f.validate = DictParameter(attrs=validate)
-        else:
-            f.validate = validate
-        return f
-
-    return decorate
-
-
-class ViewAPI:
-    """
-    API view decorator factory.
-
-    Provides HTTP method-specific decorators that create API endpoints
-    using the common :func:`view` decorator.
-
-    Example:
-        @api.get(
-            url="^brief_lookup/$",
-            access="lookup",
-        )
-        def api_brief(self, request: HttpRequest):
-            ...
-    """
-
-    def get(
-        self,
-        url: str,
-        access: str | bool | Permission,
-        url_name: str | None = None,
-        menu: list[str] | None = None,  # @todo: dead code?
-        validate: dict[str, Any] | None = None,
-    ):
-        """
-        Decorate a GET API endpoint.
-
-        Args:
-            url: URL pattern relative to the application root.
-            access: Access control rule.
-            url_name: Optional URL name.
-            menu: Optional menu entry metadata.
-            validate: Optional request parameter validation schema.
-
-        Returns:
-            A view decorator.
-        """
-        return view(
-            url=url,
-            method=["GET"],
-            access=access,
-            url_name=url_name,
-            menu=menu,
-            validate=validate,
-            api=True,
-        )
-
-    def post(
-        self,
-        url: str,
-        access: str | bool | Permission,
-        url_name: str | None = None,
-        menu: list[str] | None = None,  # @todo: dead code?
-        validate: dict[str, Any] | None = None,
-    ):
-        """
-        Decorate a POST API endpoint.
-
-        Args:
-            url: URL pattern relative to the application root.
-            access: Access control rule.
-            url_name: Optional URL name.
-            menu: Optional menu entry metadata.
-            validate: Optional request parameter validation schema.
-
-        Returns:
-            A view decorator.
-        """
-        return view(
-            url=url,
-            method=["POST"],
-            access=access,
-            url_name=url_name,
-            menu=menu,
-            validate=validate,
-            api=True,
-        )
-
-    def put(
-        self,
-        url: str,
-        access: str | bool | Permission,
-        url_name: str | None = None,
-        menu: list[str] | None = None,  # @todo: dead code?
-        validate: dict[str, Any] | None = None,
-    ):
-        """
-        Decorate a PUT endpoint.
-
-        Args:
-            url: URL pattern relative to the application root.
-            access: Access control rule.
-            url_name: Optional URL name.
-            menu: Optional menu entry metadata.
-            validate: Optional request parameter validation schema.
-
-        Returns:
-            A view decorator.
-        """
-        return view(
-            url=url,
-            method=["PUT"],
-            access=access,
-            url_name=url_name,
-            menu=menu,
-            validate=validate,
-            api=True,
-        )
-
-    def delete(
-        self,
-        url: str,
-        access: str | bool | Permission,
-        url_name: str | None = None,
-        menu: list[str] | None = None,  # @todo: dead code?
-        validate: dict[str, Any] | None = None,
-    ):
-        """
-        Decorate a DELETE API endpoint.
-
-        Args:
-            url: URL pattern relative to the application root.
-            access: Access control rule.
-            url_name: Optional URL name.
-            menu: Optional menu entry metadata.
-            validate: Optional request parameter validation schema.
-
-        Returns:
-            A view decorator.
-        """
-        return view(
-            url=url,
-            method=["DELETE"],
-            access=access,
-            url_name=url_name,
-            menu=menu,
-            validate=validate,
-            api=True,
-        )
-
-
-api = ViewAPI()
 
 
 class BoundView:
@@ -345,7 +155,7 @@ class Application(metaclass=ApplicationBase):
         menu=None,
         method=None,
         validate=None,
-        api=False,
+        api=False,  # noqa: F811 @todo: Remove
     ):
         # wrap view
         f = BoundView(func)
@@ -620,9 +430,9 @@ class Application(metaclass=ApplicationBase):
         prefix = self.get_app_id().replace(".", ":")
         p = {f"{prefix}:launch"}
         # View permissions from HasPerm
-        for view in self.iter_views():
-            if isinstance(view.access, HasPerm):
-                p.add(view.access.get_permission(self))
+        for app_view in self.iter_views():
+            if isinstance(app_view.access, HasPerm):
+                p.add(app_view.access.get_permission(self))
         # mrt_config permissions
         for mrt in self.mrt_config:
             c = self.mrt_config[mrt]


### PR DESCRIPTION
Move `@view` and `@api` definitions to a separate module. Make `@api.xxx` accept the `url` parameter as positional-only.

### Purpose
Extract the `view()` decorator and `ViewAPI` class (with `api` singleton instance) from `application.py` into their own `api.py` module for cleaner module separation. This also makes the `url` argument on all `ViewAPI.get/post/put/delete()` methods positional-only, preventing accidental keyword usage.

### Key Changes
- **New file:** `services/web/base/api.py` — contains `view()`, `ViewAPI`, and the `api = ViewAPI()` singleton
- **Modified:** `services/web/base/application.py` — removed ~160 lines of decorator code; re-exports `view` and `api` from `.api` for backward compatibility
- Made `url` parameter positional-only (`/)`) on all four HTTP methods in `ViewAPI` (get, post, put, delete)
- **Backward compatibility:** application.py re-exports `view` and `api` so existing import paths continue to work without migration

### Notable Implementation Details
- Renamed loop variable `view` → `app_view` in `Application.get_permissions()` to avoid shadowing the imported `view` function name
- Added `noqa: F401` on re-export line and `noqa: F811` on the `api=False` parameter in `add_view()` to silence linter warnings about deliberate name reuse

### Import Chain (verified)
Downstream files import `view` from `.extapplication`, `.extmodelapplication`, `.extdocapplication`, or `.reportapplication` — all of these re-export from `.application`, which now re-exports from `.api`. No changes needed in ~60+ downstream application files.
