### PR TITLE
login: improve kafka support for revokedtokens

### DIFF
--- a/services/login/service.py
+++ b/services/login/service.py
@@ -2,7 +2,7 @@
 # ---------------------------------------------------------------------
 # Login service
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2023 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -92,9 +92,15 @@ class LoginService(FastAPIService):
         async with self.revoked_cond:
             self.revoked_cond.notify_all()
 
-    async def subscribe_lift(self):
+    async def subscrube_streams(self):
         # revokedtokens is optional, so mark liftbridge as non-critical service.
-        config.find_parameter("liftbridge.addresses").set_critical(False)
+        match config.msgstream.client_class:
+            case "noc.core.msgstream.liftbridge.LiftBridgeClient":
+                config.find_parameter("liftbridge.addresses").set_critical(False)
+            case "noc.core.msgstream.kafka.KafkaClient":
+                config.find_parameter("kafka.addresses").set_critical(False)
+            case _:
+                pass
         # expire = config.login.session_ttl
         # start_timestamp = time.time() - expire
         await self.subscribe_stream(
@@ -108,7 +114,7 @@ class LoginService(FastAPIService):
         )
 
     async def on_activate(self) -> None:
-        self.loop.create_task(self.subscribe_lift())
+        self.loop.create_task(self.subscrube_streams())
 
 
 if __name__ == "__main__":

--- a/services/login/service.py
+++ b/services/login/service.py
@@ -92,7 +92,7 @@ class LoginService(FastAPIService):
         async with self.revoked_cond:
             self.revoked_cond.notify_all()
 
-    async def subscrube_streams(self):
+    async def subscribe_streams(self):
         # revokedtokens is optional, so mark liftbridge as non-critical service.
         match config.msgstream.client_class:
             case "noc.core.msgstream.liftbridge.LiftBridgeClient":
@@ -114,7 +114,7 @@ class LoginService(FastAPIService):
         )
 
     async def on_activate(self) -> None:
-        self.loop.create_task(self.subscrube_streams())
+        self.loop.create_task(self.subscribe_streams())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The login service subscribes to the `revokedtokens` message stream so that revoked tokens take effect immediately at runtime when sessions are invalidated. This subscription must not block service startup if the upstream message broker is unavailable, as token revocation is a best-effort optimization rather than a hard requirement.

Previously, only LiftBridge was marked as non-critical (`liftbridge.addresses`). When users switched to Kafka as the message stream backend, missing configuration caused the login service to fail on startup — an unintended regression that blocked production Kafka deployments.

### Key changes
- Replace the hardcoded `liftbridge.addresses` critical flag with a dynamic approach based on `config.msgstream.client_class`
- Add explicit Kafka support by marking `kafka.addresses` as non-critical when using `noc.core.msgstream.kafka.KafkaClient`
- Leave unknown message stream backends unaffected (they retain default critical behavior)
