### PR TITLE
Application: Reexport `api` and `view` properly

### DIFF
--- a/services/web/base/api.py
+++ b/services/web/base/api.py
@@ -16,6 +16,8 @@ from django.http import HttpRequest
 from noc.sa.interfaces.base import DictParameter
 from .access import HasPerm, Permit, Deny, Permission
 
+__all__ = ["api", "view"]
+
 P = ParamSpec("P")
 R = TypeVar("R")
 T = TypeVar("T")

--- a/services/web/base/application.py
+++ b/services/web/base/application.py
@@ -40,8 +40,10 @@ from noc import settings
 from noc.core.feature import Feature
 from noc.models import is_document
 from .access import HasPerm
-from .api import view, api  # noqa: F401 @todo: remove
+from .api import view, api
 from .site import site
+
+__all__ = ["Application", "api", "view"]
 
 T = TypeVar("T")
 

--- a/services/web/base/extapplication.py
+++ b/services/web/base/extapplication.py
@@ -23,7 +23,7 @@ from noc.config import config
 from noc.models import is_document
 from noc.aaa.models.user import User
 from .api import api, view
-from .application import Application, view
+from .application import Application
 from .access import HasPerm, PermitLogged
 
 __all__ = ["ExtApplication", "api", "view"]

--- a/services/web/base/extapplication.py
+++ b/services/web/base/extapplication.py
@@ -22,8 +22,11 @@ from noc.main.models.slowop import SlowOp
 from noc.config import config
 from noc.models import is_document
 from noc.aaa.models.user import User
+from .api import api, view
 from .application import Application, view
 from .access import HasPerm, PermitLogged
+
+__all__ = ["ExtApplication", "api", "view"]
 
 
 class ExtApplication(Application):

--- a/services/web/base/extdocapplication.py
+++ b/services/web/base/extdocapplication.py
@@ -57,7 +57,10 @@ from noc.main.models.label import Label
 from noc.core.collection.base import Collection
 from noc.core.comp import smart_text
 from noc.models import get_model_id
-from .extapplication import ExtApplication, view
+from .api import api, view
+from .extapplication import ExtApplication
+
+__all__ = ["ExtDocApplication", "api", "view"]
 
 
 class ExtDocApplication(ExtApplication):

--- a/services/web/base/extmodelapplication.py
+++ b/services/web/base/extmodelapplication.py
@@ -54,8 +54,11 @@ from noc.core.protocols.get_css_class import GetCssClass
 from noc.models import get_model_id
 from noc.core.model.util import is_related_field
 from noc.inv.models.resourcegroup import ResourceGroup
-from .extapplication import ExtApplication, view
+from .api import api, view
+from .extapplication import ExtApplication
 from .interfaces import DateParameter, DateTimeParameter
+
+__all__ = ["ExtModelApplication", "api", "view"]
 
 
 class ExtModelApplication(ExtApplication):

--- a/services/web/base/reportapplication.py
+++ b/services/web/base/reportapplication.py
@@ -14,6 +14,8 @@ from noc.core.middleware.tls import get_user
 from .application import Application, view
 from .access import Permission
 
+__all__ = ["ReportApplication", "view"]
+
 
 class ReportApplication(Application):
     # django.forms.Form class for report queries


### PR DESCRIPTION
Add explicit `__all__` declarations to properly re-export `api` and `view` through the application hierarchy. This follows up on PR #426, which extracted these decorators into `services/web/base/api.py`. Without `__all__`, downstream modules cannot rely on star imports or documented public APIs from parent classes.

**Key changes:**
- Add `__all__ = ["api", "view"]` to `api.py` (source module)
- Add `__all__` re-exports to each application in the hierarchy: `Application`, `ExtApplication`, `ExtDocApplication`, `ExtModelApplication`, `ReportApplication`
- Remove stale `# noqa: F401 @todo: remove` comment from `application.py` import (now properly declared)
- Fix intermediate duplicate import of `view` in `ExtApplication` (resolve via direct `.api` import only)

**Notable implementation details:**
- All existing absolute import paths (`from noc.services.web.base.application import view`) remain functional — no breaking changes
- `ExtApplication`, `ExtDocApplication`, `ExtModelApplication` now source `view` and `api` directly from `.api` rather than transitively through parent modules, avoiding duplicate imports
- `ReportApplication` exports only `view` (not `api`) as it has no API-style endpoints
