### PR TITLE
Remove multiple methods in @view

### DIFF
--- a/services/web/apps/fm/alarm/views.py
+++ b/services/web/apps/fm/alarm/views.py
@@ -435,7 +435,7 @@ class AlarmApplication(ExtApplication):
             adm_path__in=UserAccess.get_domains(request.user),
         ).read_preference(ReadPreference.SECONDARY_PREFERRED)
 
-    @view(method=["GET", "POST"], url=r"^$", access="launch", api=True)
+    @view(method=["GET"], url=r"^$", access="launch", api=True)
     def api_list(self, request: HttpRequest):
         return self.list_data(request, self.instance_to_dict)
 

--- a/services/web/apps/fm/alarm/views.py
+++ b/services/web/apps/fm/alarm/views.py
@@ -435,7 +435,8 @@ class AlarmApplication(ExtApplication):
             adm_path__in=UserAccess.get_domains(request.user),
         ).read_preference(ReadPreference.SECONDARY_PREFERRED)
 
-    @view(method=["GET"], url=r"^$", access="launch", api=True)
+    # Both methods are really used
+    @view(method=["GET", "POST"], url=r"^$", access="launch", api=True)
     def api_list(self, request: HttpRequest):
         return self.list_data(request, self.instance_to_dict)
 

--- a/services/web/apps/fm/event/views.py
+++ b/services/web/apps/fm/event/views.py
@@ -40,7 +40,7 @@ class EventApplication(ExtApplication):
     icon = "icon_find"
     ignored_params = ["status", "_dc"]
 
-    @view(method=["GET", "POST"], url="^$", access="read", api=True)
+    @view(method=["GET"], url="^$", access="read", api=True)
     def api_list(self, request: HttpRequest):
         q = self.parse_request_query(request)
         start = q.get("__start") or 0

--- a/services/web/apps/inv/macdb.py
+++ b/services/web/apps/inv/macdb.py
@@ -183,7 +183,7 @@ class MACApplication(ExtApplication):
             )
         return out, rows_count
 
-    @view(method=["GET", "POST"], url="^$", access="read", api=True)
+    @view(method=["GET"], url="^$", access="read", api=True)
     def api_list(self, request: HttpRequest):
         q = self.parse_request_query(request)
         query = q.get("__query")

--- a/services/web/apps/sa/managedobject.py
+++ b/services/web/apps/sa/managedobject.py
@@ -1310,6 +1310,14 @@ class ManagedObjectApplication(ExtModelApplication):
             ]
         return r
 
+    @view(url=r"^full/", method=["POST"], access="read", api=True)
+    def api_list_full(self, request: HttpRequest):
+        try:
+            return self.list_data(request, self.instance_to_dict)
+        except Exception as e:
+            error_report()
+            return self.response({"status": False, "message": str(e)}, status=self.INTERNAL_ERROR)
+
     @view(url=r"^list/", method=["POST"], access="read", api=True)
     def api_list_short(self, request: HttpRequest):
         try:

--- a/services/web/apps/sa/managedobject.py
+++ b/services/web/apps/sa/managedobject.py
@@ -1310,15 +1310,7 @@ class ManagedObjectApplication(ExtModelApplication):
             ]
         return r
 
-    @view(url=r"^full/", method=["GET", "POST"], access="read", api=True)
-    def api_list_full(self, request: HttpRequest):
-        try:
-            return self.list_data(request, self.instance_to_dict)
-        except Exception as e:
-            error_report()
-            return self.response({"status": False, "message": str(e)}, status=self.INTERNAL_ERROR)
-
-    @view(url=r"^list/", method=["GET", "POST"], access="read", api=True)
+    @view(url=r"^list/", method=["POST"], access="read", api=True)
     def api_list_short(self, request: HttpRequest):
         try:
             return self.list_data(request, self.instance_to_dict_list)

--- a/services/web/apps/sa/objectlist.py
+++ b/services/web/apps/sa/objectlist.py
@@ -170,7 +170,7 @@ class ObjectListApplication(ExtApplication):
         self.logger.info(f"Extra: {extra}")
         return extra, [] if "order_by" in extra else order
 
-    @view(method=["GET", "POST"], url="^$", access="read", api=True)
+    @view(method=["POST"], url="^$", access="read", api=True)
     def api_list(self, request: HttpRequest):
         return self.list_data(request, self.instance_to_dict)
 


### PR DESCRIPTION
Narrow HTTP method lists on `@view` decorators to the methods actually used by each endpoint. Retain POST where required by existing callers to avoid breaking changes.

**Key changes**
- Restrict `/sa/managedobject/full/`, `/sa/managedobject/list/`, `/sa/objectlist/` to `["POST"]` — all UI callers confirmed as POST-only via ExtJS model configurations
- Restrict `/fm/event/`, `/inv/macdb/` from `["GET", "POST"]` to `["GET"]` — verified no POST callers exist
- Retain `["GET", "POST"]` for `/fm/alarm/` with explicit comment documenting both methods are used (selection filter sends POST with JSON body)

**Notable implementation details**
- All changes affect only the `method=` parameter in existing `@view` decorators
- The framework routes via `method_map[request.method]` lookups, enforcing at routing layer (404 on mismatch)
- No behavioral changes — only route registration narrowing
