### PR TITLE
install gufo-liftbridge only when liftbridge selected

### DIFF
--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -124,7 +124,7 @@ jobs:
         uses: astral-sh/setup-uv@v1
 
       - name: Install Dependencies
-        run: uv pip install --system -e .[node,test,bh,activator,cache-redis,node,login-ldap,login-pam,login-radius,prod-tools,testing,sender-kafka,ping]
+        run: uv pip install --system -e .[node,test,bh,activator,cache-redis,node,login-ldap,login-pam,login-radius,prod-tools,testing,sender-kafka,ping,liftbridge]
 
       - name: Run Tests (with coverage)
         run: pytest --maxfail=10 --cov --cov-branch --cov-report=xml tests/

--- a/ansible/noc_roles/noc/tasks/init_venv_python3.yml
+++ b/ansible/noc_roles/noc/tasks/init_venv_python3.yml
@@ -57,7 +57,7 @@
 
 # Archive whole directory with old python2.* version and then delete folder's content
 - block:
-    - name:
+    - name: "Clean directory"
       include_tasks: "clean_dir.yml"
 
     - name: Bring Python of {{ noc_py3_ver }} version when system's python differs
@@ -247,6 +247,14 @@
     python_deps: "{{ python_deps + ['cache-redis'] }}"
   when:
     - "'svc-redis-exec' in groups and groups['svc-redis-exec']|length>0"
+  tags:
+    - requirements
+
+- name: Add -liftbridge- python packages
+  set_fact:
+    python_deps: "{{ python_deps + ['liftbridge'] }}"
+  when:
+    - "'svc-liftbridge-exec' in groups and groups['svc-liftbridge-exec']|length>0"
   tags:
     - requirements
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ docs = [
   "minify_html==0.18.1",
   "cachetools==5.5.2", # For {{ config_param() }}
 ]
+liftbridge = ["gufo-liftbridge==0.2.0"]
 lint = [
   "ruff==0.15.18",
   "mypy==1.10",
@@ -111,8 +112,7 @@ node = [
   "starlette>=1.3.1", # Used by FastAPI, restricted by security reasons
   "uvicorn==0.40.0",
   'yappi==1.7.3',
-  "python-multipart==0.0.32", # Used by FastAPI to process form data
-  "gufo-liftbridge==0.2.0",
+  "python-multipart==0.0.32", # Used by FastAPI to process form data  
   "gufo-snmp==0.12.0",
   "gufo_noc_speedup==0.1.0",
   "gufo-loader==2.0.1",


### PR DESCRIPTION
Avoid installing `gufo-liftbridge` (and its GRPC transitive dependency) on NOC instances where Kafka serves as the primary message queue, reducing unnecessary binary footprint.

**Key Changes:**
1. **`pyproject.toml`:** Extract `gufo-liftbridge==0.2.0` from the `node` extra into a new dedicated `[project.optional-dependencies.liftbridge]`.
2. **`.github/workflows/py-tests.yml`:** Add `liftbridge` to the test environment extras so the test suite continues to cover LiftBridge modules.
3. **`ansible/noc_roles/noc/tasks/init_venv_python3.yml`:** Conditionally add `liftbridge` to `python_deps` only when the inventory contains hosts in the `svc-liftbridge-exec` group, following the same pattern as `redis`, `ping`, and `bh` extras.

**Notable Implementation Details:**
- The 3 LiftBridge modules (`commands/liftbridge.py`, `core/msgstream/liftbridge.py`, `services/selfmon/collectors/liftbridge.py`) still unconditionally import `gufo.liftbridge.*` at module level. This is intentional — they are only loaded when LiftBridge is installed, and Ansible ensures installation parity.
- CI now explicitly installs the `liftbridge` extra to maintain test coverage for these modules.