### PR TITLE
Replace @view with @api

### DIFF
--- a/services/web/apps/aaa/group.py
+++ b/services/web/apps/aaa/group.py
@@ -12,7 +12,7 @@ from django.http import HttpResponse, HttpRequest
 
 # NOC modules
 from noc.services.web.base.site import site
-from noc.services.web.base.extmodelapplication import ExtModelApplication, view
+from noc.services.web.base.extmodelapplication import ExtModelApplication, api
 from noc.aaa.models.group import Group
 from noc.aaa.models.permission import Permission
 from noc.core.translation import ugettext as _
@@ -34,7 +34,7 @@ class GroupsApplication(ExtModelApplication):
     default_ordering = ["name"]
     custom_m2m_fields = {"permissions": Permission}
 
-    @view(method=["GET"], url=r"^(?P<id>\d+)/?$", access="read", api=True)
+    @api.get(url=r"^(?P<id>\d+)/?$", access="read")
     def api_read(self, request: HttpRequest, id):
         """
         Returns dict with object's fields and values
@@ -70,7 +70,7 @@ class GroupsApplication(ExtModelApplication):
         else:
             super().update_m2m(o, name, values)
 
-    @view(method=["GET"], url=r"^new_permissions/$", access="read", api=True)
+    @api.get(url=r"^new_permissions/$", access="read")
     def api_read_permission(self, request: HttpRequest):
         """
         Returns dict available permissions

--- a/services/web/apps/aaa/group.py
+++ b/services/web/apps/aaa/group.py
@@ -34,7 +34,7 @@ class GroupsApplication(ExtModelApplication):
     default_ordering = ["name"]
     custom_m2m_fields = {"permissions": Permission}
 
-    @api.get(url=r"^(?P<id>\d+)/?$", access="read")
+    @api.get(r"^(?P<id>\d+)/?$", access="read")
     def api_read(self, request: HttpRequest, id):
         """
         Returns dict with object's fields and values
@@ -70,7 +70,7 @@ class GroupsApplication(ExtModelApplication):
         else:
             super().update_m2m(o, name, values)
 
-    @api.get(url=r"^new_permissions/$", access="read")
+    @api.get(r"^new_permissions/$", access="read")
     def api_read_permission(self, request: HttpRequest):
         """
         Returns dict available permissions

--- a/services/web/apps/aaa/modelprotectionprofile.py
+++ b/services/web/apps/aaa/modelprotectionprofile.py
@@ -32,7 +32,7 @@ class ModelProtectionProfileApplication(ExtDocApplication):
     model = ModelProtectionProfile
     # glyph = "key"
 
-    @api.get(url=r"^(?P<model_id>\w+\.\w+)/fields/lookup/$", access="lookup")
+    @api.get(r"^(?P<model_id>\w+\.\w+)/fields/lookup/$", access="lookup")
     def api_model_fields_lookup(self, request: HttpRequest, model_id):
         try:
             model = get_model(model_id=model_id)

--- a/services/web/apps/aaa/modelprotectionprofile.py
+++ b/services/web/apps/aaa/modelprotectionprofile.py
@@ -9,7 +9,7 @@
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.aaa.models.modelprotectionprofile import (
     ModelProtectionProfile,
     FieldAccess,
@@ -32,7 +32,7 @@ class ModelProtectionProfileApplication(ExtDocApplication):
     model = ModelProtectionProfile
     # glyph = "key"
 
-    @view(url=r"^(?P<model_id>\w+\.\w+)/fields/lookup/$", method=["GET"], access="lookup", api=True)
+    @api.get(url=r"^(?P<model_id>\w+\.\w+)/fields/lookup/$", access="lookup")
     def api_model_fields_lookup(self, request: HttpRequest, model_id):
         try:
             model = get_model(model_id=model_id)

--- a/services/web/apps/aaa/user.py
+++ b/services/web/apps/aaa/user.py
@@ -13,7 +13,7 @@ from django.http import HttpResponse, HttpRequest
 
 # NOC modules
 from noc.services.web.base.site import site
-from noc.services.web.base.extmodelapplication import ExtModelApplication, view
+from noc.services.web.base.extmodelapplication import ExtModelApplication, api
 from noc.aaa.models.permission import Permission
 from noc.sa.interfaces.base import StringParameter
 from noc.core.translation import ugettext as _
@@ -53,7 +53,7 @@ class UserApplication(ExtModelApplication):
     ignored_fields = {"id", "bi_id", "password"}
     custom_m2m_fields = {"permissions": Permission}
 
-    @view(method=["POST"], url=r"^$", access="create", api=True)
+    @api.post(url=r"^$", access="create")
     def api_create(self, request: HttpRequest):
         response = super().api_create(request)
         if response.status_code == self.CREATED:
@@ -68,7 +68,7 @@ class UserApplication(ExtModelApplication):
             user.save()
         return response
 
-    @view(method=["GET"], url=r"^(?P<id>\d+)/?$", access="read", api=True)
+    @api.get(url=r"^(?P<id>\d+)/?$", access="read")
     def api_read(self, request: HttpRequest, id):
         """
         Returns dict with object's fields and values
@@ -117,7 +117,7 @@ class UserApplication(ExtModelApplication):
         else:
             super().update_m2m(o, name, values)
 
-    @view(method=["GET"], url=r"^new_permissions/$", access="read", api=True)
+    @api.get(url=r"^new_permissions/$", access="read")
     def api_read_permission(self, request: HttpRequest):
         """
         Returns dict available permissions
@@ -139,9 +139,8 @@ class UserApplication(ExtModelApplication):
             status=self.OK,
         )
 
-    @view(
+    @api.post(
         url=r"^(\d+)/password/$",
-        method=["POST"],
         access="change",
         validate={"password": StringParameter(required=True)},
     )

--- a/services/web/apps/aaa/user.py
+++ b/services/web/apps/aaa/user.py
@@ -53,7 +53,7 @@ class UserApplication(ExtModelApplication):
     ignored_fields = {"id", "bi_id", "password"}
     custom_m2m_fields = {"permissions": Permission}
 
-    @api.post(url=r"^$", access="create")
+    @api.post(r"^$", access="create")
     def api_create(self, request: HttpRequest):
         response = super().api_create(request)
         if response.status_code == self.CREATED:
@@ -68,7 +68,7 @@ class UserApplication(ExtModelApplication):
             user.save()
         return response
 
-    @api.get(url=r"^(?P<id>\d+)/?$", access="read")
+    @api.get(r"^(?P<id>\d+)/?$", access="read")
     def api_read(self, request: HttpRequest, id):
         """
         Returns dict with object's fields and values
@@ -117,7 +117,7 @@ class UserApplication(ExtModelApplication):
         else:
             super().update_m2m(o, name, values)
 
-    @api.get(url=r"^new_permissions/$", access="read")
+    @api.get(r"^new_permissions/$", access="read")
     def api_read_permission(self, request: HttpRequest):
         """
         Returns dict available permissions
@@ -140,7 +140,7 @@ class UserApplication(ExtModelApplication):
         )
 
     @api.post(
-        url=r"^(\d+)/password/$",
+        r"^(\d+)/password/$",
         access="change",
         validate={"password": StringParameter(required=True)},
     )

--- a/services/web/apps/bi/dashboardlayout.py
+++ b/services/web/apps/bi/dashboardlayout.py
@@ -9,7 +9,7 @@
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.bi.models.dashboardlayout import DashboardLayout
 from noc.core.translation import ugettext as _
 
@@ -23,7 +23,7 @@ class DashboardLayoutApplication(ExtDocApplication):
     menu = [_("Setup"), _("Dashboard Layout")]
     model = DashboardLayout
 
-    @view(url="^(?P<id>[0-9a-f]{24})/json/$", method=["GET"], access="read", api=True)
+    @api.get(url="^(?P<id>[0-9a-f]{24})/json/$", access="read")
     def api_json(self, request: HttpRequest, id):
         layout = self.get_object_or_404(DashboardLayout, id=id)
         return layout.to_json()

--- a/services/web/apps/bi/dashboardlayout.py
+++ b/services/web/apps/bi/dashboardlayout.py
@@ -23,7 +23,7 @@ class DashboardLayoutApplication(ExtDocApplication):
     menu = [_("Setup"), _("Dashboard Layout")]
     model = DashboardLayout
 
-    @api.get(url="^(?P<id>[0-9a-f]{24})/json/$", access="read")
+    @api.get("^(?P<id>[0-9a-f]{24})/json/$", access="read")
     def api_json(self, request: HttpRequest, id):
         layout = self.get_object_or_404(DashboardLayout, id=id)
         return layout.to_json()

--- a/services/web/apps/fm/alarm/views.py
+++ b/services/web/apps/fm/alarm/views.py
@@ -25,7 +25,7 @@ from mongoengine.queryset.visitor import Q
 from noc.config import config
 from noc.core.clickhouse.connect import connection
 from noc.core.comp import smart_text
-from noc.services.web.base.extapplication import ExtApplication, view
+from noc.services.web.base.extapplication import ExtApplication, view, api
 from noc.inv.models.object import Object
 from noc.inv.models.networksegment import NetworkSegment
 from noc.fm.models.activealarm import ActiveAlarm, Effect
@@ -440,7 +440,7 @@ class AlarmApplication(ExtApplication):
     def api_list(self, request: HttpRequest):
         return self.list_data(request, self.instance_to_dict)
 
-    @view(url=r"^(?P<id>[a-z0-9]{24})/$", method=["GET"], api=True, access="launch")
+    @api.get(url=r"^(?P<id>[a-z0-9]{24})/$", access="launch")
     def api_alarm(self, request: HttpRequest, id):
         alarm = get_alarm(id)
         if not alarm:
@@ -655,12 +655,8 @@ class AlarmApplication(ExtApplication):
                     processed.add(c["id"])
         return children
 
-    @view(
-        url=r"^(?P<id>[a-z0-9]{24})/post/",
-        method=["POST"],
-        api=True,
-        access="launch",
-        validate={"msg": UnicodeParameter()},
+    @api.post(
+        url=r"^(?P<id>[a-z0-9]{24})/post/", access="launch", validate={"msg": UnicodeParameter()}
     )
     def api_post(self, request: HttpRequest, id, msg):
         alarm = get_alarm(id)
@@ -669,10 +665,8 @@ class AlarmApplication(ExtApplication):
         alarm.log_message(msg, source=request.user.username)
         return True
 
-    @view(
+    @api.post(
         url=r"^comment/post/",
-        method=["POST"],
-        api=True,
         access="launch",
         validate={
             "ids": StringListParameter(required=True),
@@ -688,10 +682,8 @@ class AlarmApplication(ExtApplication):
             alarm.log_message(msg, source=request.user.username)
         return True
 
-    @view(
+    @api.post(
         url=r"^group/favorites/",
-        method=["POST"],
-        api=True,
         access="launch",
         validate={
             "ids": StringListParameter(required=True),
@@ -705,10 +697,8 @@ class AlarmApplication(ExtApplication):
             Favorites.remove_items(request.user, self.app_id, ids)
         return {"status": True}
 
-    @view(
+    @api.post(
         url=r"^(?P<id>[a-z0-9]{24})/acknowledge/",
-        method=["POST"],
-        api=True,
         access="acknowledge",
         validate={
             "msg": UnicodeParameter(default=""),
@@ -725,10 +715,8 @@ class AlarmApplication(ExtApplication):
         alarm.acknowledge(request.user, msg)
         return {"status": True}
 
-    @view(
+    @api.post(
         url=r"^(?P<id>[a-z0-9]{24})/unacknowledge/",
-        method=["POST"],
-        api=True,
         access="acknowledge",
         validate={
             "msg": UnicodeParameter(default=""),
@@ -745,7 +733,7 @@ class AlarmApplication(ExtApplication):
         alarm.unacknowledge(request.user, msg=msg)
         return {"status": True}
 
-    @view(url=r"^(?P<id>[a-z0-9]{24})/subscribe/", method=["POST"], api=True, access="launch")
+    @api.post(url=r"^(?P<id>[a-z0-9]{24})/subscribe/", access="launch")
     def api_subscribe(self, request: HttpRequest, id):
         alarm = get_alarm(id)
         if not alarm:
@@ -755,7 +743,7 @@ class AlarmApplication(ExtApplication):
             return self.get_alarm_subscribers(alarm)
         return []
 
-    @view(url=r"^(?P<id>[a-z0-9]{24})/unsubscribe/", method=["POST"], api=True, access="launch")
+    @api.post(url=r"^(?P<id>[a-z0-9]{24})/unsubscribe/", access="launch")
     def api_unsubscribe(self, request: HttpRequest, id):
         alarm = get_alarm(id)
         if not alarm:
@@ -765,10 +753,8 @@ class AlarmApplication(ExtApplication):
             return self.get_alarm_subscribers(alarm)
         return []
 
-    @view(
+    @api.post(
         url=r"^(?P<id>[a-z0-9]{24})/clear/",
-        method=["POST"],
-        api=True,
         access="clear",
         validate={
             "msg": UnicodeParameter(default=""),
@@ -783,10 +769,8 @@ class AlarmApplication(ExtApplication):
             alarm.register_clear(f"Cleared by user: {request.user.username}", user=request.user)
         return True
 
-    @view(
+    @api.post(
         url=r"^clear/",
-        method=["POST"],
-        api=True,
         access="clear",
         validate={
             "msg": UnicodeParameter(default=""),
@@ -807,10 +791,8 @@ class AlarmApplication(ExtApplication):
             return {"status": True}
         return {"status": False, "message": _("Failed to clear alarms")}
 
-    @view(
+    @api.post(
         url=r"^(?P<id>[a-z0-9]{24})/set_root/",
-        method=["POST"],
-        api=True,
         access="launch",
         validate={"root": StringParameter()},
     )
@@ -822,7 +804,7 @@ class AlarmApplication(ExtApplication):
         alarm.set_root(r)
         return True
 
-    @view(url=r"notification/$", method=["GET"], api=True, access="launch")
+    @api.get(url=r"notification/$", access="launch")
     def api_notification(self, request: HttpRequest):
         delta = request.GET.get("delta")
         n = 0
@@ -892,12 +874,8 @@ class AlarmApplication(ExtApplication):
         r = [x for x in r if x]
         return "".join(r)
 
-    @view(
-        url=r"^escalate/",
-        method=["POST"],
-        api=True,
-        access="escalate",
-        validate={"ids": StringListParameter(required=True)},
+    @api.post(
+        url=r"^escalate/", access="escalate", validate={"ids": StringListParameter(required=True)}
     )
     def api_escalation_alarm(self, request: HttpRequest, ids):
         alarms = list(ActiveAlarm.objects.filter(id__in=ids))
@@ -1061,7 +1039,7 @@ class AlarmApplication(ExtApplication):
             x["group_subject"] = subj_map[g]
         return data
 
-    @view(url=r"profile_lookup/$", access="launch", method=["GET"], api=True)
+    @api.get(url=r"profile_lookup/$", access="launch")
     def api_profile_lookup(self, request: HttpRequest):
         r = []
         for model, short_type, field_id in (

--- a/services/web/apps/fm/alarm/views.py
+++ b/services/web/apps/fm/alarm/views.py
@@ -440,7 +440,7 @@ class AlarmApplication(ExtApplication):
     def api_list(self, request: HttpRequest):
         return self.list_data(request, self.instance_to_dict)
 
-    @api.get(url=r"^(?P<id>[a-z0-9]{24})/$", access="launch")
+    @api.get(r"^(?P<id>[a-z0-9]{24})/$", access="launch")
     def api_alarm(self, request: HttpRequest, id):
         alarm = get_alarm(id)
         if not alarm:
@@ -655,9 +655,7 @@ class AlarmApplication(ExtApplication):
                     processed.add(c["id"])
         return children
 
-    @api.post(
-        url=r"^(?P<id>[a-z0-9]{24})/post/", access="launch", validate={"msg": UnicodeParameter()}
-    )
+    @api.post(r"^(?P<id>[a-z0-9]{24})/post/", access="launch", validate={"msg": UnicodeParameter()})
     def api_post(self, request: HttpRequest, id, msg):
         alarm = get_alarm(id)
         if not alarm:
@@ -666,7 +664,7 @@ class AlarmApplication(ExtApplication):
         return True
 
     @api.post(
-        url=r"^comment/post/",
+        r"^comment/post/",
         access="launch",
         validate={
             "ids": StringListParameter(required=True),
@@ -683,7 +681,7 @@ class AlarmApplication(ExtApplication):
         return True
 
     @api.post(
-        url=r"^group/favorites/",
+        r"^group/favorites/",
         access="launch",
         validate={
             "ids": StringListParameter(required=True),
@@ -698,7 +696,7 @@ class AlarmApplication(ExtApplication):
         return {"status": True}
 
     @api.post(
-        url=r"^(?P<id>[a-z0-9]{24})/acknowledge/",
+        r"^(?P<id>[a-z0-9]{24})/acknowledge/",
         access="acknowledge",
         validate={
             "msg": UnicodeParameter(default=""),
@@ -716,7 +714,7 @@ class AlarmApplication(ExtApplication):
         return {"status": True}
 
     @api.post(
-        url=r"^(?P<id>[a-z0-9]{24})/unacknowledge/",
+        r"^(?P<id>[a-z0-9]{24})/unacknowledge/",
         access="acknowledge",
         validate={
             "msg": UnicodeParameter(default=""),
@@ -733,7 +731,7 @@ class AlarmApplication(ExtApplication):
         alarm.unacknowledge(request.user, msg=msg)
         return {"status": True}
 
-    @api.post(url=r"^(?P<id>[a-z0-9]{24})/subscribe/", access="launch")
+    @api.post(r"^(?P<id>[a-z0-9]{24})/subscribe/", access="launch")
     def api_subscribe(self, request: HttpRequest, id):
         alarm = get_alarm(id)
         if not alarm:
@@ -743,7 +741,7 @@ class AlarmApplication(ExtApplication):
             return self.get_alarm_subscribers(alarm)
         return []
 
-    @api.post(url=r"^(?P<id>[a-z0-9]{24})/unsubscribe/", access="launch")
+    @api.post(r"^(?P<id>[a-z0-9]{24})/unsubscribe/", access="launch")
     def api_unsubscribe(self, request: HttpRequest, id):
         alarm = get_alarm(id)
         if not alarm:
@@ -754,7 +752,7 @@ class AlarmApplication(ExtApplication):
         return []
 
     @api.post(
-        url=r"^(?P<id>[a-z0-9]{24})/clear/",
+        r"^(?P<id>[a-z0-9]{24})/clear/",
         access="clear",
         validate={
             "msg": UnicodeParameter(default=""),
@@ -770,7 +768,7 @@ class AlarmApplication(ExtApplication):
         return True
 
     @api.post(
-        url=r"^clear/",
+        r"^clear/",
         access="clear",
         validate={
             "msg": UnicodeParameter(default=""),
@@ -792,7 +790,7 @@ class AlarmApplication(ExtApplication):
         return {"status": False, "message": _("Failed to clear alarms")}
 
     @api.post(
-        url=r"^(?P<id>[a-z0-9]{24})/set_root/",
+        r"^(?P<id>[a-z0-9]{24})/set_root/",
         access="launch",
         validate={"root": StringParameter()},
     )
@@ -804,7 +802,7 @@ class AlarmApplication(ExtApplication):
         alarm.set_root(r)
         return True
 
-    @api.get(url=r"notification/$", access="launch")
+    @api.get(r"notification/$", access="launch")
     def api_notification(self, request: HttpRequest):
         delta = request.GET.get("delta")
         n = 0
@@ -875,7 +873,7 @@ class AlarmApplication(ExtApplication):
         return "".join(r)
 
     @api.post(
-        url=r"^escalate/", access="escalate", validate={"ids": StringListParameter(required=True)}
+        r"^escalate/", access="escalate", validate={"ids": StringListParameter(required=True)}
     )
     def api_escalation_alarm(self, request: HttpRequest, ids):
         alarms = list(ActiveAlarm.objects.filter(id__in=ids))
@@ -1039,7 +1037,7 @@ class AlarmApplication(ExtApplication):
             x["group_subject"] = subj_map[g]
         return data
 
-    @api.get(url=r"profile_lookup/$", access="launch")
+    @api.get(r"profile_lookup/$", access="launch")
     def api_profile_lookup(self, request: HttpRequest):
         r = []
         for model, short_type, field_id in (

--- a/services/web/apps/fm/classificationrule.py
+++ b/services/web/apps/fm/classificationrule.py
@@ -38,7 +38,7 @@ class EventClassificationRuleApplication(ExtDocApplication):
     parent_field = "parent"
     query_condition = "icontains"
 
-    @api.post(url="^test/$", access="test")
+    @api.post("^test/$", access="test")
     def api_test(self, request: HttpRequest):
         q = self.deserialize(request.body)
         errors = []
@@ -202,7 +202,7 @@ class EventClassificationRuleApplication(ExtDocApplication):
 
     IGNORED_OIDS = {"RFC1213-MIB::sysUpTime.0", "SNMPv2-MIB::sysUpTime.0"}
 
-    @api.post(url="^from_event/(?P<event_id>[0-9a-f]{24})/$", access="create")
+    @api.post("^from_event/(?P<event_id>[0-9a-f]{24})/$", access="create")
     def api_from_event(self, request: HttpRequest, event_id):
         """
         Create classification rule from event

--- a/services/web/apps/fm/classificationrule.py
+++ b/services/web/apps/fm/classificationrule.py
@@ -13,7 +13,7 @@ from django.template import Template, Context
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.fm.models.eventclassificationrule import (
     EventClassificationRule,
     EventClassificationRuleCategory,
@@ -38,7 +38,7 @@ class EventClassificationRuleApplication(ExtDocApplication):
     parent_field = "parent"
     query_condition = "icontains"
 
-    @view(url="^test/$", method=["POST"], access="test", api=True)
+    @api.post(url="^test/$", access="test")
     def api_test(self, request: HttpRequest):
         q = self.deserialize(request.body)
         errors = []
@@ -202,9 +202,7 @@ class EventClassificationRuleApplication(ExtDocApplication):
 
     IGNORED_OIDS = {"RFC1213-MIB::sysUpTime.0", "SNMPv2-MIB::sysUpTime.0"}
 
-    @view(
-        url="^from_event/(?P<event_id>[0-9a-f]{24})/$", method=["POST"], access="create", api=True
-    )
+    @api.post(url="^from_event/(?P<event_id>[0-9a-f]{24})/$", access="create")
     def api_from_event(self, request: HttpRequest, event_id):
         """
         Create classification rule from event

--- a/services/web/apps/fm/event/views.py
+++ b/services/web/apps/fm/event/views.py
@@ -40,7 +40,7 @@ class EventApplication(ExtApplication):
     icon = "icon_find"
     ignored_params = ["status", "_dc"]
 
-    @view(method=["GET", "POST"], url="^$", access="read", api=True)
+    @api.get("^$", access="read")
     def api_list(self, request: HttpRequest):
         q = self.parse_request_query(request)
         start = q.get("__start") or 0

--- a/services/web/apps/fm/event/views.py
+++ b/services/web/apps/fm/event/views.py
@@ -13,7 +13,7 @@ import orjson
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extapplication import ExtApplication, view, api
+from noc.services.web.base.extapplication import ExtApplication, api
 from noc.fm.models.eventclass import EventClass
 from noc.sa.models.managedobject import ManagedObject
 from noc.sa.models.useraccess import UserAccess

--- a/services/web/apps/fm/event/views.py
+++ b/services/web/apps/fm/event/views.py
@@ -13,7 +13,7 @@ import orjson
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extapplication import ExtApplication, view
+from noc.services.web.base.extapplication import ExtApplication, view, api
 from noc.fm.models.eventclass import EventClass
 from noc.sa.models.managedobject import ManagedObject
 from noc.sa.models.useraccess import UserAccess
@@ -40,7 +40,7 @@ class EventApplication(ExtApplication):
     icon = "icon_find"
     ignored_params = ["status", "_dc"]
 
-    @view(method=["GET"], url="^$", access="read", api=True)
+    @view(method=["GET", "POST"], url="^$", access="read", api=True)
     def api_list(self, request: HttpRequest):
         q = self.parse_request_query(request)
         start = q.get("__start") or 0
@@ -232,7 +232,7 @@ class EventApplication(ExtApplication):
             out += [r]
         return out, rows_count
 
-    @view(url=r"^(?P<id>[a-z0-9]{24})/reclassify/$", method=["POST"], api=True, access="reclassify")
+    @api.post(url=r"^(?P<id>[a-z0-9]{24})/reclassify/$", access="reclassify")
     def api_reclassify(self, request: HttpRequest, id):
         q = self.parse_request_query(request)
         if q.get("managed_object_id"):
@@ -277,7 +277,7 @@ class EventApplication(ExtApplication):
         svc.publish(orjson.dumps(data), stream=s, partition=p)
         return {"status": True}
 
-    @view(url=r"^(?P<id>[a-z0-9]{24})/json/$", method=["GET"], api=True, access="launch")
+    @api.get(url=r"^(?P<id>[a-z0-9]{24})/json/$", access="launch")
     def api_json(self, request: HttpRequest, id):
         e = Event.get_by_id(id)
         return orjson.dumps(e.model_dump(), option=orjson.OPT_INDENT_2).decode()

--- a/services/web/apps/fm/event/views.py
+++ b/services/web/apps/fm/event/views.py
@@ -232,7 +232,7 @@ class EventApplication(ExtApplication):
             out += [r]
         return out, rows_count
 
-    @api.post(url=r"^(?P<id>[a-z0-9]{24})/reclassify/$", access="reclassify")
+    @api.post(r"^(?P<id>[a-z0-9]{24})/reclassify/$", access="reclassify")
     def api_reclassify(self, request: HttpRequest, id):
         q = self.parse_request_query(request)
         if q.get("managed_object_id"):
@@ -277,7 +277,7 @@ class EventApplication(ExtApplication):
         svc.publish(orjson.dumps(data), stream=s, partition=p)
         return {"status": True}
 
-    @api.get(url=r"^(?P<id>[a-z0-9]{24})/json/$", access="launch")
+    @api.get(r"^(?P<id>[a-z0-9]{24})/json/$", access="launch")
     def api_json(self, request: HttpRequest, id):
         e = Event.get_by_id(id)
         return orjson.dumps(e.model_dump(), option=orjson.OPT_INDENT_2).decode()

--- a/services/web/apps/fm/ignorepattern.py
+++ b/services/web/apps/fm/ignorepattern.py
@@ -9,7 +9,7 @@
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.fm.models.ignorepattern import IgnorePattern
 from noc.core.fm.event import EventSource
 from noc.core.translation import ugettext as _
@@ -24,9 +24,7 @@ class IgnorePatternApplication(ExtDocApplication):
     menu = [_("Setup"), _("Ignore Patterns")]
     model = IgnorePattern
 
-    @view(
-        url="^from_event/(?P<event_id>[0-9a-f]{24})/$", method=["POST"], access="create", api=True
-    )
+    @api.post(url="^from_event/(?P<event_id>[0-9a-f]{24})/$", access="create")
     def api_from_event(self, request: HttpRequest, event_id):
         """
         Create ignore pattern rule from event

--- a/services/web/apps/fm/ignorepattern.py
+++ b/services/web/apps/fm/ignorepattern.py
@@ -24,7 +24,7 @@ class IgnorePatternApplication(ExtDocApplication):
     menu = [_("Setup"), _("Ignore Patterns")]
     model = IgnorePattern
 
-    @api.post(url="^from_event/(?P<event_id>[0-9a-f]{24})/$", access="create")
+    @api.post("^from_event/(?P<event_id>[0-9a-f]{24})/$", access="create")
     def api_from_event(self, request: HttpRequest, event_id):
         """
         Create ignore pattern rule from event

--- a/services/web/apps/fm/mib.py
+++ b/services/web/apps/fm/mib.py
@@ -10,7 +10,7 @@ import networkx as nx
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.fm.models.mib import MIB
 from noc.fm.models.mibdata import MIBData
 from noc.fm.models.syntaxalias import SyntaxAlias
@@ -28,7 +28,7 @@ class MIBApplication(ExtDocApplication):
     menu = _("MIB")
     model = MIB
 
-    @view(url="^(?P<id>[0-9a-f]{24})/data/$", method=["GET"], access="launch", api=True)
+    @api.get(url="^(?P<id>[0-9a-f]{24})/data/$", access="launch")
     def api_data(self, request: HttpRequest, id):
         def insert_tree(data, ds):
             if len(data["path"]) + 1 == len(ds["path"]) and data["path"] == ds["path"][:-1]:
@@ -153,7 +153,7 @@ class MIBApplication(ExtDocApplication):
             s += syntax_descr(sa)
         return "\n".join(s)
 
-    @view(url="^upload/", method=["POST"], access="create", api=True)
+    @api.post(url="^upload/", access="create")
     def api_upload(self, request: HttpRequest):
         left = {}  # name -> data
         for f in request.FILES:
@@ -180,7 +180,7 @@ class MIBApplication(ExtDocApplication):
             {"success": len(left) == 0, "message": f"ERROR: {errors}"}, status=self.OK
         )
 
-    @view(url="^(?P<id>[0-9a-f]{24})/text/$", method=["GET"], access="launch", api=True)
+    @api.get(url="^(?P<id>[0-9a-f]{24})/text/$", access="launch")
     def api_text(self, request: HttpRequest, id):
         mib = self.get_object_or_404(MIB, id=id)
         try:

--- a/services/web/apps/fm/mib.py
+++ b/services/web/apps/fm/mib.py
@@ -28,7 +28,7 @@ class MIBApplication(ExtDocApplication):
     menu = _("MIB")
     model = MIB
 
-    @api.get(url="^(?P<id>[0-9a-f]{24})/data/$", access="launch")
+    @api.get("^(?P<id>[0-9a-f]{24})/data/$", access="launch")
     def api_data(self, request: HttpRequest, id):
         def insert_tree(data, ds):
             if len(data["path"]) + 1 == len(ds["path"]) and data["path"] == ds["path"][:-1]:
@@ -153,7 +153,7 @@ class MIBApplication(ExtDocApplication):
             s += syntax_descr(sa)
         return "\n".join(s)
 
-    @api.post(url="^upload/", access="create")
+    @api.post("^upload/", access="create")
     def api_upload(self, request: HttpRequest):
         left = {}  # name -> data
         for f in request.FILES:
@@ -180,7 +180,7 @@ class MIBApplication(ExtDocApplication):
             {"success": len(left) == 0, "message": f"ERROR: {errors}"}, status=self.OK
         )
 
-    @api.get(url="^(?P<id>[0-9a-f]{24})/text/$", access="launch")
+    @api.get("^(?P<id>[0-9a-f]{24})/text/$", access="launch")
     def api_text(self, request: HttpRequest, id):
         mib = self.get_object_or_404(MIB, id=id)
         try:

--- a/services/web/apps/fm/oidalias.py
+++ b/services/web/apps/fm/oidalias.py
@@ -23,7 +23,7 @@ class OIDAliasApplication(ExtDocApplication):
     menu = [_("Setup"), _("OID Aliases")]
     model = OIDAlias
 
-    @api.get(url="^(?P<id>[0-9a-f]{24})/json/$", access="read")
+    @api.get("^(?P<id>[0-9a-f]{24})/json/$", access="read")
     def api_json(self, request: HttpRequest, id):
         oa = self.get_object_or_404(OIDAlias, id=id)
         return oa.to_json()

--- a/services/web/apps/fm/oidalias.py
+++ b/services/web/apps/fm/oidalias.py
@@ -9,7 +9,7 @@
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.fm.models.oidalias import OIDAlias
 from noc.core.translation import ugettext as _
 
@@ -23,7 +23,7 @@ class OIDAliasApplication(ExtDocApplication):
     menu = [_("Setup"), _("OID Aliases")]
     model = OIDAlias
 
-    @view(url="^(?P<id>[0-9a-f]{24})/json/$", method=["GET"], access="read", api=True)
+    @api.get(url="^(?P<id>[0-9a-f]{24})/json/$", access="read")
     def api_json(self, request: HttpRequest, id):
         oa = self.get_object_or_404(OIDAlias, id=id)
         return oa.to_json()

--- a/services/web/apps/fm/reportalarmcomments.py
+++ b/services/web/apps/fm/reportalarmcomments.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # fm.reportalarmcomments application
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -20,7 +20,7 @@ from django.http import HttpResponse
 # from pymongo import ReadPreference
 
 # NOC modules
-from noc.services.web.base.extapplication import ExtApplication, view
+from noc.services.web.base.extapplication import ExtApplication, api
 from noc.sa.interfaces.base import StringParameter
 from noc.fm.models.archivedalarm import ArchivedAlarm
 from noc.fm.models.activealarm import ActiveAlarm
@@ -56,11 +56,9 @@ class ReportAlarmCommentsApplication(ExtApplication):
     menu = _("Reports") + "|" + _("Alarm Comments")
     title = _("Alarm Comments Detail")
 
-    @view(
+    @api.get(
         "^download/$",
-        method=["GET"],
         access="launch",
-        api=True,
         validate={
             "from_date": StringParameter(required=True),
             "to_date": StringParameter(required=True),

--- a/services/web/apps/fm/reportalarmdetail.py
+++ b/services/web/apps/fm/reportalarmdetail.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # fm.reportalarmdetail application
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2022 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -16,7 +16,7 @@ from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseNotFou
 import polars as pl
 
 # NOC modules
-from noc.services.web.base.extapplication import ExtApplication, view
+from noc.services.web.base.extapplication import ExtApplication, api
 from noc.sa.interfaces.base import StringParameter, IntParameter, ObjectIdParameter
 from noc.sa.models.useraccess import UserAccess
 from noc.sa.models.administrativedomain import AdministrativeDomain
@@ -90,11 +90,9 @@ class ReportAlarmDetailApplication(ExtApplication):
         "location": _("LOCATION"),
     }
 
-    @view(
+    @api.get(
         "^download/$",
-        method=["GET"],
         access="launch",
-        api=True,
         validate={
             "from_date": StringParameter(required=False),
             "to_date": StringParameter(required=False),

--- a/services/web/apps/gis/geocoder.py
+++ b/services/web/apps/gis/geocoder.py
@@ -10,14 +10,14 @@ from django.http import HttpRequest
 
 # NOC modules
 from noc.config import config
-from noc.services.web.base.extapplication import ExtApplication, view
+from noc.services.web.base.extapplication import ExtApplication, api
 from noc.core.geocoder.loader import loader
 
 
 class GeoCoderApplication(ExtApplication):
     name = "geocoder"
 
-    @view(url=r"^lookup/$", method=["GET"], access="lookup", api=True)
+    @api.get(url=r"^lookup/$", access="lookup")
     def api_lookup(self, request: HttpRequest, ref=None):
         q = {str(k): v[0] if len(v) == 1 else v for k, v in request.GET.lists()}
         limit = int(q.get(self.limit_param, 0))

--- a/services/web/apps/gis/geocoder.py
+++ b/services/web/apps/gis/geocoder.py
@@ -17,7 +17,7 @@ from noc.core.geocoder.loader import loader
 class GeoCoderApplication(ExtApplication):
     name = "geocoder"
 
-    @api.get(url=r"^lookup/$", access="lookup")
+    @api.get(r"^lookup/$", access="lookup")
     def api_lookup(self, request: HttpRequest, ref=None):
         q = {str(k): v[0] if len(v) == 1 else v for k, v in request.GET.lists()}
         limit = int(q.get(self.limit_param, 0))

--- a/services/web/apps/inv/capability.py
+++ b/services/web/apps/inv/capability.py
@@ -13,7 +13,7 @@ from collections import defaultdict
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.inv.models.capability import Capability
 from noc.main.models.doccategory import DocCategory
 from noc.core.translation import ugettext as _
@@ -32,7 +32,7 @@ class CapabilityApplication(ExtDocApplication):
     parent_model = DocCategory
     parent_field = "parent"
 
-    @view(method=["GET"], url="^tree$", access="read", api=True)
+    @api.get(url="^tree$", access="read")
     def get_tree(self, request: HttpRequest):
         """
         Return capabilities for tree build.

--- a/services/web/apps/inv/capability.py
+++ b/services/web/apps/inv/capability.py
@@ -32,7 +32,7 @@ class CapabilityApplication(ExtDocApplication):
     parent_model = DocCategory
     parent_field = "parent"
 
-    @api.get(url="^tree$", access="read")
+    @api.get("^tree$", access="read")
     def get_tree(self, request: HttpRequest):
         """
         Return capabilities for tree build.

--- a/services/web/apps/inv/channel.py
+++ b/services/web/apps/inv/channel.py
@@ -9,7 +9,7 @@
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.inv.models.channel import Channel
 from noc.inv.models.endpoint import Endpoint, UsageItem, ConstraintItem
 from noc.core.translation import ugettext as _
@@ -51,7 +51,7 @@ class ChannelApplication(ExtDocApplication):
     query_fields = ["name__icontains"]
     require_feature = Feature.CHANNEL
 
-    @view(url="^(?P<id>[0-9a-f]{24})/viz/", method=["GET"], api=True, access="read")
+    @api.get(url="^(?P<id>[0-9a-f]{24})/viz/", access="read")
     def api_viz(self, request: HttpRequest, id: str):
         channel = self.get_object_or_404(Channel, id=id)
         mapper = mapper_loader[channel.tech_domain.code](channel)

--- a/services/web/apps/inv/channel.py
+++ b/services/web/apps/inv/channel.py
@@ -51,7 +51,7 @@ class ChannelApplication(ExtDocApplication):
     query_fields = ["name__icontains"]
     require_feature = Feature.CHANNEL
 
-    @api.get(url="^(?P<id>[0-9a-f]{24})/viz/", access="read")
+    @api.get("^(?P<id>[0-9a-f]{24})/viz/", access="read")
     def api_viz(self, request: HttpRequest, id: str):
         channel = self.get_object_or_404(Channel, id=id)
         mapper = mapper_loader[channel.tech_domain.code](channel)

--- a/services/web/apps/inv/configuredmap.py
+++ b/services/web/apps/inv/configuredmap.py
@@ -9,7 +9,7 @@
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.inv.models.configuredmap import ConfiguredMap, ObjectFilter
 from noc.core.translation import ugettext as _
 
@@ -103,7 +103,7 @@ class ConfiguredMapApplication(ExtDocApplication):
             node["object_filter"] = object_filter or None
         return super().clean(data)
 
-    @view(r"^(?P<map_id>[0-9a-f]{24})/nodes/$", method=["GET"], access="read", api=True)
+    @api.get(r"^(?P<map_id>[0-9a-f]{24})/nodes/$", access="read")
     def get_map_nodes(self, request: HttpRequest, map_id):
         r = []
         rid = request.GET.getlist("id")

--- a/services/web/apps/inv/connectionrule.py
+++ b/services/web/apps/inv/connectionrule.py
@@ -9,7 +9,7 @@
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.inv.models.connectionrule import ConnectionRule
 from noc.sa.interfaces.base import ListOfParameter, DocumentParameter
 from noc.core.prettyjson import to_json
@@ -26,12 +26,10 @@ class ConnectionRuleApplication(ExtDocApplication):
     model = ConnectionRule
     query_fields = ["name__icontains", "description__icontains"]
 
-    @view(
+    @api.post(
         url="^actions/json/$",
-        method=["POST"],
         access="read",
         validate={"ids": ListOfParameter(element=DocumentParameter(ConnectionRule), convert=True)},
-        api=True,
     )
     def api_action_json(self, request: HttpRequest, ids):
         r = [o.json_data for o in ids]

--- a/services/web/apps/inv/connectionrule.py
+++ b/services/web/apps/inv/connectionrule.py
@@ -27,7 +27,7 @@ class ConnectionRuleApplication(ExtDocApplication):
     query_fields = ["name__icontains", "description__icontains"]
 
     @api.post(
-        url="^actions/json/$",
+        "^actions/json/$",
         access="read",
         validate={"ids": ListOfParameter(element=DocumentParameter(ConnectionRule), convert=True)},
     )

--- a/services/web/apps/inv/connectiontype.py
+++ b/services/web/apps/inv/connectiontype.py
@@ -9,7 +9,7 @@
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.inv.models.modelinterface import ModelInterface
 from noc.inv.models.connectiontype import ConnectionType
 from noc.main.models.doccategory import DocCategory
@@ -33,7 +33,7 @@ class ConnectionTypeApplication(ExtDocApplication):
             data["data"] = ModelInterface.clean_data(data["data"])
         return super().clean(data)
 
-    @view(url="^(?P<id>[0-9a-f]{24})/compatible/$", method=["GET"], access="read", api=True)
+    @api.get(url="^(?P<id>[0-9a-f]{24})/compatible/$", access="read")
     def api_compatible(self, request: HttpRequest, id):
         def fn(t, gender, reason):
             return {

--- a/services/web/apps/inv/connectiontype.py
+++ b/services/web/apps/inv/connectiontype.py
@@ -33,7 +33,7 @@ class ConnectionTypeApplication(ExtDocApplication):
             data["data"] = ModelInterface.clean_data(data["data"])
         return super().clean(data)
 
-    @api.get(url="^(?P<id>[0-9a-f]{24})/compatible/$", access="read")
+    @api.get("^(?P<id>[0-9a-f]{24})/compatible/$", access="read")
     def api_compatible(self, request: HttpRequest, id):
         def fn(t, gender, reason):
             return {

--- a/services/web/apps/inv/container.py
+++ b/services/web/apps/inv/container.py
@@ -59,7 +59,7 @@ class ObjectContainerApplication(ExtApplication):
     def api_lookup(self, request: HttpRequest):
         return self.list_data(request, self.instance_to_lookup)
 
-    @api.get()
+    @api.get("^(?P<oid>[0-9a-f]{24})/get_path/$", access="read")
     def api_get_path(self, request: HttpRequest, oid):
         o = self.get_object_or_404(Object, id=oid)
         path = [Object.get_by_id(ns) for ns in o.get_path()]

--- a/services/web/apps/inv/container.py
+++ b/services/web/apps/inv/container.py
@@ -55,7 +55,7 @@ class ObjectContainerApplication(ExtApplication):
     def instance_to_lookup(self, o, fields=None):
         return {"id": str(o.id), "label": (o.name), "has_children": o.has_children}
 
-    @api.get(url=r"^lookup/$", access="lookup")
+    @api.get(r"^lookup/$", access="lookup")
     def api_lookup(self, request: HttpRequest):
         return self.list_data(request, self.instance_to_lookup)
 

--- a/services/web/apps/inv/container.py
+++ b/services/web/apps/inv/container.py
@@ -9,7 +9,7 @@
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extapplication import ExtApplication, view
+from noc.services.web.base.extapplication import ExtApplication, api
 from noc.inv.models.objectmodel import ObjectModel
 from noc.inv.models.object import Object
 
@@ -55,11 +55,11 @@ class ObjectContainerApplication(ExtApplication):
     def instance_to_lookup(self, o, fields=None):
         return {"id": str(o.id), "label": (o.name), "has_children": o.has_children}
 
-    @view(method=["GET"], url=r"^lookup/$", access="lookup", api=True)
+    @api.get(url=r"^lookup/$", access="lookup")
     def api_lookup(self, request: HttpRequest):
         return self.list_data(request, self.instance_to_lookup)
 
-    @view("^(?P<oid>[0-9a-f]{24})/get_path/$", access="read", api=True)
+    @api.get()
     def api_get_path(self, request: HttpRequest, oid):
         o = self.get_object_or_404(Object, id=oid)
         path = [Object.get_by_id(ns) for ns in o.get_path()]

--- a/services/web/apps/inv/facade.py
+++ b/services/web/apps/inv/facade.py
@@ -28,7 +28,7 @@ class FacadeApplication(ExtDocApplication):
     query_fields = ["name__icontains", "description__icontains"]
     glyph = "table"
 
-    @api.get(url="^(?P<id>[0-9a-f]{24})/facade.svg$", access="read")
+    @api.get("^(?P<id>[0-9a-f]{24})/facade.svg$", access="read")
     def api_svg(self, request: HttpRequest, id: str):
         o = self.get_object_or_404(Facade, id)
         return HttpResponse(o.data, content_type="image/svg+xml", status=200)

--- a/services/web/apps/inv/facade.py
+++ b/services/web/apps/inv/facade.py
@@ -9,7 +9,7 @@
 from django.http import HttpResponse, HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.main.models.doccategory import DocCategory
 from noc.inv.models.facade import Facade
 from noc.core.translation import ugettext as _
@@ -28,7 +28,7 @@ class FacadeApplication(ExtDocApplication):
     query_fields = ["name__icontains", "description__icontains"]
     glyph = "table"
 
-    @view(url="^(?P<id>[0-9a-f]{24})/facade.svg$", method=["GET"], access="read", api=True)
+    @api.get(url="^(?P<id>[0-9a-f]{24})/facade.svg$", access="read")
     def api_svg(self, request: HttpRequest, id: str):
         o = self.get_object_or_404(Facade, id)
         return HttpResponse(o.data, content_type="image/svg+xml", status=200)

--- a/services/web/apps/inv/interface.py
+++ b/services/web/apps/inv/interface.py
@@ -152,7 +152,7 @@ class InterfaceApplication(ExtDocApplication):
             r["link__label"] = link["label"]
         return r
 
-    @api.get(url=r"^(?P<managed_object>\d+)/$", access="view")
+    @api.get(r"^(?P<managed_object>\d+)/$", access="view")
     def api_get_interfaces(self, request: HttpRequest, managed_object):
         """
         GET interfaces
@@ -244,7 +244,7 @@ class InterfaceApplication(ExtDocApplication):
         }
 
     @api.post(
-        url=r"^link/$",
+        r"^link/$",
         validate={
             "type": StringParameter(choices=["ptp"]),
             "interfaces": ListOfParameter(element=DocumentParameter(Interface)),
@@ -259,7 +259,7 @@ class InterfaceApplication(ExtDocApplication):
             raise ValueError("Invalid interfaces length")
         return {"status": False}
 
-    @api.post(url=r"^unlink/(?P<iface_id>[0-9a-f]{24})/$", access="link")
+    @api.post(r"^unlink/(?P<iface_id>[0-9a-f]{24})/$", access="link")
     def api_unlink(self, request: HttpRequest, iface_id):
         i = Interface.objects.filter(id=iface_id).first()
         if not i:
@@ -270,7 +270,7 @@ class InterfaceApplication(ExtDocApplication):
         except ValueError as why:
             return {"status": False, "msg": str(why)}
 
-    @api.get(url=r"^unlinked/(?P<object_id>\d+)/$", access="link")
+    @api.get(r"^unlinked/(?P<object_id>\d+)/$", access="link")
     def api_unlinked(self, request: HttpRequest, object_id):
         def get_label(i):
             if i.description:
@@ -286,7 +286,7 @@ class InterfaceApplication(ExtDocApplication):
         return sorted(r, key=lambda x: alnum_key(x["label"]))
 
     @api.post(
-        url=r"^l1/(?P<iface_id>[0-9a-f]{24})/change_profile/$",
+        r"^l1/(?P<iface_id>[0-9a-f]{24})/change_profile/$",
         validate={"profile": DocumentParameter(InterfaceProfile)},
         access="profile",
     )
@@ -301,7 +301,7 @@ class InterfaceApplication(ExtDocApplication):
         return True
 
     @api.post(
-        url=r"^l1/(?P<iface_id>[0-9a-f]{24})/change_project/$",
+        r"^l1/(?P<iface_id>[0-9a-f]{24})/change_project/$",
         validate={"project": ModelParameter(Project, required=False)},
         access="profile",
     )

--- a/services/web/apps/inv/interface.py
+++ b/services/web/apps/inv/interface.py
@@ -12,7 +12,7 @@ from django.http import HttpRequest
 # NOC modules
 from noc.services.web.base.decorators.state import state_handler
 from noc.services.web.base.decorators.caps import capabilities_handler
-from noc.services.web.base.extapplication import view
+from noc.services.web.base.extapplication import api
 from noc.services.web.base.extdocapplication import ExtDocApplication
 from noc.sa.models.managedobject import ManagedObject
 from noc.inv.models.interface import Interface
@@ -152,7 +152,7 @@ class InterfaceApplication(ExtDocApplication):
             r["link__label"] = link["label"]
         return r
 
-    @view(url=r"^(?P<managed_object>\d+)/$", method=["GET"], access="view", api=True)
+    @api.get(url=r"^(?P<managed_object>\d+)/$", access="view")
     def api_get_interfaces(self, request: HttpRequest, managed_object):
         """
         GET interfaces
@@ -243,15 +243,13 @@ class InterfaceApplication(ExtDocApplication):
             "l3": sorted_iname(l3),
         }
 
-    @view(
+    @api.post(
         url=r"^link/$",
-        method=["POST"],
         validate={
             "type": StringParameter(choices=["ptp"]),
             "interfaces": ListOfParameter(element=DocumentParameter(Interface)),
         },
         access="link",
-        api=True,
     )
     def api_link(self, request: HttpRequest, type, interfaces):
         if type == "ptp":
@@ -261,7 +259,7 @@ class InterfaceApplication(ExtDocApplication):
             raise ValueError("Invalid interfaces length")
         return {"status": False}
 
-    @view(url=r"^unlink/(?P<iface_id>[0-9a-f]{24})/$", method=["POST"], access="link", api=True)
+    @api.post(url=r"^unlink/(?P<iface_id>[0-9a-f]{24})/$", access="link")
     def api_unlink(self, request: HttpRequest, iface_id):
         i = Interface.objects.filter(id=iface_id).first()
         if not i:
@@ -272,7 +270,7 @@ class InterfaceApplication(ExtDocApplication):
         except ValueError as why:
             return {"status": False, "msg": str(why)}
 
-    @view(url=r"^unlinked/(?P<object_id>\d+)/$", method=["GET"], access="link", api=True)
+    @api.get(url=r"^unlinked/(?P<object_id>\d+)/$", access="link")
     def api_unlinked(self, request: HttpRequest, object_id):
         def get_label(i):
             if i.description:
@@ -287,12 +285,10 @@ class InterfaceApplication(ExtDocApplication):
         ]
         return sorted(r, key=lambda x: alnum_key(x["label"]))
 
-    @view(
+    @api.post(
         url=r"^l1/(?P<iface_id>[0-9a-f]{24})/change_profile/$",
         validate={"profile": DocumentParameter(InterfaceProfile)},
-        method=["POST"],
         access="profile",
-        api=True,
     )
     def api_change_profile(self, request: HttpRequest, iface_id, profile):
         i = Interface.objects.filter(id=iface_id).first()
@@ -304,12 +300,10 @@ class InterfaceApplication(ExtDocApplication):
             i.save()
         return True
 
-    @view(
+    @api.post(
         url=r"^l1/(?P<iface_id>[0-9a-f]{24})/change_project/$",
         validate={"project": ModelParameter(Project, required=False)},
-        method=["POST"],
         access="profile",
-        api=True,
     )
     def api_change_project(self, request: HttpRequest, iface_id, project):
         i = Interface.objects.filter(id=iface_id).first()

--- a/services/web/apps/inv/inv/views.py
+++ b/services/web/apps/inv/inv/views.py
@@ -98,7 +98,7 @@ class InvApplication(ExtApplication):
                     if not o.required_feature or o.required_feature.is_active():
                         self.plugins[o.name] = o(self)
 
-    @api.get()
+    @api.get("^node/$", method=["GET"], access="read")
     def api_node(self, request: HttpRequest):
         children = []
         if request.GET and "node" in request.GET:
@@ -456,7 +456,7 @@ class InvApplication(ExtApplication):
                 x.put_into(cc)
         return True
 
-    @api.get()
+    @api.get(r"^(?P<id>[0-9a-f]{24})/path/$", method=["GET"], access="read")
     def api_get_path(self, request: HttpRequest, id):
         o = self.get_object_or_404(Object, id=id)
         path = [{"id": str(o.id), "name": o.name}]
@@ -691,7 +691,7 @@ class InvApplication(ExtApplication):
             o = o.parent
         return False
 
-    @api.get()
+    @api.get(r"^(?P<oid>[0-9a-f]{24})/map_lookup/$", access="read")
     def api_map_lookup(self, request: HttpRequest, oid):
         o: Object = self.get_object_or_404(Object, id=oid)
         if not o.is_container:

--- a/services/web/apps/inv/inv/views.py
+++ b/services/web/apps/inv/inv/views.py
@@ -98,7 +98,7 @@ class InvApplication(ExtApplication):
                     if not o.required_feature or o.required_feature.is_active():
                         self.plugins[o.name] = o(self)
 
-    @api.get("^node/$", method=["GET"], access="read")
+    @api.get("^node/$", access="read")
     def api_node(self, request: HttpRequest):
         children = []
         if request.GET and "node" in request.GET:
@@ -456,7 +456,7 @@ class InvApplication(ExtApplication):
                 x.put_into(cc)
         return True
 
-    @api.get(r"^(?P<id>[0-9a-f]{24})/path/$", method=["GET"], access="read")
+    @api.get(r"^(?P<id>[0-9a-f]{24})/path/$", access="read")
     def api_get_path(self, request: HttpRequest, id):
         o = self.get_object_or_404(Object, id=id)
         path = [{"id": str(o.id), "name": o.name}]

--- a/services/web/apps/inv/inv/views.py
+++ b/services/web/apps/inv/inv/views.py
@@ -20,7 +20,7 @@ from mongoengine import ValidationError
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extapplication import ExtApplication, view
+from noc.services.web.base.extapplication import ExtApplication, api
 from noc.inv.models.object import Object
 from noc.inv.models.error import ConnectionError
 from noc.inv.models.objectmodel import ObjectModel
@@ -98,7 +98,7 @@ class InvApplication(ExtApplication):
                     if not o.required_feature or o.required_feature.is_active():
                         self.plugins[o.name] = o(self)
 
-    @view("^node/$", method=["GET"], access="read", api=True)
+    @api.get()
     def api_node(self, request: HttpRequest):
         children = []
         if request.GET and "node" in request.GET:
@@ -212,11 +212,9 @@ class InvApplication(ExtApplication):
                 item["is_alarm"] = resource_statuses[f"o:{item['id']}"]
         return r
 
-    @view(
+    @api.post(
         "^attach/$",
-        method=["POST"],
         access="create_group",
-        api=True,
         validate={
             "container": ObjectIdParameter(),
             "item": ObjectIdParameter(),
@@ -332,11 +330,9 @@ class InvApplication(ExtApplication):
             return {"choices": {"children": [r], "expanded": True}}
         return Result(status=False, message="Cannot connect").as_response()
 
-    @view(
+    @api.post(
         "^add_group/$",
-        method=["POST"],
         access="create_group",
-        api=True,
         validate={
             "container": ObjectIdParameter(required=False),
             "type": ObjectIdParameter(),
@@ -364,11 +360,9 @@ class InvApplication(ExtApplication):
         o.log("Created", user=request.user.username, system="WEB", op="CREATE")
         return str(o.id)
 
-    @view(
+    @api.post(
         "^add/$",
-        method=["POST"],
         access="create_group",
-        api=True,
         validate={
             "container": ObjectIdParameter(required=False),
             "items": DictListParameter(
@@ -397,11 +391,9 @@ class InvApplication(ExtApplication):
             obj.log("Created", user=request.user.username, system="WEB", op="CREATE")
         return {"status": True}
 
-    @view(
+    @api.delete(
         "^remove_group/$",
-        method=["DELETE"],
         access="remove_group",
-        api=True,
         validate={
             "container": ObjectIdParameter(required=True),
             "action": StringParameter(choices=["p", "l", "r"]),
@@ -423,11 +415,9 @@ class InvApplication(ExtApplication):
                 raise NotImplementedError
         return {"status": True, "message": f"{n} objects deleted"}
 
-    @view(
+    @api.delete(
         "^remove_connections/$",
-        method=["DELETE"],
         access="remove_group",
-        api=True,
         validate={
             "container": ObjectIdParameter(required=True),
         },
@@ -437,11 +427,9 @@ class InvApplication(ExtApplication):
         remove_connections(obj)
         return {"status": True, "message": "Conections cleared"}
 
-    @view(
+    @api.post(
         "^insert/$",
-        method=["POST"],
         access="reorder",
-        api=True,
         validate={
             "container": ObjectIdParameter(required=False),
             "objects": ListOfParameter(element=ObjectIdParameter()),
@@ -468,7 +456,7 @@ class InvApplication(ExtApplication):
                 x.put_into(cc)
         return True
 
-    @view("^(?P<id>[0-9a-f]{24})/path/$", method=["GET"], access="read", api=True)
+    @api.get()
     def api_get_path(self, request: HttpRequest, id):
         o = self.get_object_or_404(Object, id=id)
         path = [{"id": str(o.id), "name": o.name}]
@@ -479,11 +467,9 @@ class InvApplication(ExtApplication):
             )
         return path
 
-    @view(
+    @api.get(
         "^crossing_proposals/$",
-        method=["GET"],
         access="read",
-        api=True,
         validate={
             "o1": ObjectIdParameter(required=True),
             "o2": ObjectIdParameter(required=False),
@@ -540,11 +526,9 @@ class InvApplication(ExtApplication):
         )
         return builder.build()
 
-    @view(
+    @api.post(
         "^connect/$",
-        method=["POST"],
         access="connect",
-        api=True,
         validate=DictListParameter(
             attrs={
                 "object": ObjectIdParameter(required=True),
@@ -650,11 +634,9 @@ class InvApplication(ExtApplication):
             )
         return self.render_json({"status": True, "text": ""})
 
-    @view(
+    @api.post(
         "^disconnect/$",
-        method=["POST"],
         access="connect",
-        api=True,
         validate={
             "object": ObjectIdParameter(required=True),
             "name": StringParameter(required=True),
@@ -709,7 +691,7 @@ class InvApplication(ExtApplication):
             o = o.parent
         return False
 
-    @view(url=r"^(?P<oid>[0-9a-f]{24})/map_lookup/$", method=["GET"], access="read", api=True)
+    @api.get()
     def api_map_lookup(self, request: HttpRequest, oid):
         o: Object = self.get_object_or_404(Object, id=oid)
         if not o.is_container:
@@ -733,11 +715,9 @@ class InvApplication(ExtApplication):
             ]
         return r
 
-    @view(
+    @api.post(
         "^clone/$",
-        method=["POST"],
         access="create_group",
-        api=True,
         validate=DictParameter(
             attrs={
                 "container": ObjectIdParameter(required=True),
@@ -755,11 +735,9 @@ class InvApplication(ExtApplication):
         cloned = clone(obj, clone_connections=clone_connections)
         return {"status": True, "object": str(cloned.id), "message": "Object cloned successfully"}
 
-    @view(
+    @api.post(
         "^baloon/",
-        method=["POST"],
         access="read",
-        api=True,
         validate=DictParameter(attrs={"resource": StringParameter(required=True)}),
     )
     def api_baloon(self, request: HttpRequest, resource: str):
@@ -788,13 +766,7 @@ class InvApplication(ExtApplication):
         ).values_list("id")
         return list(ids)
 
-    @view(
-        "^search/$",
-        method=["GET"],
-        access="read",
-        api=True,
-        validate={"q": UnicodeParameter(required=True)},
-    )
+    @api.get("^search/$", access="read", validate={"q": UnicodeParameter(required=True)})
     def api_search(self, request: HttpRequest, q: str, **kwargs):
         def path(o: Object) -> list[dict]:
             result = []
@@ -861,13 +833,7 @@ class InvApplication(ExtApplication):
         objs = list(objs)[start : start + limit]
         return {"status": True, "items": [{"path": path(Object.get_by_id(o["_id"]))} for o in objs]}
 
-    @view(
-        "^resource_status/$",
-        method=["POST"],
-        access="read",
-        api=True,
-        validate={"resources": StringListParameter()},
-    )
+    @api.post("^resource_status/$", access="read", validate={"resources": StringListParameter()})
     def api_resource_status(self, request: HttpRequest, resources: list[str]):
         # @todo: Limit access
         alarmed = ActiveAlarm.get_resource_statuses(resources)

--- a/services/web/apps/inv/macdb.py
+++ b/services/web/apps/inv/macdb.py
@@ -14,7 +14,7 @@ from django.http import HttpRequest
 import orjson
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtApplication, view
+from noc.services.web.base.extdocapplication import ExtApplication, view, api
 from noc.sa.models.managedobject import ManagedObject
 from noc.sa.interfaces.base import MACAddressParameter
 from noc.core.mac import MAC
@@ -252,7 +252,7 @@ class MACApplication(ExtApplication):
         r = ch.execute(sql, return_raw=True)
         return orjson.loads(r)
 
-    @view(url="^(?P<mac>[0-9A-F:]+)/$", method=["GET"], access="view", api=True)
+    @api.get(url="^(?P<mac>[0-9A-F:]+)/$", access="view")
     def api_get_maclog(self, request: HttpRequest, mac):
         """GET maclog"""
 

--- a/services/web/apps/inv/macdb.py
+++ b/services/web/apps/inv/macdb.py
@@ -252,7 +252,7 @@ class MACApplication(ExtApplication):
         r = ch.execute(sql, return_raw=True)
         return orjson.loads(r)
 
-    @api.get(url="^(?P<mac>[0-9A-F:]+)/$", access="view")
+    @api.get("^(?P<mac>[0-9A-F:]+)/$", access="view")
     def api_get_maclog(self, request: HttpRequest, mac):
         """GET maclog"""
 

--- a/services/web/apps/inv/map/views.py
+++ b/services/web/apps/inv/map/views.py
@@ -247,7 +247,7 @@ class MapApplication(ExtApplication):
         }
 
     @api.get(
-        url=r"^info/(?P<inspector>\w+)/(?P<gen_id>[0-9a-f]{24}|\d+)/(?P<r_id>([0-9a-f]{24}|\d+))/$",
+        r"^info/(?P<inspector>\w+)/(?P<gen_id>[0-9a-f]{24}|\d+)/(?P<r_id>([0-9a-f]{24}|\d+))/$",
         access="read",
     )
     def inspector(self, request: HttpRequest, inspector, gen_id, r_id):
@@ -264,7 +264,7 @@ class MapApplication(ExtApplication):
         hi = getattr(self, f"inspector_{inspector}")
         return hi(request, gen_id, r_id)
 
-    @api.get(url=r"^info/segment/(?P<id>[0-9a-f]{24})/$", access="read")
+    @api.get(r"^info/segment/(?P<id>[0-9a-f]{24})/$", access="read")
     def api_info_segment(self, request: HttpRequest, id):
         segment = self.get_object_or_404(NetworkSegment, id=id)
         return {
@@ -273,7 +273,7 @@ class MapApplication(ExtApplication):
             "objects": segment.managed_objects.count(),
         }
 
-    @api.get(url=r"^lookup/$", access="lookup")
+    @api.get(r"^lookup/$", access="lookup")
     def api_lookup(self, request: HttpRequest):
         """
         Lookup available map by generator.
@@ -332,7 +332,7 @@ class MapApplication(ExtApplication):
                 )
             return r
 
-    @api.get(url=r"^(?P<gen_id>[0-9a-f]{24}|\d+)/get_path/$", access="lookup")
+    @api.get(r"^(?P<gen_id>[0-9a-f]{24}|\d+)/get_path/$", access="lookup")
     def api_lookup_maps_get_path(self, request: HttpRequest, gen_id):
         # Parse params
         q = {str(k): v[0] if len(v) == 1 else v for k, v in request.GET.lists()}
@@ -353,7 +353,7 @@ class MapApplication(ExtApplication):
         }
 
     @api.post(
-        url=r"^objects_statuses/$",
+        r"^objects_statuses/$",
         access="read",
         validate={
             "nodes": DictListParameter(
@@ -566,7 +566,7 @@ class MapApplication(ExtApplication):
         return None
 
     @api.post(
-        url=r"^metrics/$",
+        r"^metrics/$",
         access="read",
         validate={
             "metrics": DictListParameter(
@@ -639,7 +639,7 @@ class MapApplication(ExtApplication):
         return r
 
     @api.post(
-        url=r"^stp/status/$", access="read", validate={"objects": ListOfParameter(IntParameter())}
+        r"^stp/status/$", access="read", validate={"objects": ListOfParameter(IntParameter())}
     )
     def api_objects_stp_status(self, request: HttpRequest, objects):
         def get_stp_status(object_id: int) -> tuple[set[int], set[str]]:

--- a/services/web/apps/inv/map/views.py
+++ b/services/web/apps/inv/map/views.py
@@ -19,7 +19,7 @@ from jinja2.exceptions import TemplateError
 from bson import ObjectId
 
 # NOC modules
-from noc.services.web.base.extapplication import ExtApplication, view
+from noc.services.web.base.extapplication import ExtApplication, api
 from noc.inv.models.networksegment import NetworkSegment
 from noc.inv.models.interface import Interface
 from noc.inv.models.discoveryid import DiscoveryID
@@ -70,12 +70,7 @@ class MapApplication(ExtApplication):
     ST_DOWN = 4  # Object is down
     ST_MAINTENANCE = 32  # Maintenance bit
 
-    @view(
-        r"^(?P<gen_type>\w+)/(?P<gen_id>[0-9a-f]{24}|\d+)/data/$",
-        method=["GET"],
-        access="read",
-        api=True,
-    )
+    @api.get(r"^(?P<gen_type>\w+)/(?P<gen_id>[0-9a-f]{24}|\d+)/data/$", access="read")
     def api_data(self, request: HttpRequest, gen_type, gen_id):
         """
         Return data for render map
@@ -88,12 +83,7 @@ class MapApplication(ExtApplication):
         except ValueError as e:
             return {"id": gen_id, "name": f"{gen_type}: {gen_id}", "error": str(e)}
 
-    @view(
-        r"^(?P<gen_type>\w+)/(?P<gen_id>[0-9a-f]{24}|\d+)/data/$",
-        method=["POST"],
-        access="write",
-        api=True,
-    )
+    @api.post(r"^(?P<gen_type>\w+)/(?P<gen_id>[0-9a-f]{24}|\d+)/data/$", access="write")
     def api_save(self, request: HttpRequest, gen_type, gen_id):
         """
         Save Manual layout
@@ -105,12 +95,7 @@ class MapApplication(ExtApplication):
         MapSettings.load_json(data, request.user.username)
         return {"status": True}
 
-    @view(
-        r"^(?P<gen_type>\w+)/(?P<gen_id>[0-9a-f]{24}|\d+)/data/$",
-        method=["DELETE"],
-        access="write",
-        api=True,
-    )
+    @api.delete(r"^(?P<gen_type>\w+)/(?P<gen_id>[0-9a-f]{24}|\d+)/data/$", access="write")
     def api_reset(self, request: HttpRequest, gen_type, gen_id):
         # MapSettings.objects.filter(gen_type=gen_type, gen_id=gen_id).delete()
         settings = MapSettings.objects.filter(gen_type=gen_type, gen_id=gen_id).first()
@@ -261,11 +246,9 @@ class MapApplication(ExtApplication):
             "caps": caps,
         }
 
-    @view(
+    @api.get(
         url=r"^info/(?P<inspector>\w+)/(?P<gen_id>[0-9a-f]{24}|\d+)/(?P<r_id>([0-9a-f]{24}|\d+))/$",
-        method=["GET"],
         access="read",
-        api=True,
     )
     def inspector(self, request: HttpRequest, inspector, gen_id, r_id):
         """
@@ -281,7 +264,7 @@ class MapApplication(ExtApplication):
         hi = getattr(self, f"inspector_{inspector}")
         return hi(request, gen_id, r_id)
 
-    @view(url=r"^info/segment/(?P<id>[0-9a-f]{24})/$", method=["GET"], access="read", api=True)
+    @api.get(url=r"^info/segment/(?P<id>[0-9a-f]{24})/$", access="read")
     def api_info_segment(self, request: HttpRequest, id):
         segment = self.get_object_or_404(NetworkSegment, id=id)
         return {
@@ -290,7 +273,7 @@ class MapApplication(ExtApplication):
             "objects": segment.managed_objects.count(),
         }
 
-    @view(method=["GET"], url=r"^lookup/$", access="lookup", api=True)
+    @api.get(url=r"^lookup/$", access="lookup")
     def api_lookup(self, request: HttpRequest):
         """
         Lookup available map by generator.
@@ -349,9 +332,7 @@ class MapApplication(ExtApplication):
                 )
             return r
 
-    @view(
-        method=["GET"], url=r"^(?P<gen_id>[0-9a-f]{24}|\d+)/get_path/$", access="lookup", api=True
-    )
+    @api.get(url=r"^(?P<gen_id>[0-9a-f]{24}|\d+)/get_path/$", access="lookup")
     def api_lookup_maps_get_path(self, request: HttpRequest, gen_id):
         # Parse params
         q = {str(k): v[0] if len(v) == 1 else v for k, v in request.GET.lists()}
@@ -371,11 +352,9 @@ class MapApplication(ExtApplication):
             ]
         }
 
-    @view(
+    @api.post(
         url=r"^objects_statuses/$",
-        method=["POST"],
         access="read",
-        api=True,
         validate={
             "nodes": DictListParameter(
                 attrs={
@@ -586,11 +565,9 @@ class MapApplication(ExtApplication):
             return i["_id"]
         return None
 
-    @view(
+    @api.post(
         url=r"^metrics/$",
-        method=["POST"],
         access="read",
-        api=True,
         validate={
             "metrics": DictListParameter(
                 attrs={
@@ -661,12 +638,8 @@ class MapApplication(ExtApplication):
             r[pid]["Interface | Load | Out"] = int(metric_map[rq_mo][rq_iface]["load_out"])
         return r
 
-    @view(
-        url=r"^stp/status/$",
-        method=["POST"],
-        access="read",
-        api=True,
-        validate={"objects": ListOfParameter(IntParameter())},
+    @api.post(
+        url=r"^stp/status/$", access="read", validate={"objects": ListOfParameter(IntParameter())}
     )
     def api_objects_stp_status(self, request: HttpRequest, objects):
         def get_stp_status(object_id: int) -> tuple[set[int], set[str]]:

--- a/services/web/apps/inv/networksegment.py
+++ b/services/web/apps/inv/networksegment.py
@@ -10,7 +10,7 @@ from django.db.models import Count
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.inv.models.networksegment import NetworkSegment
 from noc.sa.models.managedobject import ManagedObject
 from noc.sa.models.useraccess import UserAccess
@@ -61,7 +61,7 @@ class NetworkSegmentApplication(ExtDocApplication):
             row["count"] = counts.get(row["id"], 0)
         return data
 
-    @view("^(?P<id>[0-9a-f]{24})/get_path/$", access="read", api=True)
+    @api.get(url=r"^(?P<id>[0-9a-f]{24})/get_path/$", access="read")
     def api_get_path(self, request: HttpRequest, id):
         o = self.get_object_or_404(NetworkSegment, id=id)
         path = [NetworkSegment.get_by_id(ns) for ns in o.get_path()]
@@ -72,7 +72,7 @@ class NetworkSegmentApplication(ExtDocApplication):
             ]
         }
 
-    @view("^(?P<id>[0-9a-f]{24})/effective_settings/$", access="read", api=True)
+    @api.get(url=r"^(?P<id>[0-9a-f]{24})/effective_settings/$", access="read")
     def api_effective_settings(self, request: HttpRequest, id):
         o = self.get_object_or_404(NetworkSegment, id=id)
         return o.effective_settings

--- a/services/web/apps/inv/networksegment.py
+++ b/services/web/apps/inv/networksegment.py
@@ -61,7 +61,7 @@ class NetworkSegmentApplication(ExtDocApplication):
             row["count"] = counts.get(row["id"], 0)
         return data
 
-    @api.get(url=r"^(?P<id>[0-9a-f]{24})/get_path/$", access="read")
+    @api.get(r"^(?P<id>[0-9a-f]{24})/get_path/$", access="read")
     def api_get_path(self, request: HttpRequest, id):
         o = self.get_object_or_404(NetworkSegment, id=id)
         path = [NetworkSegment.get_by_id(ns) for ns in o.get_path()]
@@ -72,7 +72,7 @@ class NetworkSegmentApplication(ExtDocApplication):
             ]
         }
 
-    @api.get(url=r"^(?P<id>[0-9a-f]{24})/effective_settings/$", access="read")
+    @api.get(r"^(?P<id>[0-9a-f]{24})/effective_settings/$", access="read")
     def api_effective_settings(self, request: HttpRequest, id):
         o = self.get_object_or_404(NetworkSegment, id=id)
         return o.effective_settings

--- a/services/web/apps/inv/objectmodel.py
+++ b/services/web/apps/inv/objectmodel.py
@@ -137,7 +137,7 @@ class ObjectModelApplication(ExtDocApplication):
             del q["is_container"]
         return super().cleaned_query(q)
 
-    @api.get(url="^(?P<id>[0-9a-f]{24})/compatible/$", access="read")
+    @api.get("^(?P<id>[0-9a-f]{24})/compatible/$", access="read")
     def api_compatible(self, request: HttpRequest, id):
         o = self.get_object_or_404(ObjectModel, id=id)
         # Connections
@@ -182,7 +182,7 @@ class ObjectModelApplication(ExtDocApplication):
         return {"connections": r, "crossing": rc}
 
     @api.post(
-        url="^actions/json/$",
+        "^actions/json/$",
         access="read",
         validate={"ids": ListOfParameter(element=DocumentParameter(ObjectModel), convert=True)},
     )
@@ -191,7 +191,7 @@ class ObjectModelApplication(ExtDocApplication):
         s = to_json(r, order=["name", "vendor__code", "description"])
         return {"data": s}
 
-    @api.get(url="^(?P<id>[0-9a-f]{24})/(?P<name>front|rear)/template.svg$", access="read")
+    @api.get("^(?P<id>[0-9a-f]{24})/(?P<name>front|rear)/template.svg$", access="read")
     def api_template(self, request: HttpRequest, id: str, name: str):
         o = self.get_object_or_404(ObjectModel, id=id)
         last_part = o.name.split("|")[-1].strip()
@@ -206,7 +206,7 @@ class ObjectModelApplication(ExtDocApplication):
             status=200,
         )
 
-    @api.get(url="^(?P<id>[0-9a-f]{24})/is_valid_template/$", access="read")
+    @api.get("^(?P<id>[0-9a-f]{24})/is_valid_template/$", access="read")
     def api_is_valid_template(self, request: HttpRequest, id: str):
         o = self.get_object_or_404(ObjectModel, id=id)
         return self.render_json({"status": is_valid_model_for_template(o)})

--- a/services/web/apps/inv/objectmodel.py
+++ b/services/web/apps/inv/objectmodel.py
@@ -14,7 +14,7 @@ from mongoengine.queryset import Q
 from django.http import HttpResponse, HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.main.models.doccategory import DocCategory
 from noc.inv.models.objectmodel import ObjectModel, ProtocolVariantItem, ContainerType
 from noc.inv.models.modelinterface import ModelInterface
@@ -137,7 +137,7 @@ class ObjectModelApplication(ExtDocApplication):
             del q["is_container"]
         return super().cleaned_query(q)
 
-    @view(url="^(?P<id>[0-9a-f]{24})/compatible/$", method=["GET"], access="read", api=True)
+    @api.get(url="^(?P<id>[0-9a-f]{24})/compatible/$", access="read")
     def api_compatible(self, request: HttpRequest, id):
         o = self.get_object_or_404(ObjectModel, id=id)
         # Connections
@@ -181,24 +181,17 @@ class ObjectModelApplication(ExtDocApplication):
         #         rc += [{"y": c.name, "x": c.cross, "v": "1"}]
         return {"connections": r, "crossing": rc}
 
-    @view(
+    @api.post(
         url="^actions/json/$",
-        method=["POST"],
         access="read",
         validate={"ids": ListOfParameter(element=DocumentParameter(ObjectModel), convert=True)},
-        api=True,
     )
     def api_action_json(self, request: HttpRequest, ids):
         r = [o.json_data for o in ids]
         s = to_json(r, order=["name", "vendor__code", "description"])
         return {"data": s}
 
-    @view(
-        url="^(?P<id>[0-9a-f]{24})/(?P<name>front|rear)/template.svg$",
-        method=["GET"],
-        access="read",
-        api=True,
-    )
+    @api.get(url="^(?P<id>[0-9a-f]{24})/(?P<name>front|rear)/template.svg$", access="read")
     def api_template(self, request: HttpRequest, id: str, name: str):
         o = self.get_object_or_404(ObjectModel, id=id)
         last_part = o.name.split("|")[-1].strip()
@@ -213,12 +206,7 @@ class ObjectModelApplication(ExtDocApplication):
             status=200,
         )
 
-    @view(
-        url="^(?P<id>[0-9a-f]{24})/is_valid_template/$",
-        method=["GET"],
-        access="read",
-        api=True,
-    )
+    @api.get(url="^(?P<id>[0-9a-f]{24})/is_valid_template/$", access="read")
     def api_is_valid_template(self, request: HttpRequest, id: str):
         o = self.get_object_or_404(ObjectModel, id=id)
         return self.render_json({"status": is_valid_model_for_template(o)})

--- a/services/web/apps/inv/protocol.py
+++ b/services/web/apps/inv/protocol.py
@@ -70,7 +70,7 @@ class ProtocolApplication(ExtDocApplication):
         # Clean other
         return super().clean(data)
 
-    @api.get(url="^lookup_tree/", access=True)
+    @api.get("^lookup_tree/", access=True)
     def api_protocols_lookup_tree(self, request: HttpRequest):
         r = {}
         protocol_filter = {}

--- a/services/web/apps/inv/protocol.py
+++ b/services/web/apps/inv/protocol.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.inv.models.protocol import Protocol
 from noc.inv.models.modelinterface import ModelInterface
 from noc.core.translation import ugettext as _
@@ -70,7 +70,7 @@ class ProtocolApplication(ExtDocApplication):
         # Clean other
         return super().clean(data)
 
-    @view(url="^lookup_tree/", method=["GET"], access=True)
+    @api.get(url="^lookup_tree/", access=True)
     def api_protocols_lookup_tree(self, request: HttpRequest):
         r = {}
         protocol_filter = {}

--- a/services/web/apps/inv/reportifacestatus.py
+++ b/services/web/apps/inv/reportifacestatus.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # inv.reportinterfacestatus
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -20,7 +20,7 @@ from bson import ObjectId
 import xlsxwriter
 
 # NOC modules
-from noc.services.web.base.extapplication import ExtApplication, view
+from noc.services.web.base.extapplication import ExtApplication, api
 from noc.inv.models.interfaceprofile import InterfaceProfile
 from noc.inv.models.interface import Interface
 from noc.sa.models.managedobject import ManagedObject
@@ -99,11 +99,9 @@ class ReportInterfaceStatusApplication(ExtApplication):
     menu = _("Reports") + "|" + _("Interface Status")
     title = _("Interface Status")
 
-    @view(
+    @api.get(
         "^download/$",
-        method=["GET"],
         access="launch",
-        api=True,
         validate={
             "administrative_domain": StringParameter(required=False),
             "interface_profile": StringParameter(required=False),

--- a/services/web/apps/inv/reportlinkdetail.py
+++ b/services/web/apps/inv/reportlinkdetail.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # fm.reportobjectdetail application
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2025 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -20,7 +20,7 @@ import xlsxwriter
 
 # NOC modules
 from noc.core.mongo.connection import get_db
-from noc.services.web.base.extapplication import ExtApplication, view
+from noc.services.web.base.extapplication import ExtApplication, api
 from noc.main.models.pool import Pool
 from noc.sa.models.managedobject import ManagedObject
 from noc.inv.models.resourcegroup import ResourceGroup
@@ -115,11 +115,9 @@ class ReportLinkDetailApplication(ExtApplication):
     SEGMENT_PATH_DEPTH = 7
     CONTAINER_PATH_DEPTH = 7
 
-    @view(
+    @api.get(
         "^download/$",
-        method=["GET"],
         access="launch",
-        api=True,
         validate={
             "administrative_domain": StringParameter(required=False),
             "pool": StringParameter(required=False),

--- a/services/web/apps/inv/reportmaxmetrics.py
+++ b/services/web/apps/inv/reportmaxmetrics.py
@@ -62,7 +62,7 @@ class ReportMaxMetricsmaxDetailApplication(ExtApplication):
     title = _("Load Metrics max")
 
     @api.get(
-        url=r"^download/$",
+        r"^download/$",
         access="launch",
         validate={
             "from_date": StringParameter(required=True),

--- a/services/web/apps/inv/reportmaxmetrics.py
+++ b/services/web/apps/inv/reportmaxmetrics.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # inv.reportmaxmetrics
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2024 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -27,7 +27,7 @@ from noc.services.web.base.reportdatasources.report_metrics import ReportInterfa
 from noc.sa.models.managedobject import ManagedObject
 from noc.services.web.base.reportdatasources.report_container import ReportContainerData
 from noc.sa.models.useraccess import UserAccess
-from noc.services.web.base.extapplication import ExtApplication, view
+from noc.services.web.base.extapplication import ExtApplication, api
 from noc.sa.interfaces.base import StringParameter, BooleanParameter
 from noc.core.comp import smart_text
 from noc.inv.models.resourcegroup import ResourceGroup
@@ -61,11 +61,9 @@ class ReportMaxMetricsmaxDetailApplication(ExtApplication):
     menu = _("Reports") + "|" + _("Load Metrics max")
     title = _("Load Metrics max")
 
-    @view(
-        r"^download/$",
-        method=["GET"],
+    @api.get(
+        url=r"^download/$",
         access="launch",
-        api=True,
         validate={
             "from_date": StringParameter(required=True),
             "to_date": StringParameter(required=True),

--- a/services/web/apps/inv/reportmetrics.py
+++ b/services/web/apps/inv/reportmetrics.py
@@ -76,7 +76,7 @@ class ReportMetricsDetailApplication(ExtApplication):
     }
 
     @api.get(
-        url=r"^download/$",
+        r"^download/$",
         access="launch",
         validate={
             "from_date": StringParameter(required=True),

--- a/services/web/apps/inv/reportmetrics.py
+++ b/services/web/apps/inv/reportmetrics.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # inv.reportmetrics
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2025 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -26,7 +26,7 @@ from noc.inv.models.networksegment import NetworkSegment
 from noc.inv.models.resourcegroup import ResourceGroup
 from noc.services.web.base.reportdatasources.loader import loader
 from noc.services.web.base.reportdatasources.report_container import ReportContainerData
-from noc.services.web.base.extapplication import ExtApplication, view
+from noc.services.web.base.extapplication import ExtApplication, api
 from noc.sa.models.useraccess import UserAccess
 from noc.sa.interfaces.base import StringParameter, BooleanParameter
 from noc.sa.models.administrativedomain import AdministrativeDomain
@@ -75,11 +75,9 @@ class ReportMetricsDetailApplication(ExtApplication):
         },
     }
 
-    @view(
-        r"^download/$",
-        method=["GET"],
+    @api.get(
+        url=r"^download/$",
         access="launch",
-        api=True,
         validate={
             "from_date": StringParameter(required=True),
             "to_date": StringParameter(required=True),

--- a/services/web/apps/inv/reportmovedmac.py
+++ b/services/web/apps/inv/reportmovedmac.py
@@ -153,7 +153,7 @@ class ReportMovedMacApplication(ExtApplication):
         return mos
 
     @api.get(
-        url=r"^download/$",
+        r"^download/$",
         access="launch",
         validate={
             "from_date": StringParameter(required=True),

--- a/services/web/apps/inv/reportmovedmac.py
+++ b/services/web/apps/inv/reportmovedmac.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # fm.reportmovedmac application
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -25,7 +25,7 @@ from django.http import HttpResponse
 from noc.core.clickhouse.connect import connection
 from noc.core.mac import MAC
 from noc.main.models.pool import Pool
-from noc.services.web.base.extapplication import ExtApplication, view
+from noc.services.web.base.extapplication import ExtApplication, api
 from noc.sa.interfaces.base import StringParameter, BooleanParameter
 from noc.sa.models.managedobject import ManagedObject
 from noc.inv.models.resourcegroup import ResourceGroup
@@ -152,11 +152,9 @@ class ReportMovedMacApplication(ExtApplication):
                 mos = mos.filter(segment__in=segment.get_nested_ids())
         return mos
 
-    @view(
-        r"^download/$",
-        method=["GET"],
+    @api.get(
+        url=r"^download/$",
         access="launch",
-        api=True,
         validate={
             "from_date": StringParameter(required=True),
             "to_date": StringParameter(required=True),

--- a/services/web/apps/inv/resourcegroup.py
+++ b/services/web/apps/inv/resourcegroup.py
@@ -9,7 +9,7 @@
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.inv.models.resourcegroup import ResourceGroup
 from noc.core.comp import smart_text
 from noc.main.models.label import MATCH_BADGES, MATCH_OPS
@@ -113,7 +113,7 @@ class ResourceGroupApplication(ExtDocApplication):
     def instance_to_lookup(self, o, fields=None):
         return {"id": str(o.id), "label": smart_text(o), "has_children": o.has_children}
 
-    @view("^(?P<id>[0-9a-f]{24})/get_path/$", access="read", api=True)
+    @api.get(url=r"^(?P<id>[0-9a-f]{24})/get_path/$", access="read")
     def api_get_path(self, request: HttpRequest, id):
         o = self.get_object_or_404(ResourceGroup, id=id)
         path = [ResourceGroup.get_by_id(rg) for rg in o.get_path()]

--- a/services/web/apps/inv/resourcegroup.py
+++ b/services/web/apps/inv/resourcegroup.py
@@ -113,7 +113,7 @@ class ResourceGroupApplication(ExtDocApplication):
     def instance_to_lookup(self, o, fields=None):
         return {"id": str(o.id), "label": smart_text(o), "has_children": o.has_children}
 
-    @api.get(url=r"^(?P<id>[0-9a-f]{24})/get_path/$", access="read")
+    @api.get(r"^(?P<id>[0-9a-f]{24})/get_path/$", access="read")
     def api_get_path(self, request: HttpRequest, id):
         o = self.get_object_or_404(ResourceGroup, id=id)
         path = [ResourceGroup.get_by_id(rg) for rg in o.get_path()]

--- a/services/web/apps/inv/unknownmodel.py
+++ b/services/web/apps/inv/unknownmodel.py
@@ -9,7 +9,7 @@
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.inv.models.unknownmodel import UnknownModel
 from noc.sa.interfaces.base import ListOfParameter, DocumentParameter
 from noc.core.translation import ugettext as _
@@ -27,11 +27,9 @@ class UnknownModelApplication(ExtDocApplication):
     query_condition = "icontains"
     query_fields = ["vendor", "managed_object", "platform", "part_no", "description"]
 
-    @view(
+    @api.post(
         url="^actions/remove/$",
-        method=["POST"],
         access="launch",
-        api=True,
         validate={"ids": ListOfParameter(element=DocumentParameter(UnknownModel), convert=True)},
     )
     def api_action_run_discovery(self, request: HttpRequest, ids):

--- a/services/web/apps/inv/unknownmodel.py
+++ b/services/web/apps/inv/unknownmodel.py
@@ -28,7 +28,7 @@ class UnknownModelApplication(ExtDocApplication):
     query_fields = ["vendor", "managed_object", "platform", "part_no", "description"]
 
     @api.post(
-        url="^actions/remove/$",
+        "^actions/remove/$",
         access="launch",
         validate={"ids": ListOfParameter(element=DocumentParameter(UnknownModel), convert=True)},
     )

--- a/services/web/apps/inv/vendor.py
+++ b/services/web/apps/inv/vendor.py
@@ -9,7 +9,7 @@
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.inv.models.vendor import Vendor
 from noc.core.translation import ugettext as _
 
@@ -25,7 +25,7 @@ class VendorApplication(ExtDocApplication):
     query_fields = ["name__icontains", "code__icontains", "site__icontains"]
     default_ordering = ["name"]
 
-    @view(url="^(?P<id>[0-9a-f]{24})/json/$", method=["GET"], access="read", api=True)
+    @api.get(url="^(?P<id>[0-9a-f]{24})/json/$", access="read")
     def api_json(self, request: HttpRequest, id):
         vendor = self.get_object_or_404(Vendor, id=id)
         return vendor.to_json()

--- a/services/web/apps/inv/vendor.py
+++ b/services/web/apps/inv/vendor.py
@@ -25,7 +25,7 @@ class VendorApplication(ExtDocApplication):
     query_fields = ["name__icontains", "code__icontains", "site__icontains"]
     default_ordering = ["name"]
 
-    @api.get(url="^(?P<id>[0-9a-f]{24})/json/$", access="read")
+    @api.get("^(?P<id>[0-9a-f]{24})/json/$", access="read")
     def api_json(self, request: HttpRequest, id):
         vendor = self.get_object_or_404(Vendor, id=id)
         return vendor.to_json()

--- a/services/web/apps/ip/ipam.py
+++ b/services/web/apps/ip/ipam.py
@@ -23,7 +23,7 @@ from noc.ip.models.vrf import VRF
 from noc.main.models.customfield import CustomField
 
 # NOC modules
-from noc.services.web.base.extapplication import ExtApplication, view
+from noc.services.web.base.extapplication import ExtApplication, view, api
 
 
 class IPAMApplication(ExtApplication):
@@ -53,7 +53,7 @@ class IPAMApplication(ExtApplication):
             [a.address for a in prefix.address_set.all()] + extra, dist=dist, sep=sep
         )
 
-    @view(url=r"^(?P<prefix_id>\d+)/toggle_bookmark/$", method=["GET"], api=True, access="launch")
+    @api.get(url=r"^(?P<prefix_id>\d+)/toggle_bookmark/$", access="launch")
     def view_toggle_bookmark(self, request: HttpRequest, prefix_id):
         """
         Toggle block bookmark status
@@ -62,10 +62,8 @@ class IPAMApplication(ExtApplication):
         prefix.toggle_bookmark(request.user)
         return {"has_bookmark": prefix.has_bookmark(request.user)}
 
-    @view(
+    @api.get(
         url=r"get_vrf_prefix/(?P<vrf_id>\d+)/(?P<afi>[46])/(?:(?P<prefix>[0-9a-f.:/]+)/)?$",
-        method=["GET"],
-        api=True,
         access="launch",
     )
     def get_vrf_prefix(self, request: HttpRequest, vrf_id, afi, prefix=None):
@@ -80,7 +78,7 @@ class IPAMApplication(ExtApplication):
         prefix = self.get_object_or_404(Prefix, vrf=vrf, afi=afi, prefix=prefix)
         return self.prefix_contents(request, prefix=prefix)
 
-    @view(url=r"^contents/(?P<prefix_id>\d+)/$", method=["GET"], api=True, access="launch")
+    @api.get(url=r"^contents/(?P<prefix_id>\d+)/$", access="launch")
     def get_prefix_content(self, request: HttpRequest, prefix_id):
         prefix = self.get_object_or_404(Prefix, id=int(prefix_id))
         return self.prefix_contents(request, prefix=prefix)

--- a/services/web/apps/ip/ipam.py
+++ b/services/web/apps/ip/ipam.py
@@ -53,7 +53,7 @@ class IPAMApplication(ExtApplication):
             [a.address for a in prefix.address_set.all()] + extra, dist=dist, sep=sep
         )
 
-    @api.get(url=r"^(?P<prefix_id>\d+)/toggle_bookmark/$", access="launch")
+    @api.get(r"^(?P<prefix_id>\d+)/toggle_bookmark/$", access="launch")
     def view_toggle_bookmark(self, request: HttpRequest, prefix_id):
         """
         Toggle block bookmark status
@@ -63,7 +63,7 @@ class IPAMApplication(ExtApplication):
         return {"has_bookmark": prefix.has_bookmark(request.user)}
 
     @api.get(
-        url=r"get_vrf_prefix/(?P<vrf_id>\d+)/(?P<afi>[46])/(?:(?P<prefix>[0-9a-f.:/]+)/)?$",
+        r"get_vrf_prefix/(?P<vrf_id>\d+)/(?P<afi>[46])/(?:(?P<prefix>[0-9a-f.:/]+)/)?$",
         access="launch",
     )
     def get_vrf_prefix(self, request: HttpRequest, vrf_id, afi, prefix=None):
@@ -78,7 +78,7 @@ class IPAMApplication(ExtApplication):
         prefix = self.get_object_or_404(Prefix, vrf=vrf, afi=afi, prefix=prefix)
         return self.prefix_contents(request, prefix=prefix)
 
-    @api.get(url=r"^contents/(?P<prefix_id>\d+)/$", access="launch")
+    @api.get(r"^contents/(?P<prefix_id>\d+)/$", access="launch")
     def get_prefix_content(self, request: HttpRequest, prefix_id):
         prefix = self.get_object_or_404(Prefix, id=int(prefix_id))
         return self.prefix_contents(request, prefix=prefix)

--- a/services/web/apps/ip/prefix.py
+++ b/services/web/apps/ip/prefix.py
@@ -46,7 +46,7 @@ class PrefixApplication(ExtModelApplication):
         return qs.filter(PrefixAccess.read_Q(request.user))
 
     @api.post(
-        url=r"^(?P<prefix_id>\d+)/rebase/$",
+        r"^(?P<prefix_id>\d+)/rebase/$",
         access="rebase",
         validate={"to_vrf": ModelParameter(VRF), "to_prefix": PrefixParameter()},
     )
@@ -58,7 +58,7 @@ class PrefixApplication(ExtModelApplication):
         except ValueError as e:
             return self.response_bad_request(str(e))
 
-    @api.get(url=r"^(?P<prefix_id>\d+)/suggest_free/$", access="read")
+    @api.get(r"^(?P<prefix_id>\d+)/suggest_free/$", access="read")
     def api_suggest_free(self, request: HttpRequest, prefix_id):
         """
         Suggest free blocks of different sizes
@@ -86,7 +86,7 @@ class PrefixApplication(ExtModelApplication):
                     break
         return suggestions
 
-    @api.delete(url=r"^(?P<id>\d+)/recursive/$", access="delete")
+    @api.delete(r"^(?P<id>\d+)/recursive/$", access="delete")
     def api_delete_recursive(self, request: HttpRequest, id):
         try:
             o = self.queryset(request).get(**{self.pk: int(id)})
@@ -107,7 +107,7 @@ class PrefixApplication(ExtModelApplication):
             )
         return HttpResponse(status=self.DELETED)
 
-    @api.get(url=r"^(?P<id>\d+)/get_path/$", access="read")
+    @api.get(r"^(?P<id>\d+)/get_path/$", access="read")
     def api_get_path(self, request: HttpRequest, id):
         o = self.get_object_or_404(Prefix, id=int(id))
         try:

--- a/services/web/apps/ip/prefix.py
+++ b/services/web/apps/ip/prefix.py
@@ -12,7 +12,7 @@ from operator import attrgetter
 from django.http import HttpResponse, HttpRequest
 
 # NOC modules
-from noc.services.web.base.extmodelapplication import ExtModelApplication, view
+from noc.services.web.base.extmodelapplication import ExtModelApplication, api
 from noc.ip.models.vrf import VRF
 from noc.ip.models.prefix import Prefix
 from noc.ip.models.prefixaccess import PrefixAccess
@@ -45,11 +45,9 @@ class PrefixApplication(ExtModelApplication):
         qs = super().queryset(request, query=query)
         return qs.filter(PrefixAccess.read_Q(request.user))
 
-    @view(
+    @api.post(
         url=r"^(?P<prefix_id>\d+)/rebase/$",
-        method=["POST"],
         access="rebase",
-        api=True,
         validate={"to_vrf": ModelParameter(VRF), "to_prefix": PrefixParameter()},
     )
     def api_rebase(self, request: HttpRequest, prefix_id, to_vrf, to_prefix):
@@ -60,7 +58,7 @@ class PrefixApplication(ExtModelApplication):
         except ValueError as e:
             return self.response_bad_request(str(e))
 
-    @view(url=r"^(?P<prefix_id>\d+)/suggest_free/$", method=["GET"], access="read", api=True)
+    @api.get(url=r"^(?P<prefix_id>\d+)/suggest_free/$", access="read")
     def api_suggest_free(self, request: HttpRequest, prefix_id):
         """
         Suggest free blocks of different sizes
@@ -88,7 +86,7 @@ class PrefixApplication(ExtModelApplication):
                     break
         return suggestions
 
-    @view(method=["DELETE"], url=r"^(?P<id>\d+)/recursive/$", access="delete", api=True)
+    @api.delete(url=r"^(?P<id>\d+)/recursive/$", access="delete")
     def api_delete_recursive(self, request: HttpRequest, id):
         try:
             o = self.queryset(request).get(**{self.pk: int(id)})
@@ -109,7 +107,7 @@ class PrefixApplication(ExtModelApplication):
             )
         return HttpResponse(status=self.DELETED)
 
-    @view(r"^(?P<id>\d+)/get_path/$", access="read", api=True)
+    @api.get(url=r"^(?P<id>\d+)/get_path/$", access="read")
     def api_get_path(self, request: HttpRequest, id):
         o = self.get_object_or_404(Prefix, id=int(id))
         try:

--- a/services/web/apps/ip/vrf.py
+++ b/services/web/apps/ip/vrf.py
@@ -45,7 +45,7 @@ class VRFApplication(ExtModelApplication):
         return super().clean(data)
 
     @api.post(
-        url="^bulk/import/$",
+        "^bulk/import/$",
         access="import",
         validate={
             "items": ListOfParameter(

--- a/services/web/apps/ip/vrf.py
+++ b/services/web/apps/ip/vrf.py
@@ -9,7 +9,7 @@
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extmodelapplication import ExtModelApplication, view
+from noc.services.web.base.extmodelapplication import ExtModelApplication, api
 from noc.ip.models.vrfgroup import VRFGroup
 from noc.ip.models.vrf import VRF
 from noc.sa.interfaces.base import (
@@ -44,11 +44,9 @@ class VRFApplication(ExtModelApplication):
             data["vpn_id"] = get_vpn_id(vdata)
         return super().clean(data)
 
-    @view(
+    @api.post(
         url="^bulk/import/$",
-        method=["POST"],
         access="import",
-        api=True,
         validate={
             "items": ListOfParameter(
                 element=DictParameter(

--- a/services/web/apps/kb/kbentry.py
+++ b/services/web/apps/kb/kbentry.py
@@ -43,7 +43,7 @@ class KBEntryApplication(ExtModelApplication):
         ]
         return r
 
-    @api.get(url=r"^(?P<id>\d+)/history/$", access="read")
+    @api.get(r"^(?P<id>\d+)/history/$", access="read")
     def api_get_entry_history(self, request: HttpRequest, id):
         o = self.get_object_or_404(KBEntry, id=id)
         return {
@@ -53,16 +53,16 @@ class KBEntryApplication(ExtModelApplication):
             ]
         }
 
-    @api.get(url=r"^(?P<id>\d+)/html/$", access="read")
+    @api.get(r"^(?P<id>\d+)/html/$", access="read")
     def api_get_entry_html(self, request: HttpRequest, id):
         o = self.get_object_or_404(KBEntry, id=id)
         return self.render_plain_text(o.html)
 
-    @api.get(url=r"^most_popular/$", access="read")
+    @api.get(r"^most_popular/$", access="read")
     def api_get_most_popular(self, request: HttpRequest):
         return KBEntry.most_popular()
 
-    @api.get(url=r"^(?P<id>\d+)/attachments/$", access="read")
+    @api.get(r"^(?P<id>\d+)/attachments/$", access="read")
     def api_list_attachments(self, request: HttpRequest, id):
         o = self.get_object_or_404(KBEntry, id=id)
         return [
@@ -75,7 +75,7 @@ class KBEntryApplication(ExtModelApplication):
             for x in KBEntryAttachment.objects.filter(kb_entry=o, is_hidden=False).order_by("name")
         ]
 
-    @api.get(url=r"^(?P<id>\d+)/attachment/(?P<name>.+)/$", access="read")
+    @api.get(r"^(?P<id>\d+)/attachment/(?P<name>.+)/$", access="read")
     def api_get_attachment(self, request: HttpRequest, id, name):
         o = self.get_object_or_404(KBEntry, id=id)
         attach = self.get_object_or_404(KBEntryAttachment, kb_entry=o, name=name)
@@ -84,14 +84,14 @@ class KBEntryApplication(ExtModelApplication):
         response["Content-Disposition"] = f'attachment; filename="{attach.file.name}"'
         return response
 
-    @api.delete(url=r"^(?P<id>\d+)/attachment/(?P<name>.+)/$", access="delete")
+    @api.delete(r"^(?P<id>\d+)/attachment/(?P<name>.+)/$", access="delete")
     def api_delete_attachment(self, request: HttpRequest, id, name):
         o = self.get_object_or_404(KBEntry, id=id)
         attach = self.get_object_or_404(KBEntryAttachment, kb_entry=o, name=name)
         attach.delete()
         return self.response({"result": "Delete succesful"}, status=self.OK)
 
-    @api.post(url=r"^(?P<id>\d+)/attach/$", access="write")
+    @api.post(r"^(?P<id>\d+)/attach/$", access="write")
     def api_post_set_attachment(self, request: HttpRequest, id):
         o = self.get_object_or_404(KBEntry, id=id)
         attach = KBEntryAttachment(
@@ -122,6 +122,6 @@ class KBEntryApplication(ExtModelApplication):
                 attach.save()
         return True
 
-    @api.post(url=r"^(?P<id>\d+)/?$", access="update")
+    @api.post(r"^(?P<id>\d+)/?$", access="update")
     def api_post_update(self, request: HttpRequest, id):
         return self.api_update(request, id)

--- a/services/web/apps/kb/kbentry.py
+++ b/services/web/apps/kb/kbentry.py
@@ -13,7 +13,7 @@ from django.http import HttpResponse, HttpRequest
 import mimetypes
 
 # NOC modules
-from noc.services.web.base.extmodelapplication import ExtModelApplication, view
+from noc.services.web.base.extmodelapplication import ExtModelApplication, api
 from noc.kb.models.kbentry import KBEntry
 from noc.kb.models.kbentryhistory import KBEntryHistory
 from noc.kb.models.kbentryattachment import KBEntryAttachment
@@ -43,7 +43,7 @@ class KBEntryApplication(ExtModelApplication):
         ]
         return r
 
-    @view(r"^(?P<id>\d+)/history/$", access="read", api=True)
+    @api.get(url=r"^(?P<id>\d+)/history/$", access="read")
     def api_get_entry_history(self, request: HttpRequest, id):
         o = self.get_object_or_404(KBEntry, id=id)
         return {
@@ -53,16 +53,16 @@ class KBEntryApplication(ExtModelApplication):
             ]
         }
 
-    @view(r"^(?P<id>\d+)/html/$", access="read", api=True)
+    @api.get(url=r"^(?P<id>\d+)/html/$", access="read")
     def api_get_entry_html(self, request: HttpRequest, id):
         o = self.get_object_or_404(KBEntry, id=id)
         return self.render_plain_text(o.html)
 
-    @view(r"^most_popular/$", access="read", api=True)
+    @api.get(url=r"^most_popular/$", access="read")
     def api_get_most_popular(self, request: HttpRequest):
         return KBEntry.most_popular()
 
-    @view(r"^(?P<id>\d+)/attachments/$", access="read", api=True, method=["GET"])
+    @api.get(url=r"^(?P<id>\d+)/attachments/$", access="read")
     def api_list_attachments(self, request: HttpRequest, id):
         o = self.get_object_or_404(KBEntry, id=id)
         return [
@@ -75,7 +75,7 @@ class KBEntryApplication(ExtModelApplication):
             for x in KBEntryAttachment.objects.filter(kb_entry=o, is_hidden=False).order_by("name")
         ]
 
-    @view(r"^(?P<id>\d+)/attachment/(?P<name>.+)/$", access="read", api=True, method=["GET"])
+    @api.get(url=r"^(?P<id>\d+)/attachment/(?P<name>.+)/$", access="read")
     def api_get_attachment(self, request: HttpRequest, id, name):
         o = self.get_object_or_404(KBEntry, id=id)
         attach = self.get_object_or_404(KBEntryAttachment, kb_entry=o, name=name)
@@ -84,14 +84,14 @@ class KBEntryApplication(ExtModelApplication):
         response["Content-Disposition"] = f'attachment; filename="{attach.file.name}"'
         return response
 
-    @view(r"^(?P<id>\d+)/attachment/(?P<name>.+)/$", access="delete", api=True, method=["DELETE"])
+    @api.delete(url=r"^(?P<id>\d+)/attachment/(?P<name>.+)/$", access="delete")
     def api_delete_attachment(self, request: HttpRequest, id, name):
         o = self.get_object_or_404(KBEntry, id=id)
         attach = self.get_object_or_404(KBEntryAttachment, kb_entry=o, name=name)
         attach.delete()
         return self.response({"result": "Delete succesful"}, status=self.OK)
 
-    @view(r"^(?P<id>\d+)/attach/$", access="write", api=True, method=["POST"])
+    @api.post(url=r"^(?P<id>\d+)/attach/$", access="write")
     def api_post_set_attachment(self, request: HttpRequest, id):
         o = self.get_object_or_404(KBEntry, id=id)
         attach = KBEntryAttachment(
@@ -122,6 +122,6 @@ class KBEntryApplication(ExtModelApplication):
                 attach.save()
         return True
 
-    @view(r"^(?P<id>\d+)/?$", access="update", api=True, method=["POST"])
+    @api.post(url=r"^(?P<id>\d+)/?$", access="update")
     def api_post_update(self, request: HttpRequest, id):
         return self.api_update(request, id)

--- a/services/web/apps/main/apitoken.py
+++ b/services/web/apps/main/apitoken.py
@@ -9,7 +9,7 @@
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extapplication import ExtApplication, view
+from noc.services.web.base.extapplication import ExtApplication, api
 from noc.services.web.base.access import PermitLogged
 from noc.main.models.apitoken import APIToken
 from noc.sa.interfaces.base import StringParameter
@@ -20,20 +20,14 @@ class APITokenApplication(ExtApplication):
     APIToken Application
     """
 
-    @view("^(?P<type>[^/]+)/$", method=["GET"], access=PermitLogged(), api=True)
+    @api.get("^(?P<type>[^/]+)/$", access=PermitLogged())
     def api_get_token(self, request: HttpRequest, type):
         token = APIToken.objects.filter(type=type, user=request.user.id).first()
         if token:
             return {"type": token.type, "token": token.token}
         self.response_not_found()
 
-    @view(
-        "^(?P<type>[^/]+)/$",
-        method=["POST"],
-        access=PermitLogged(),
-        validate={"token": StringParameter()},
-        api=True,
-    )
+    @api.post("^(?P<type>[^/]+)/$", access=PermitLogged(), validate={"token": StringParameter()})
     def api_set_token(self, request: HttpRequest, type, token=None):
         APIToken._get_collection().update_many(
             {"type": type, "user": request.user.id}, {"$set": {"token": token}}, upsert=True

--- a/services/web/apps/main/audittrail.py
+++ b/services/web/apps/main/audittrail.py
@@ -110,6 +110,6 @@ class AuditTrailApplication(ExtApplication):
             status=self.OK,
         )
 
-    @api.get(url=r"^$", access="read")
+    @api.get(r"^$", access="read")
     def api_list(self, request: HttpRequest):
         return self.list_data(request, None)

--- a/services/web/apps/main/audittrail.py
+++ b/services/web/apps/main/audittrail.py
@@ -13,7 +13,7 @@ from django.http import HttpRequest
 import orjson
 
 # NOC modules
-from noc.services.web.base.extapplication import ExtApplication, view
+from noc.services.web.base.extapplication import ExtApplication, api
 from noc.core.translation import ugettext as _
 from noc.core.clickhouse.connect import connection
 from noc.models import get_object, get_model
@@ -110,6 +110,6 @@ class AuditTrailApplication(ExtApplication):
             status=self.OK,
         )
 
-    @view(method=["GET"], url=r"^$", access="read", api=True)
+    @api.get(url=r"^$", access="read")
     def api_list(self, request: HttpRequest):
         return self.list_data(request, None)

--- a/services/web/apps/main/desktop/views.py
+++ b/services/web/apps/main/desktop/views.py
@@ -60,7 +60,7 @@ class DesktopApplication(ExtApplication):
             return config.language
         return request.user.preferred_language or config.language
 
-    @api.get(url="/index.html", url_name="desktop", access=True)
+    @api.get("/index.html", url_name="desktop", access=True)
     def view_desktop(self, request: HttpRequest):
         """
         Render application root template
@@ -73,7 +73,7 @@ class DesktopApplication(ExtApplication):
             brand=version.brand,
         )
 
-    @api.get(url="^settings/$", access=True)
+    @api.get("^settings/$", access=True)
     def api_settings(self, request: HttpRequest):
         cp = CPClient()
         if request.user.is_authenticated():
@@ -142,7 +142,7 @@ class DesktopApplication(ExtApplication):
             "color_scheme": Style.get_scheme(),
         }
 
-    @api.get(url="^version/$", access=True)
+    @api.get("^version/$", access=True)
     def api_version(self, request: HttpRequest):
         """
         Return current NOC version
@@ -151,7 +151,7 @@ class DesktopApplication(ExtApplication):
         """
         return version.version
 
-    @api.get(url="^is_logged/$", access=True)
+    @api.get("^is_logged/$", access=True)
     def api_is_logged(self, request: HttpRequest):
         """
         Check wrether the session is authenticated.
@@ -160,7 +160,7 @@ class DesktopApplication(ExtApplication):
         """
         return request.user.is_authenticated()
 
-    @api.get(url="^user_settings/$", access=PermitLogged())
+    @api.get("^user_settings/$", access=PermitLogged())
     def api_user_settings(self, request: HttpRequest):
         """
         Get user settings
@@ -223,7 +223,7 @@ class DesktopApplication(ExtApplication):
                 return self.response_not_found()
         return get_children(root, request.user)
 
-    @api.get(url="^launch_info/$", access=PermitLogged())
+    @api.get("^launch_info/$", access=PermitLogged())
     def api_launch_info(self, request: HttpRequest):
         """
         Get application launch information
@@ -238,7 +238,7 @@ class DesktopApplication(ExtApplication):
             return self.response_not_found()
         return menu["app"].get_launch_info(request)
 
-    @api.get(url="^state/", access=PermitLogged())
+    @api.get("^state/", access=PermitLogged())
     def api_get_state(self, request: HttpRequest):
         """
         Get user state
@@ -247,7 +247,7 @@ class DesktopApplication(ExtApplication):
         uid = request.user.id
         return {r.key: r.value for r in UserState.objects.filter(user_id=uid)}
 
-    @api.get(url="^state/(?P<name>.+)/$", access=PermitLogged())
+    @api.get("^state/(?P<name>.+)/$", access=PermitLogged())
     def api_get_state_by_name(self, request: HttpRequest, name):
         """
         Get user state
@@ -256,7 +256,7 @@ class DesktopApplication(ExtApplication):
         uid = request.user.id
         return {r.key: r.value for r in UserState.objects.filter(user_id=uid, key=name)}
 
-    @api.delete(url="^state/(?P<name>.+)/$", access=PermitLogged())
+    @api.delete("^state/(?P<name>.+)/$", access=PermitLogged())
     def api_clear_state(self, request: HttpRequest, name):
         """
         Clear user state
@@ -266,7 +266,7 @@ class DesktopApplication(ExtApplication):
         UserState.objects.filter(user_id=uid, key=name).delete()
         return True
 
-    @api.post(url="^state/(?P<name>.+)/$", access=PermitLogged())
+    @api.post("^state/(?P<name>.+)/$", access=PermitLogged())
     def api_set_state(self, request: HttpRequest, name):
         """
         Clear user state
@@ -290,7 +290,7 @@ class DesktopApplication(ExtApplication):
             UserState.objects.filter(user_id=uid, key=name).delete()
         return True
 
-    @api.get(url="^favapps/$", access=PermitLogged())
+    @api.get("^favapps/$", access=PermitLogged())
     def api_favapps(self, request: HttpRequest):
         favapps = [
             f.app
@@ -305,7 +305,7 @@ class DesktopApplication(ExtApplication):
             for fa in favapps
         ]
 
-    @api.get(url="^about/", access=True)
+    @api.get("^about/", access=True)
     def api_about(self, request: HttpRequest):
         current_year = datetime.date.today().year
         data = {

--- a/services/web/apps/main/desktop/views.py
+++ b/services/web/apps/main/desktop/views.py
@@ -14,7 +14,7 @@ from django.http import HttpRequest
 
 # NOC modules
 from noc.config import config
-from noc.services.web.base.extapplication import ExtApplication, view
+from noc.services.web.base.extapplication import ExtApplication, api
 from noc.services.web.base.access import PermitLogged
 from noc.core.version import version
 from noc.aaa.models.group import Group
@@ -60,7 +60,7 @@ class DesktopApplication(ExtApplication):
             return config.language
         return request.user.preferred_language or config.language
 
-    @view(method=["GET"], url="/index.html", url_name="desktop", access=True)
+    @api.get(url="/index.html", url_name="desktop", access=True)
     def view_desktop(self, request: HttpRequest):
         """
         Render application root template
@@ -73,7 +73,7 @@ class DesktopApplication(ExtApplication):
             brand=version.brand,
         )
 
-    @view(method=["GET"], url="^settings/$", access=True, api=True)
+    @api.get(url="^settings/$", access=True)
     def api_settings(self, request: HttpRequest):
         cp = CPClient()
         if request.user.is_authenticated():
@@ -142,7 +142,7 @@ class DesktopApplication(ExtApplication):
             "color_scheme": Style.get_scheme(),
         }
 
-    @view(method=["GET"], url="^version/$", access=True, api=True)
+    @api.get(url="^version/$", access=True)
     def api_version(self, request: HttpRequest):
         """
         Return current NOC version
@@ -151,7 +151,7 @@ class DesktopApplication(ExtApplication):
         """
         return version.version
 
-    @view(method=["GET"], url="^is_logged/$", access=True, api=True)
+    @api.get(url="^is_logged/$", access=True)
     def api_is_logged(self, request: HttpRequest):
         """
         Check wrether the session is authenticated.
@@ -160,7 +160,7 @@ class DesktopApplication(ExtApplication):
         """
         return request.user.is_authenticated()
 
-    @view(method=["GET"], url="^user_settings/$", access=PermitLogged(), api=True)
+    @api.get(url="^user_settings/$", access=PermitLogged())
     def api_user_settings(self, request: HttpRequest):
         """
         Get user settings
@@ -223,7 +223,7 @@ class DesktopApplication(ExtApplication):
                 return self.response_not_found()
         return get_children(root, request.user)
 
-    @view(method=["GET"], url="^launch_info/$", access=PermitLogged(), api=True)
+    @api.get(url="^launch_info/$", access=PermitLogged())
     def api_launch_info(self, request: HttpRequest):
         """
         Get application launch information
@@ -238,7 +238,7 @@ class DesktopApplication(ExtApplication):
             return self.response_not_found()
         return menu["app"].get_launch_info(request)
 
-    @view(method=["GET"], url="^state/", access=PermitLogged(), api=True)
+    @api.get(url="^state/", access=PermitLogged())
     def api_get_state(self, request: HttpRequest):
         """
         Get user state
@@ -247,7 +247,7 @@ class DesktopApplication(ExtApplication):
         uid = request.user.id
         return {r.key: r.value for r in UserState.objects.filter(user_id=uid)}
 
-    @view(method=["GET"], url="^state/(?P<name>.+)/$", access=PermitLogged(), api=True)
+    @api.get(url="^state/(?P<name>.+)/$", access=PermitLogged())
     def api_get_state_by_name(self, request: HttpRequest, name):
         """
         Get user state
@@ -256,7 +256,7 @@ class DesktopApplication(ExtApplication):
         uid = request.user.id
         return {r.key: r.value for r in UserState.objects.filter(user_id=uid, key=name)}
 
-    @view(method=["DELETE"], url="^state/(?P<name>.+)/$", access=PermitLogged(), api=True)
+    @api.delete(url="^state/(?P<name>.+)/$", access=PermitLogged())
     def api_clear_state(self, request: HttpRequest, name):
         """
         Clear user state
@@ -266,7 +266,7 @@ class DesktopApplication(ExtApplication):
         UserState.objects.filter(user_id=uid, key=name).delete()
         return True
 
-    @view(method=["POST"], url="^state/(?P<name>.+)/$", access=PermitLogged(), api=True)
+    @api.post(url="^state/(?P<name>.+)/$", access=PermitLogged())
     def api_set_state(self, request: HttpRequest, name):
         """
         Clear user state
@@ -290,7 +290,7 @@ class DesktopApplication(ExtApplication):
             UserState.objects.filter(user_id=uid, key=name).delete()
         return True
 
-    @view(url="^favapps/$", method=["GET"], access=PermitLogged(), api=True)
+    @api.get(url="^favapps/$", access=PermitLogged())
     def api_favapps(self, request: HttpRequest):
         favapps = [
             f.app
@@ -305,7 +305,7 @@ class DesktopApplication(ExtApplication):
             for fa in favapps
         ]
 
-    @view(url="^about/", method=["GET"], access=True, api=True)
+    @api.get(url="^about/", access=True)
     def api_about(self, request: HttpRequest):
         current_year = datetime.date.today().year
         data = {

--- a/services/web/apps/main/home/views.py
+++ b/services/web/apps/main/home/views.py
@@ -38,7 +38,7 @@ class HomeAppplication(ExtApplication):
     _welcome_text: str | None = None
     _community_text: str | None = None
 
-    @api.get(url=r"^dashboard/", access=True)
+    @api.get(r"^dashboard/", access=True)
     def api_welcome(self, request: HttpRequest):
         def append_if(is_enabled: bool, h: Callable[[User], dict[str, Any] | None]) -> None:
             if not is_enabled:

--- a/services/web/apps/main/home/views.py
+++ b/services/web/apps/main/home/views.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 #  main.home application
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2025 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -14,7 +14,7 @@ from jinja2 import Template
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extapplication import ExtApplication, view
+from noc.services.web.base.extapplication import ExtApplication, api
 from noc.core.translation import ugettext as _
 from noc.aaa.models.user import User
 from noc.config import config
@@ -38,7 +38,7 @@ class HomeAppplication(ExtApplication):
     _welcome_text: str | None = None
     _community_text: str | None = None
 
-    @view("^dashboard/", access=True, api=True)
+    @api.get(url=r"^dashboard/", access=True)
     def api_welcome(self, request: HttpRequest):
         def append_if(is_enabled: bool, h: Callable[[User], dict[str, Any] | None]) -> None:
             if not is_enabled:

--- a/services/web/apps/main/imagestore.py
+++ b/services/web/apps/main/imagestore.py
@@ -39,7 +39,7 @@ class ImageStoreApplication(ExtDocApplication):
         o.file.put(file.read(), content_type=file.content_type, filename=file_attrs.get("filename"))
         return True
 
-    @api.get(url=r"^(?P<id>[0-9a-f]{24})/image/$", access="read")
+    @api.get(r"^(?P<id>[0-9a-f]{24})/image/$", access="read")
     def api_image(self, request: HttpRequest, id):
         o = self.get_object_or_404(ImageStore, id=id)
         return HttpResponse(o.file.read(), content_type=o.get_content_type())

--- a/services/web/apps/main/imagestore.py
+++ b/services/web/apps/main/imagestore.py
@@ -9,7 +9,7 @@
 from django.http import HttpResponse, HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.main.models.imagestore import ImageStore
 from noc.core.translation import ugettext as _
 from noc.core.mime import _R_CONTENT_TYPE
@@ -39,7 +39,7 @@ class ImageStoreApplication(ExtDocApplication):
         o.file.put(file.read(), content_type=file.content_type, filename=file_attrs.get("filename"))
         return True
 
-    @view("^(?P<id>[0-9a-f]{24})/image/$", access="read", api=True)
+    @api.get(url=r"^(?P<id>[0-9a-f]{24})/image/$", access="read")
     def api_image(self, request: HttpRequest, id):
         o = self.get_object_or_404(ImageStore, id=id)
         return HttpResponse(o.file.read(), content_type=o.get_content_type())

--- a/services/web/apps/main/jsonimport.py
+++ b/services/web/apps/main/jsonimport.py
@@ -10,7 +10,7 @@ import orjson
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extapplication import ExtApplication, view
+from noc.services.web.base.extapplication import ExtApplication, api
 from noc.sa.interfaces.base import StringParameter
 from noc.core.collection.base import Collection
 from noc.core.translation import ugettext as _
@@ -24,13 +24,7 @@ class JSONImportApplication(ExtApplication):
     title = _("JSON Import")
     menu = [_("Setup"), _("JSON Import")]
 
-    @view(
-        url="^$",
-        method=["POST"],
-        access="launch",
-        validate={"json": StringParameter(required=True)},
-        api=True,
-    )
+    @api.post(url="^$", access="launch", validate={"json": StringParameter(required=True)})
     def api_import(self, request: HttpRequest, json):
         try:
             jdata = orjson.loads(json)

--- a/services/web/apps/main/jsonimport.py
+++ b/services/web/apps/main/jsonimport.py
@@ -24,7 +24,7 @@ class JSONImportApplication(ExtApplication):
     title = _("JSON Import")
     menu = [_("Setup"), _("JSON Import")]
 
-    @api.post(url="^$", access="launch", validate={"json": StringParameter(required=True)})
+    @api.post("^$", access="launch", validate={"json": StringParameter(required=True)})
     def api_import(self, request: HttpRequest, json):
         try:
             jdata = orjson.loads(json)

--- a/services/web/apps/main/label.py
+++ b/services/web/apps/main/label.py
@@ -14,7 +14,7 @@ from django.http import HttpRequest
 
 # NOC modules
 from noc.sa.interfaces.base import ColorParameter
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.main.models.label import Label
 from noc.core.translation import ugettext as _
 from noc.models import LABEL_MODELS
@@ -88,7 +88,7 @@ class LabelApplication(ExtDocApplication):
                     data["allow_models"].append(Label.ENABLE_MODEL_ID_MAP[k])
         return super().clean(data)
 
-    @view(url="^ac_lookup/", method=["GET"], access=True)
+    @api.get(url="^ac_lookup/", access=True)
     def api_ac_lookup(self, request: HttpRequest):
         """
         Legacy AutoCompleteTags widget support
@@ -151,7 +151,7 @@ class LabelApplication(ExtDocApplication):
             "success": True,
         }
 
-    @view(url="^lookup_tree/", method=["GET"], access=True)
+    @api.get(url="^lookup_tree/", access=True)
     def api_labels_lookup_tree(self, request: HttpRequest):
         leafs = defaultdict(list)
         level = 1

--- a/services/web/apps/main/label.py
+++ b/services/web/apps/main/label.py
@@ -88,7 +88,7 @@ class LabelApplication(ExtDocApplication):
                     data["allow_models"].append(Label.ENABLE_MODEL_ID_MAP[k])
         return super().clean(data)
 
-    @api.get(url="^ac_lookup/", access=True)
+    @api.get("^ac_lookup/", access=True)
     def api_ac_lookup(self, request: HttpRequest):
         """
         Legacy AutoCompleteTags widget support
@@ -151,7 +151,7 @@ class LabelApplication(ExtDocApplication):
             "success": True,
         }
 
-    @api.get(url="^lookup_tree/", access=True)
+    @api.get("^lookup_tree/", access=True)
     def api_labels_lookup_tree(self, request: HttpRequest):
         leafs = defaultdict(list)
         level = 1

--- a/services/web/apps/main/modeltemplate.py
+++ b/services/web/apps/main/modeltemplate.py
@@ -50,12 +50,12 @@ class ModelTemplateApplication(ExtDocApplication):
                 p["default_expression"] = str(p["default_expression"])
         return super().clean(data)
 
-    @api.get(url=r"^directory/(?P<type>\w+)/fields/?$", access="read")
+    @api.get(r"^directory/(?P<type>\w+)/fields/?$", access="read")
     def api_get_template_fields(self, request: HttpRequest, type):
         r = ModelTemplate.get_templating_fields()
         return sorted([x.model_dump() for x in r], key=lambda x: x["id"].lower())
 
-    @api.get(url=r"^directory/(?P<type>\w+)/fields/(?P<field>[\w_]+)/?$", access="read")
+    @api.get(r"^directory/(?P<type>\w+)/fields/(?P<field>[\w_]+)/?$", access="read")
     def api_get_template_field(self, request: HttpRequest, type, field):
         r = [x for x in ModelTemplate.get_templating_fields() if x.id == field]
         if not r:

--- a/services/web/apps/main/modeltemplate.py
+++ b/services/web/apps/main/modeltemplate.py
@@ -9,7 +9,7 @@
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view, HttpResponse
+from noc.services.web.base.extdocapplication import ExtDocApplication, api, HttpResponse
 from noc.main.models.modeltemplate import ModelTemplate, Param
 from noc.core.translation import ugettext as _
 from noc.models import get_model
@@ -50,17 +50,12 @@ class ModelTemplateApplication(ExtDocApplication):
                 p["default_expression"] = str(p["default_expression"])
         return super().clean(data)
 
-    @view(url=r"^directory/(?P<type>\w+)/fields/?$", method=["GET"], access="read", api=True)
+    @api.get(url=r"^directory/(?P<type>\w+)/fields/?$", access="read")
     def api_get_template_fields(self, request: HttpRequest, type):
         r = ModelTemplate.get_templating_fields()
         return sorted([x.model_dump() for x in r], key=lambda x: x["id"].lower())
 
-    @view(
-        url=r"^directory/(?P<type>\w+)/fields/(?P<field>[\w_]+)/?$",
-        method=["GET"],
-        access="read",
-        api=True,
-    )
+    @api.get(url=r"^directory/(?P<type>\w+)/fields/(?P<field>[\w_]+)/?$", access="read")
     def api_get_template_field(self, request: HttpRequest, type, field):
         r = [x for x in ModelTemplate.get_templating_fields() if x.id == field]
         if not r:

--- a/services/web/apps/main/notificationgroup.py
+++ b/services/web/apps/main/notificationgroup.py
@@ -49,7 +49,7 @@ class NotificationGroupApplication(ExtModelApplication):
     }
 
     @api.post(
-        url="^actions/test/$",
+        "^actions/test/$",
         access="update",
         validate={
             "ids": ListOfParameter(element=ModelParameter(NotificationGroup)),
@@ -63,7 +63,7 @@ class NotificationGroupApplication(ExtModelApplication):
         return "Notification message has been sent"
 
     @api.post(
-        url=r"^(?P<group_id>\d+)/change_user_subscription/$",
+        r"^(?P<group_id>\d+)/change_user_subscription/$",
         validate={
             "user_policy": StringParameter(choices=["D", "W", "F", "A"]),
             "time_pattern": ModelParameter(TimePattern, required=False),

--- a/services/web/apps/main/notificationgroup.py
+++ b/services/web/apps/main/notificationgroup.py
@@ -12,7 +12,7 @@ import datetime
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extmodelapplication import ExtModelApplication, view
+from noc.services.web.base.extmodelapplication import ExtModelApplication, api
 from noc.services.web.base.extapplication import PermitLogged
 from noc.core.mx import NOTIFICATION_METHODS
 from noc.aaa.models.user import User
@@ -48,11 +48,9 @@ class NotificationGroupApplication(ExtModelApplication):
         "xmpp": "Jabber",
     }
 
-    @view(
+    @api.post(
         url="^actions/test/$",
-        method=["POST"],
         access="update",
-        api=True,
         validate={
             "ids": ListOfParameter(element=ModelParameter(NotificationGroup)),
             "subject": UnicodeParameter(),
@@ -64,7 +62,7 @@ class NotificationGroupApplication(ExtModelApplication):
             g.notify(subject=subject, body=body)
         return "Notification message has been sent"
 
-    @view(
+    @api.post(
         url=r"^(?P<group_id>\d+)/change_user_subscription/$",
         validate={
             "user_policy": StringParameter(choices=["D", "W", "F", "A"]),
@@ -73,9 +71,7 @@ class NotificationGroupApplication(ExtModelApplication):
             "title_tag": StringParameter(required=False),
             "preferred_method": StringParameter(choices=list(NOTIFICATION_METHODS), required=False),
         },
-        method=["POST"],
         access=PermitLogged(),
-        api=True,
     )
     def api_change_user_subscription(
         self,

--- a/services/web/apps/main/prefixtable.py
+++ b/services/web/apps/main/prefixtable.py
@@ -32,7 +32,7 @@ class PrefixTableApplication(ExtModelApplication):
     prefixes = ModelInline(PrefixTablePrefix)
 
     @api.post(
-        url="^actions/test/$",
+        "^actions/test/$",
         access="update",
         validate={"ids": ListOfParameter(element=ModelParameter(PrefixTable)), "ip": IPParameter()},
     )

--- a/services/web/apps/main/prefixtable.py
+++ b/services/web/apps/main/prefixtable.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extmodelapplication import ExtModelApplication, view
+from noc.services.web.base.extmodelapplication import ExtModelApplication, api
 from noc.services.web.base.modelinline import ModelInline
 from noc.main.models.prefixtable import PrefixTable, PrefixTablePrefix
 from noc.main.models.label import Label
@@ -31,11 +31,9 @@ class PrefixTableApplication(ExtModelApplication):
 
     prefixes = ModelInline(PrefixTablePrefix)
 
-    @view(
+    @api.post(
         url="^actions/test/$",
-        method=["POST"],
         access="update",
-        api=True,
         validate={"ids": ListOfParameter(element=ModelParameter(PrefixTable)), "ip": IPParameter()},
     )
     def api_action_test(self, request: HttpRequest, ids, ip):

--- a/services/web/apps/main/ref.py
+++ b/services/web/apps/main/ref.py
@@ -15,7 +15,7 @@ from django.http import HttpRequest
 from mongoengine.base.common import _document_registry
 
 # NOC modules
-from noc.services.web.base.extapplication import ExtApplication, view
+from noc.services.web.base.extapplication import ExtApplication, api
 from noc.services.web.base.site import site
 from noc.core.interface.loader import loader as interface_loader
 from noc.core.profile.loader import loader as profile_loader
@@ -251,7 +251,7 @@ class RefAppplication(ExtApplication):
         """Container type loolup"""
         return [{"id": x.value, "label": x.name} for x in ContainerType]
 
-    @view(url=r"^(?P<ref>\S+)/lookup/$", method=["GET"], access=True, api=True)
+    @api.get(url=r"^(?P<ref>\S+)/lookup/$", access=True)
     def api_lookup(self, request: HttpRequest, ref=None):
         if ref not in self.refs:
             if ref == "report":

--- a/services/web/apps/main/ref.py
+++ b/services/web/apps/main/ref.py
@@ -251,7 +251,7 @@ class RefAppplication(ExtApplication):
         """Container type loolup"""
         return [{"id": x.value, "label": x.name} for x in ContainerType]
 
-    @api.get(url=r"^(?P<ref>\S+)/lookup/$", access=True)
+    @api.get(r"^(?P<ref>\S+)/lookup/$", access=True)
     def api_lookup(self, request: HttpRequest, ref=None):
         if ref not in self.refs:
             if ref == "report":

--- a/services/web/apps/main/remotesystem.py
+++ b/services/web/apps/main/remotesystem.py
@@ -9,7 +9,7 @@
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.main.models.remotesystem import RemoteSystem
 from noc.core.translation import ugettext as _
 
@@ -23,7 +23,7 @@ class RemoteSystemApplication(ExtDocApplication):
     menu = [_("Setup"), _("Remote Systems")]
     model = RemoteSystem
 
-    @view(method=["GET"], url="^brief_lookup/$", access="lookup", api=True)
+    @api.get(url="^brief_lookup/$", access="lookup")
     def api_brief(self, request: HttpRequest):
         return [
             {

--- a/services/web/apps/main/remotesystem.py
+++ b/services/web/apps/main/remotesystem.py
@@ -23,7 +23,7 @@ class RemoteSystemApplication(ExtDocApplication):
     menu = [_("Setup"), _("Remote Systems")]
     model = RemoteSystem
 
-    @api.get(url="^brief_lookup/$", access="lookup")
+    @api.get("^brief_lookup/$", access="lookup")
     def api_brief(self, request: HttpRequest):
         return [
             {

--- a/services/web/apps/main/reportconfig.py
+++ b/services/web/apps/main/reportconfig.py
@@ -122,7 +122,7 @@ class ReportConfigApplication(ExtDocApplication):
             r.append(row)
         return r
 
-    @api.get(url=r"^(?P<report_id>\S+)/form/$", access="run")
+    @api.get(r"^(?P<report_id>\S+)/form/$", access="run")
     def api_form_report(self, request: HttpRequest, report_id):
         def update_choice_widget(result: dict, cond_param: str, target_name: str):
             for cfg in result["params"]:
@@ -274,7 +274,7 @@ class ReportConfigApplication(ExtDocApplication):
         # formats
         return r
 
-    @api.get(url=r"^(?P<report_id>\S+)/run/$", access="run")
+    @api.get(r"^(?P<report_id>\S+)/run/$", access="run")
     def api_report_run(self, request: HttpRequest, report_id: str):
         """
 

--- a/services/web/apps/main/reportconfig.py
+++ b/services/web/apps/main/reportconfig.py
@@ -14,7 +14,7 @@ from pydantic import ValidationError
 from django.http import HttpResponse, HttpResponseBadRequest, HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.main.models.report import Report
 from noc.core.reporter.reportengine import ReportEngine
 from noc.core.reporter.types import RunParams, OutputType
@@ -122,7 +122,7 @@ class ReportConfigApplication(ExtDocApplication):
             r.append(row)
         return r
 
-    @view(url=r"^(?P<report_id>\S+)/form/$", method=["GET"], access="run", api=True)
+    @api.get(url=r"^(?P<report_id>\S+)/form/$", access="run")
     def api_form_report(self, request: HttpRequest, report_id):
         def update_choice_widget(result: dict, cond_param: str, target_name: str):
             for cfg in result["params"]:
@@ -274,7 +274,7 @@ class ReportConfigApplication(ExtDocApplication):
         # formats
         return r
 
-    @view(method=["GET"], url=r"^(?P<report_id>\S+)/run/$", access="run", api=True)
+    @api.get(url=r"^(?P<report_id>\S+)/run/$", access="run")
     def api_report_run(self, request: HttpRequest, report_id: str):
         """
 

--- a/services/web/apps/main/search.py
+++ b/services/web/apps/main/search.py
@@ -25,7 +25,7 @@ class SearchApplication(ExtApplication):
     menu = _("Search")
     glyph = "search noc-preview"
 
-    @api.post(url="^$", access="launch", validate={"query": UnicodeParameter()})
+    @api.post("^$", access="launch", validate={"query": UnicodeParameter()})
     def api_search(self, request: HttpRequest, query):
         r = []
         for qr in TextIndex.search(query):

--- a/services/web/apps/main/search.py
+++ b/services/web/apps/main/search.py
@@ -9,7 +9,7 @@
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extapplication import ExtApplication, view
+from noc.services.web.base.extapplication import ExtApplication, api
 from noc.sa.interfaces.base import UnicodeParameter
 from noc.main.models.textindex import TextIndex
 from noc.models import get_model
@@ -25,9 +25,7 @@ class SearchApplication(ExtApplication):
     menu = _("Search")
     glyph = "search noc-preview"
 
-    @view(
-        url="^$", method=["POST"], access="launch", api=True, validate={"query": UnicodeParameter()}
-    )
+    @api.post(url="^$", access="launch", validate={"query": UnicodeParameter()})
     def api_search(self, request: HttpRequest, query):
         r = []
         for qr in TextIndex.search(query):

--- a/services/web/apps/main/style.py
+++ b/services/web/apps/main/style.py
@@ -9,7 +9,7 @@
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extmodelapplication import ExtModelApplication, view
+from noc.services.web.base.extmodelapplication import ExtModelApplication, api
 from noc.main.models.style import Style
 from noc.sa.interfaces.base import ColorParameter
 from noc.core.translation import ugettext as _
@@ -27,6 +27,6 @@ class StyleApplication(ExtModelApplication):
 
     clean_fields = {"background_color": ColorParameter(), "font_color": ColorParameter()}
 
-    @view("^scheme/$", method=["GET"], access=True)
+    @api.get(url="^scheme/$", access=True)
     def api_style(self, request: HttpRequest):
         return Style.get_scheme()

--- a/services/web/apps/main/style.py
+++ b/services/web/apps/main/style.py
@@ -27,6 +27,6 @@ class StyleApplication(ExtModelApplication):
 
     clean_fields = {"background_color": ColorParameter(), "font_color": ColorParameter()}
 
-    @api.get(url="^scheme/$", access=True)
+    @api.get("^scheme/$", access=True)
     def api_style(self, request: HttpRequest):
         return Style.get_scheme()

--- a/services/web/apps/main/timepattern.py
+++ b/services/web/apps/main/timepattern.py
@@ -33,7 +33,7 @@ class TimePatternApplication(ExtModelApplication):
     terms = ModelInline(TimePatternTerm)
 
     @api.post(
-        url="^actions/test/",
+        "^actions/test/",
         access="read",
         validate={
             "ids": ListOfParameter(element=ModelParameter(TimePattern)),

--- a/services/web/apps/main/timepattern.py
+++ b/services/web/apps/main/timepattern.py
@@ -12,7 +12,7 @@ import datetime
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extmodelapplication import ExtModelApplication, view
+from noc.services.web.base.extmodelapplication import ExtModelApplication, api
 from noc.main.models.timepattern import TimePattern
 from noc.main.models.timepatternterm import TimePatternTerm
 from noc.services.web.base.modelinline import ModelInline
@@ -32,11 +32,9 @@ class TimePatternApplication(ExtModelApplication):
 
     terms = ModelInline(TimePatternTerm)
 
-    @view(
+    @api.post(
         url="^actions/test/",
-        method=["POST"],
         access="read",
-        api=True,
         validate={
             "ids": ListOfParameter(element=ModelParameter(TimePattern)),
             "date": StringParameter(required=True),

--- a/services/web/apps/main/userprofile.py
+++ b/services/web/apps/main/userprofile.py
@@ -26,7 +26,7 @@ class UserProfileApplication(ExtApplication):
     title = _("User Profile")
     implied_permissions = {"launch": ["main:timepattern:lookup"]}
 
-    @api.get(url="^$", access=PermitLogged())
+    @api.get("^$", access=PermitLogged())
     def api_get(self, request: HttpRequest):
         user = request.user
         language = user.preferred_language
@@ -83,7 +83,7 @@ class UserProfileApplication(ExtApplication):
         }
 
     @api.post(
-        url="^$",
+        "^$",
         access=PermitLogged(),
         validate={
             "preferred_language": StringParameter(choices=[x[0] for x in LANGUAGES]),

--- a/services/web/apps/main/userprofile.py
+++ b/services/web/apps/main/userprofile.py
@@ -9,7 +9,7 @@
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extapplication import ExtApplication, view, PermitLogged
+from noc.services.web.base.extapplication import ExtApplication, api, PermitLogged
 from noc.sa.interfaces.base import StringParameter, ListOfParameter, DictParameter, ModelParameter
 from noc.settings import LANGUAGES
 from noc.main.models.timepattern import TimePattern
@@ -26,7 +26,7 @@ class UserProfileApplication(ExtApplication):
     title = _("User Profile")
     implied_permissions = {"launch": ["main:timepattern:lookup"]}
 
-    @view(url="^$", method=["GET"], access=PermitLogged(), api=True)
+    @api.get(url="^$", access=PermitLogged())
     def api_get(self, request: HttpRequest):
         user = request.user
         language = user.preferred_language
@@ -82,11 +82,9 @@ class UserProfileApplication(ExtApplication):
             "subscription_settings": subscription_settings,
         }
 
-    @view(
+    @api.post(
         url="^$",
-        method=["POST"],
         access=PermitLogged(),
-        api=True,
         validate={
             "preferred_language": StringParameter(choices=[x[0] for x in LANGUAGES]),
             "contacts": ListOfParameter(

--- a/services/web/apps/maintenance/maintenance.py
+++ b/services/web/apps/maintenance/maintenance.py
@@ -11,7 +11,7 @@ from mongoengine.queryset.visitor import Q
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.maintenance.models.maintenance import (
     Maintenance,
     MaintenanceObject,
@@ -61,7 +61,7 @@ class MaintenanceApplication(ExtDocApplication):
             return qs.filter(type=None)
         return qs
 
-    @view(url=r"^(?P<id>[a-z0-9]{24})/add/", method=["POST"], api=True, access="update")
+    @api.post(url=r"^(?P<id>[a-z0-9]{24})/add/", access="update")
     def api_add(self, request: HttpRequest, id):
         body = orjson.loads(request.body)
         o = self.model.objects.filter(**{self.pk: id}).first()
@@ -83,7 +83,7 @@ class MaintenanceApplication(ExtDocApplication):
             o.save()
         return self.response({"result": "Add object"}, status=self.OK)
 
-    @view(url="(?P<id>[0-9a-f]{24})/objects/", method=["GET"], access="read", api=True)
+    @api.get(url="(?P<id>[0-9a-f]{24})/objects/", access="read")
     def api_test(self, request: HttpRequest, id):
         r = []
         for mo in (

--- a/services/web/apps/maintenance/maintenance.py
+++ b/services/web/apps/maintenance/maintenance.py
@@ -61,7 +61,7 @@ class MaintenanceApplication(ExtDocApplication):
             return qs.filter(type=None)
         return qs
 
-    @api.post(url=r"^(?P<id>[a-z0-9]{24})/add/", access="update")
+    @api.post(r"^(?P<id>[a-z0-9]{24})/add/", access="update")
     def api_add(self, request: HttpRequest, id):
         body = orjson.loads(request.body)
         o = self.model.objects.filter(**{self.pk: id}).first()
@@ -83,7 +83,7 @@ class MaintenanceApplication(ExtDocApplication):
             o.save()
         return self.response({"result": "Add object"}, status=self.OK)
 
-    @api.get(url="(?P<id>[0-9a-f]{24})/objects/", access="read")
+    @api.get("(?P<id>[0-9a-f]{24})/objects/", access="read")
     def api_test(self, request: HttpRequest, id):
         r = []
         for mo in (

--- a/services/web/apps/peer/peer.py
+++ b/services/web/apps/peer/peer.py
@@ -9,7 +9,7 @@
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extmodelapplication import ExtModelApplication, view
+from noc.services.web.base.extmodelapplication import ExtModelApplication, api
 from noc.services.web.base.decorators.state import state_handler
 from noc.peer.models.peer import Peer
 from noc.core.validators import is_prefix
@@ -99,11 +99,9 @@ class PeerApplication(ExtModelApplication):
             return f"1 peer marked as {message}"
         return f"{count} peers marked as {message}"
 
-    @view(
+    @api.post(
         url="^actions/planned/$",
-        method=["POST"],
         access="update",
-        api=True,
         validate={"ids": ListOfParameter(element=ModelParameter(Peer))},
     )
     def api_action_planned(self, request: HttpRequest, ids):
@@ -111,11 +109,9 @@ class PeerApplication(ExtModelApplication):
 
     api_action_planned.short_description = "Mark as planned"
 
-    @view(
+    @api.post(
         url="^actions/active/$",
-        method=["POST"],
         access="update",
-        api=True,
         validate={"ids": ListOfParameter(element=ModelParameter(Peer))},
     )
     def api_action_active(self, request: HttpRequest, ids):
@@ -123,11 +119,9 @@ class PeerApplication(ExtModelApplication):
 
     api_action_active.short_description = "Mark as active"
 
-    @view(
+    @api.post(
         url="^actions/shutdown/$",
-        method=["POST"],
         access="update",
-        api=True,
         validate={"ids": ListOfParameter(element=ModelParameter(Peer))},
     )
     def api_action_shutdown(self, request: HttpRequest, ids):

--- a/services/web/apps/peer/peer.py
+++ b/services/web/apps/peer/peer.py
@@ -100,7 +100,7 @@ class PeerApplication(ExtModelApplication):
         return f"{count} peers marked as {message}"
 
     @api.post(
-        url="^actions/planned/$",
+        "^actions/planned/$",
         access="update",
         validate={"ids": ListOfParameter(element=ModelParameter(Peer))},
     )
@@ -110,7 +110,7 @@ class PeerApplication(ExtModelApplication):
     api_action_planned.short_description = "Mark as planned"
 
     @api.post(
-        url="^actions/active/$",
+        "^actions/active/$",
         access="update",
         validate={"ids": ListOfParameter(element=ModelParameter(Peer))},
     )
@@ -120,7 +120,7 @@ class PeerApplication(ExtModelApplication):
     api_action_active.short_description = "Mark as active"
 
     @api.post(
-        url="^actions/shutdown/$",
+        "^actions/shutdown/$",
         access="update",
         validate={"ids": ListOfParameter(element=ModelParameter(Peer))},
     )

--- a/services/web/apps/peer/prefixlistbuilder/views.py
+++ b/services/web/apps/peer/prefixlistbuilder/views.py
@@ -27,7 +27,7 @@ class PrefixListBuilderApplication(ExtApplication):
     menu = _("Prefix List Builder")
 
     @api.get(
-        url=r"^$",
+        r"^$",
         access="read",
         validate={
             "peering_point": ModelParameter(PeeringPoint),

--- a/services/web/apps/peer/prefixlistbuilder/views.py
+++ b/services/web/apps/peer/prefixlistbuilder/views.py
@@ -9,7 +9,7 @@
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extapplication import ExtApplication, view
+from noc.services.web.base.extapplication import ExtApplication, api
 from noc.peer.models.peeringpoint import PeeringPoint
 from noc.peer.models.whoiscache import WhoisCache
 from noc.sa.interfaces.base import UnicodeParameter, ModelParameter
@@ -26,11 +26,9 @@ class PrefixListBuilderApplication(ExtApplication):
     title = _("Prefix List Builder")
     menu = _("Prefix List Builder")
 
-    @view(
-        method=["GET"],
+    @api.get(
         url=r"^$",
         access="read",
-        api=True,
         validate={
             "peering_point": ModelParameter(PeeringPoint),
             "name": UnicodeParameter(required=False),

--- a/services/web/apps/phone/phonerange.py
+++ b/services/web/apps/phone/phonerange.py
@@ -66,7 +66,7 @@ class PhoneRangeApplication(ExtDocApplication):
         # Clean other
         return super().clean(data)
 
-    @api.get(url=r"^(?P<id>[0-9a-f]{24})/get_path/$", access="read")
+    @api.get(r"^(?P<id>[0-9a-f]{24})/get_path/$", access="read")
     def api_get_path(self, request: HttpRequest, id):
         o = self.get_object_or_404(PhoneRange, id=id)
         path = [PhoneRange.get_by_id(r) for r in o.get_path()]

--- a/services/web/apps/phone/phonerange.py
+++ b/services/web/apps/phone/phonerange.py
@@ -10,7 +10,7 @@ from mongoengine.queryset import Q
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.inv.models.resourcegroup import ResourceGroup
 from noc.phone.models.phonerange import PhoneRange
 from noc.services.web.base.decorators.state import state_handler
@@ -66,7 +66,7 @@ class PhoneRangeApplication(ExtDocApplication):
         # Clean other
         return super().clean(data)
 
-    @view("^(?P<id>[0-9a-f]{24})/get_path/$", access="read", api=True)
+    @api.get(url=r"^(?P<id>[0-9a-f]{24})/get_path/$", access="read")
     def api_get_path(self, request: HttpRequest, id):
         o = self.get_object_or_404(PhoneRange, id=id)
         path = [PhoneRange.get_by_id(r) for r in o.get_path()]

--- a/services/web/apps/pm/agent.py
+++ b/services/web/apps/pm/agent.py
@@ -26,7 +26,7 @@ class AgentApplication(ExtDocApplication):
     menu = [_("Setup"), _("Agent")]
     model = Agent
 
-    @api.get(url="^(?P<id>[0-9a-f]{24})/config/$", access="config")
+    @api.get("^(?P<id>[0-9a-f]{24})/config/$", access="config")
     def api_config(self, request: HttpRequest, id):
         from noc.services.zeroconf.util import get_config
 

--- a/services/web/apps/pm/agent.py
+++ b/services/web/apps/pm/agent.py
@@ -9,7 +9,7 @@
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.services.web.base.decorators.state import state_handler
 from noc.pm.models.agent import Agent
 from noc.core.translation import ugettext as _
@@ -26,7 +26,7 @@ class AgentApplication(ExtDocApplication):
     menu = [_("Setup"), _("Agent")]
     model = Agent
 
-    @view(url="^(?P<id>[0-9a-f]{24})/config/$", method=["GET"], access="config", api=True)
+    @api.get(url="^(?P<id>[0-9a-f]{24})/config/$", access="config")
     def api_config(self, request: HttpRequest, id):
         from noc.services.zeroconf.util import get_config
 

--- a/services/web/apps/pm/ddash/views.py
+++ b/services/web/apps/pm/ddash/views.py
@@ -22,7 +22,7 @@ class DynamicDashboardApplication(ExtApplication):
 
     title = _("Dynamic Dashboard")
 
-    @api.get(url=r"^$", access="launch")
+    @api.get(r"^$", access="launch")
     def api_dashboard(self, request: HttpRequest):
         dash_name = request.GET.get("dashboard")
         try:

--- a/services/web/apps/pm/ddash/views.py
+++ b/services/web/apps/pm/ddash/views.py
@@ -9,7 +9,7 @@
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extapplication import ExtApplication, view
+from noc.services.web.base.extapplication import ExtApplication, api
 from .dashboards.loader import loader
 from .dashboards.base import BaseDashboard
 from noc.core.translation import ugettext as _
@@ -22,7 +22,7 @@ class DynamicDashboardApplication(ExtApplication):
 
     title = _("Dynamic Dashboard")
 
-    @view(url=r"^$", method="GET", access="launch", api=True)
+    @api.get(url=r"^$", access="launch")
     def api_dashboard(self, request: HttpRequest):
         dash_name = request.GET.get("dashboard")
         try:

--- a/services/web/apps/sa/administrativedomain.py
+++ b/services/web/apps/sa/administrativedomain.py
@@ -9,7 +9,7 @@
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extmodelapplication import ExtModelApplication, view
+from noc.services.web.base.extmodelapplication import ExtModelApplication, api
 from noc.sa.models.administrativedomain import AdministrativeDomain
 from noc.core.comp import smart_text
 from noc.core.translation import ugettext as _
@@ -32,7 +32,7 @@ class AdministrativeDomainApplication(ExtModelApplication):
     def instance_to_lookup(self, o, fields=None):
         return {"id": o.id, "label": smart_text(o), "has_children": o.has_children}
 
-    @view(r"^(?P<id>\d+)/get_path/$", access="read", api=True)
+    @api.get(url=r"^(?P<id>\d+)/get_path/$", access="read")
     def api_get_path(self, request: HttpRequest, id):
         o = self.get_object_or_404(AdministrativeDomain, id=id)
         path = [AdministrativeDomain.objects.get(id=ns) for ns in o.get_path()]

--- a/services/web/apps/sa/administrativedomain.py
+++ b/services/web/apps/sa/administrativedomain.py
@@ -32,7 +32,7 @@ class AdministrativeDomainApplication(ExtModelApplication):
     def instance_to_lookup(self, o, fields=None):
         return {"id": o.id, "label": smart_text(o), "has_children": o.has_children}
 
-    @api.get(url=r"^(?P<id>\d+)/get_path/$", access="read")
+    @api.get(r"^(?P<id>\d+)/get_path/$", access="read")
     def api_get_path(self, request: HttpRequest, id):
         o = self.get_object_or_404(AdministrativeDomain, id=id)
         path = [AdministrativeDomain.objects.get(id=ns) for ns in o.get_path()]

--- a/services/web/apps/sa/discoveredobject.py
+++ b/services/web/apps/sa/discoveredobject.py
@@ -107,7 +107,7 @@ class DiscoveredObjectApplication(ExtDocApplication):
             q |= Q(address_bin__gte=int(prefix.first.d), address_bin__lte=int(prefix.last.d))
         return q
 
-    @api.post(url=r"actions/sync_records/$", access="action")
+    @api.post(r"actions/sync_records/$", access="action")
     def api_sync_action(self, request: HttpRequest):
         req = self.parse_request_query(request)
         if "template" in req["args"]:
@@ -130,14 +130,14 @@ class DiscoveredObjectApplication(ExtDocApplication):
             }
         return {"status": True}
 
-    @api.post(url=r"actions/send_event/$", access="action")
+    @api.post(r"actions/send_event/$", access="action")
     def api_send_event_action(self, request: HttpRequest):
         req = self.parse_request_query(request)
         for do in DiscoveredObject.objects.filter(id__in=req["ids"]):
             do.fire_event(req["args"]["event"])
         return {"status": True}
 
-    @api.get(url=r"^template_lookup/$", access="read")
+    @api.get(r"^template_lookup/$", access="read")
     def api_sync_template_lookup(self, request: HttpRequest):
         r = [
             {
@@ -158,7 +158,7 @@ class DiscoveredObjectApplication(ExtDocApplication):
             )
         return r
 
-    @api.get(url=r"^action_lookup/$", access="read")
+    @api.get(r"^action_lookup/$", access="read")
     def api_action_lookup(self, request: HttpRequest):
         r = {}
         wfs = Workflow.objects.filter(allowed_models__in=["sa.DiscoveredObject"])
@@ -174,7 +174,7 @@ class DiscoveredObjectApplication(ExtDocApplication):
         return list(r.values())
 
     @api.post(
-        url=r"^scan_run/$",
+        r"^scan_run/$",
         access="scan",
         validate={
             "addresses": StringListParameter(),

--- a/services/web/apps/sa/discoveredobject.py
+++ b/services/web/apps/sa/discoveredobject.py
@@ -10,7 +10,7 @@ from mongoengine.queryset import Q
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.services.web.base.decorators.state import state_handler
 from noc.main.models.modeltemplate import ModelTemplate
 from noc.sa.models.discoveredobject import DiscoveredObject, CheckStatus, DataItem
@@ -107,7 +107,7 @@ class DiscoveredObjectApplication(ExtDocApplication):
             q |= Q(address_bin__gte=int(prefix.first.d), address_bin__lte=int(prefix.last.d))
         return q
 
-    @view(url=r"actions/sync_records/$", method=["POST"], access="action", api=True)
+    @api.post(url=r"actions/sync_records/$", access="action")
     def api_sync_action(self, request: HttpRequest):
         req = self.parse_request_query(request)
         if "template" in req["args"]:
@@ -130,14 +130,14 @@ class DiscoveredObjectApplication(ExtDocApplication):
             }
         return {"status": True}
 
-    @view(url=r"actions/send_event/$", method=["POST"], access="action", api=True)
+    @api.post(url=r"actions/send_event/$", access="action")
     def api_send_event_action(self, request: HttpRequest):
         req = self.parse_request_query(request)
         for do in DiscoveredObject.objects.filter(id__in=req["ids"]):
             do.fire_event(req["args"]["event"])
         return {"status": True}
 
-    @view(url=r"^template_lookup/$", method=["GET"], access="read", api=True)
+    @api.get(url=r"^template_lookup/$", access="read")
     def api_sync_template_lookup(self, request: HttpRequest):
         r = [
             {
@@ -158,7 +158,7 @@ class DiscoveredObjectApplication(ExtDocApplication):
             )
         return r
 
-    @view(url=r"^action_lookup/$", method=["GET"], access="read", api=True)
+    @api.get(url=r"^action_lookup/$", access="read")
     def api_action_lookup(self, request: HttpRequest):
         r = {}
         wfs = Workflow.objects.filter(allowed_models__in=["sa.DiscoveredObject"])
@@ -173,18 +173,16 @@ class DiscoveredObjectApplication(ExtDocApplication):
             }
         return list(r.values())
 
-    @view(
+    @api.post(
         url=r"^scan_run/$",
-        method=["POST"],
         access="scan",
-        api=True,
         validate={
             "addresses": StringListParameter(),
             # "checks": DictListParameter(
             #     attrs={
-            #         "name": StringParameter(required=True),
-            #         "port": IntParameter(required=False, default=0),
-            #     }, required=False,
+            #      "name": StringParameter(required=True),
+            #      "port": IntParameter(required=False, default=0),
+            #       }, required=False,
             # ),
             "checks": ListOfParameter(StringParameter(), required=False),
             "credentials": StringListParameter(required=False),

--- a/services/web/apps/sa/job.py
+++ b/services/web/apps/sa/job.py
@@ -14,7 +14,7 @@ from typing import Iterable
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.sa.models.job import Job, JobStatus
 from noc.core.feature import Feature
 from noc.core.translation import ugettext as _

--- a/services/web/apps/sa/job.py
+++ b/services/web/apps/sa/job.py
@@ -60,7 +60,7 @@ class JobApplication(ExtDocApplication):
             r["effective_environment"] = o.effective_environment
         return r
 
-    @view("^(?P<id>[0-9a-f]{24})/viz/$", access="read")
+    @api.get("^(?P<id>[0-9a-f]{24})/viz/$", access="read")
     def view_viz(self, request: HttpRequest, id: str):
         job = self.get_object_or_404(Job, id=id)
         return self.get_viz(job)

--- a/services/web/apps/sa/managedobject.py
+++ b/services/web/apps/sa/managedobject.py
@@ -19,7 +19,7 @@ from django.db.models import Q as d_Q
 from mongoengine.queryset import Q as MQ
 
 # NOC modules
-from noc.services.web.base.extmodelapplication import ExtModelApplication, view
+from noc.services.web.base.extmodelapplication import ExtModelApplication, view, api
 from noc.services.web.base.decorators.state import state_handler
 from noc.services.web.base.decorators.caps import capabilities_handler
 from noc.sa.models.administrativedomain import AdministrativeDomain
@@ -481,7 +481,7 @@ class ManagedObjectApplication(ExtModelApplication):
         #    qs = qs.exclude(state__in=[str(s) for s in w_states])
         return qs
 
-    @view(url=r"^(?P<id>\d+)/links/$", method=["GET"], access="read", api=True)
+    @api.get(url=r"^(?P<id>\d+)/links/$", access="read")
     def api_links(self, request: HttpRequest, id):
         def split_local_ifaces(
             interfaces: Iterable[Interface],
@@ -535,7 +535,7 @@ class ManagedObjectApplication(ExtModelApplication):
                     )
         return result
 
-    @view(url=r"^(?P<id>\d+)/discovery/$", method=["GET"], access="read", api=True)
+    @api.get(url=r"^(?P<id>\d+)/discovery/$", access="read")
     def api_discovery(self, request: HttpRequest, id):
         from noc.core.scheduler.job import Job
 
@@ -583,11 +583,9 @@ class ManagedObjectApplication(ExtModelApplication):
             r += [d]
         return r
 
-    @view(
+    @api.post(
         url=r"^actions/set_managed/$",
-        method=["POST"],
         access="create",
-        api=True,
         validate={"ids": ListOfParameter(element=ModelParameter(ManagedObject), convert=True)},
     )
     def api_action_set_managed(self, request: HttpRequest, ids):
@@ -598,11 +596,9 @@ class ManagedObjectApplication(ExtModelApplication):
             o.save()
         return "Selected objects set to managed state"
 
-    @view(
+    @api.post(
         url=r"^actions/set_unmanaged/$",
-        method=["POST"],
         access="create",
-        api=True,
         validate={"ids": ListOfParameter(element=ModelParameter(ManagedObject), convert=True)},
     )
     def api_action_set_unmanaged(self, request: HttpRequest, ids):
@@ -613,7 +609,7 @@ class ManagedObjectApplication(ExtModelApplication):
             o.save()
         return "Selected objects set to unmanaged state"
 
-    @view(url=r"^(?P<id>\d+)/discovery/run/$", method=["POST"], access="change_discovery", api=True)
+    @api.post(url=r"^(?P<id>\d+)/discovery/run/$", access="change_discovery")
     def api_run_discovery(self, request: HttpRequest, id):
         o = self.get_object_or_404(ManagedObject, id=id)
         if not o.has_access(request.user):
@@ -639,9 +635,7 @@ class ManagedObjectApplication(ExtModelApplication):
             Job.submit("discovery", jcls, key=o.id, pool=o.pool.name, shard=shard)
         return {"success": True}
 
-    @view(
-        url=r"^(?P<id>\d+)/discovery/stop/$", method=["POST"], access="change_discovery", api=True
-    )
+    @api.post(url=r"^(?P<id>\d+)/discovery/stop/$", access="change_discovery")
     def api_stop_discovery(self, request: HttpRequest, id):
         o = self.get_object_or_404(ManagedObject, id=id)
         if not o.has_access(request.user):
@@ -664,7 +658,7 @@ class ManagedObjectApplication(ExtModelApplication):
             Job.remove("discovery", jcls, key=o.id, pool=o.pool.name)
         return {"success": True}
 
-    @view(url=r"^(?P<id>\d+)/interface/$", method=["GET"], access="read", api=True)
+    @api.get(url=r"^(?P<id>\d+)/interface/$", access="read")
     def api_interface(self, request: HttpRequest, id):
         """
         GET interfaces
@@ -803,12 +797,7 @@ class ManagedObjectApplication(ExtModelApplication):
             "l3": sorted_iname(l3),
         }
 
-    @view(
-        url=r"^(?P<id>\d+)/interface/(?P<if_id>[0-9a-f]{24})/$",
-        method=["DELETE"],
-        access="change_interface",
-        api=True,
-    )
+    @api.delete(url=r"^(?P<id>\d+)/interface/(?P<if_id>[0-9a-f]{24})/$", access="change_interface")
     def api_delete_interface(self, request: HttpRequest, id, if_id):
         o = self.get_object_or_404(ManagedObject, id=int(id))
         if not o.has_access(request.user):
@@ -818,7 +807,7 @@ class ManagedObjectApplication(ExtModelApplication):
             iface.delete()
         return {"success": True}
 
-    @view(url=r"^(?P<id>\d+)/interface/$", method=["POST"], access="change_interface", api=True)
+    @api.post(url=r"^(?P<id>\d+)/interface/$", access="change_interface")
     def api_set_interface(self, request: HttpRequest, id):
         def get_or_none(c, v):
             if not v:
@@ -852,7 +841,7 @@ class ManagedObjectApplication(ExtModelApplication):
         i.save()
         return {"success": True}
 
-    @view(method=["DELETE"], url=r"^(?P<id>\d+)/?$", access="delete", api=True)
+    @api.delete(url=r"^(?P<id>\d+)/?$", access="delete")
     def api_delete(self, request: HttpRequest, id):
         """
         Override default method
@@ -875,11 +864,9 @@ class ManagedObjectApplication(ExtModelApplication):
         o.set_state(ws)
         return HttpResponse(orjson.dumps({"status": True}), status=self.DELETED)
 
-    @view(
+    @api.post(
         url=r"^actions/run_discovery/$",
-        method=["POST"],
         access="launch",
-        api=True,
         validate={"ids": ListOfParameter(element=ModelParameter(ManagedObject), convert=True)},
     )
     def api_action_run_discovery(self, request: HttpRequest, ids):
@@ -967,7 +954,7 @@ class ManagedObjectApplication(ExtModelApplication):
             r["leaf"] = True
         return r
 
-    @view(url=r"^(?P<id>\d+)/inventory/$", method=["GET"], access="read", api=True)
+    @api.get(url=r"^(?P<id>\d+)/inventory/$", access="read")
     def api_inventory(self, request: HttpRequest, id):
         o = self.get_object_or_404(ManagedObject, id=id)
         if not o.has_access(request.user):
@@ -979,7 +966,7 @@ class ManagedObjectApplication(ExtModelApplication):
             r += [c]
         return {"expanded": True, "children": r}
 
-    @view(url=r"^(?P<id>\d+)/confdb/$", method=["GET"], access="config", api=True)
+    @api.get(url=r"^(?P<id>\d+)/confdb/$", access="config")
     def api_confdb(self, request: HttpRequest, id):
         o = self.get_object_or_404(ManagedObject, id=id)
         if not o.has_access(request.user):
@@ -991,16 +978,14 @@ class ManagedObjectApplication(ExtModelApplication):
         cdb = o.get_confdb(cleanup=cleanup)
         return self.render_plain_text(cdb.dump("json"), content_type="text/json")
 
-    @view(
+    @api.post(
         url=r"^(?P<id>\d+)/confdb/$",
-        method=["POST"],
         validate={
             "query": StringParameter(),
             "cleanup": BooleanParameter(default=True),
             "dump": BooleanParameter(default=False),
         },
         access="config",
-        api=True,
     )
     def api_confdb_query(self, request: HttpRequest, id, query="", cleanup=True, dump=False):
         o = self.get_object_or_404(ManagedObject, id=id)
@@ -1016,7 +1001,7 @@ class ManagedObjectApplication(ExtModelApplication):
             result = {"status": False, "message": str(e)}
         return result
 
-    @view(url=r"^(?P<id>\d+)/job_log/(?P<job>\S+)/$", method=["GET"], access="read", api=True)
+    @api.get(url=r"^(?P<id>\d+)/job_log/(?P<job>\S+)/$", access="read")
     def api_job_log(self, request: HttpRequest, id, job):
         o = self.get_object_or_404(ManagedObject, id=id)
         if not o.has_access(request.user):
@@ -1028,7 +1013,7 @@ class ManagedObjectApplication(ExtModelApplication):
             return self.render_plain_text(zlib.decompress(smart_bytes(d["log"])))
         return self.render_plain_text("No data")
 
-    @view(url=r"^(?P<id>\d+)/interactions/$", method=["GET"], access="interactions", api=True)
+    @api.get(url=r"^(?P<id>\d+)/interactions/$", access="interactions")
     def api_interactions(self, request: HttpRequest, id):
         o = self.get_object_or_404(ManagedObject, id=id)
         if not o.has_access(request.user):
@@ -1038,7 +1023,7 @@ class ManagedObjectApplication(ExtModelApplication):
             for i in InteractionLog.objects.filter(object=o.id).order_by("-timestamp")
         ]
 
-    @view(url=r"^(?P<id>\d+)/scripts/$", method=["GET"], access="script", api=True)
+    @api.get(url=r"^(?P<id>\d+)/scripts/$", access="script")
     def api_scripts(self, request: HttpRequest, id):
         o = self.get_object_or_404(ManagedObject, id=id)
         if not o.has_access(request.user):
@@ -1061,7 +1046,7 @@ class ManagedObjectApplication(ExtModelApplication):
             r += [ss]
         return r
 
-    @view(url=r"^(?P<id>\d+)/scripts/(?P<name>[^/]+)/$", method=["POST"], access="script", api=True)
+    @api.post(url=r"^(?P<id>\d+)/scripts/(?P<name>[^/]+)/$", access="script")
     def api_run_script(self, request: HttpRequest, id, name):
         o = self.get_object_or_404(ManagedObject, id=id)
         if not o.has_access(request.user):
@@ -1075,7 +1060,7 @@ class ManagedObjectApplication(ExtModelApplication):
             return {"error": str(e)}
         return {"result": result}
 
-    @view(url=r"^(?P<id>\d+)/console/$", method=["POST"], access="console", api=True)
+    @api.post(url=r"^(?P<id>\d+)/console/$", access="console")
     def api_console_command(self, request: HttpRequest, id):
         o = self.get_object_or_404(ManagedObject, id=id)
         if not o.has_access(request.user):
@@ -1089,7 +1074,7 @@ class ManagedObjectApplication(ExtModelApplication):
             return {"error": str(e)}
         return {"result": result}
 
-    @view(url=r"(?P<id>\d+)/caps/$", method=["GET"], access="read", api=True)
+    @api.get(url=r"(?P<id>\d+)/caps/$", access="read")
     def api_get_caps(self, request: HttpRequest, id):
         o = self.get_object_or_404(ManagedObject, id=id)
         if not o.has_access(request.user):
@@ -1103,7 +1088,7 @@ class ManagedObjectApplication(ExtModelApplication):
             r.append(caps)
         return sorted(r, key=lambda x: x["capability"])
 
-    @view(url=r"(?P<id>\d+)/actions/(?P<action>\S+)/$", method=["POST"], access="action", api=True)
+    @api.post(url=r"(?P<id>\d+)/actions/(?P<action>\S+)/$", access="action")
     def api_action(self, request: HttpRequest, id, action):
         def execute(o, a, args):
             return a.execute(o, **args)
@@ -1119,11 +1104,9 @@ class ManagedObjectApplication(ExtModelApplication):
             args = {}
         return self.submit_slow_op(request, execute, o, a, args)
 
-    @view(
+    @api.post(
         url=r"(?P<id>\d+)/mappings/$",
-        method=["POST"],
         access="change_mappings",
-        api=True,
         validate={
             "mappings": DictListParameter(
                 attrs={
@@ -1143,7 +1126,7 @@ class ManagedObjectApplication(ExtModelApplication):
         r = [m.get_object_form(o) for m in o.iter_remote_mappings()]
         return {"status": True, "data": r}
 
-    @view(url=r"^link/fix/(?P<link_id>[0-9a-f]{24})/$", method=["POST"], access="change_link")
+    @api.post(url=r"^link/fix/(?P<link_id>[0-9a-f]{24})/$", access="change_link")
     def api_fix_links(self, request: HttpRequest, link_id):
         def get_mac(arp, ip):
             for r in arp:
@@ -1225,7 +1208,7 @@ class ManagedObjectApplication(ExtModelApplication):
         iface1.link_ptp(iface2, method="macfix")
         return success_status("Relinked")
 
-    @view(url=r"^(?P<id>\d+)/cpe/$", method=["GET"], access="read", api=True)
+    @api.get(url=r"^(?P<id>\d+)/cpe/$", access="read")
     def api_cpe(self, request: HttpRequest, id):
         """
         GET CPEs
@@ -1277,7 +1260,7 @@ class ManagedObjectApplication(ExtModelApplication):
             return True
         return ManagedObject.objects.filter(id=obj.id).filter(UserAccess.Q(user)).exists()
 
-    @view(url=r"^(?P<id>\d+)/map_lookup/$", method=["GET"], access="read", api=True)
+    @api.get(url=r"^(?P<id>\d+)/map_lookup/$", access="read")
     def api_map_lookup(self, request: HttpRequest, id):
         o: ManagedObject = self.get_object_or_404(ManagedObject, id=id)
         if not o.has_access(request.user):

--- a/services/web/apps/sa/managedobject.py
+++ b/services/web/apps/sa/managedobject.py
@@ -481,7 +481,7 @@ class ManagedObjectApplication(ExtModelApplication):
         #    qs = qs.exclude(state__in=[str(s) for s in w_states])
         return qs
 
-    @api.get(url=r"^(?P<id>\d+)/links/$", access="read")
+    @api.get(r"^(?P<id>\d+)/links/$", access="read")
     def api_links(self, request: HttpRequest, id):
         def split_local_ifaces(
             interfaces: Iterable[Interface],
@@ -535,7 +535,7 @@ class ManagedObjectApplication(ExtModelApplication):
                     )
         return result
 
-    @api.get(url=r"^(?P<id>\d+)/discovery/$", access="read")
+    @api.get(r"^(?P<id>\d+)/discovery/$", access="read")
     def api_discovery(self, request: HttpRequest, id):
         from noc.core.scheduler.job import Job
 
@@ -584,7 +584,7 @@ class ManagedObjectApplication(ExtModelApplication):
         return r
 
     @api.post(
-        url=r"^actions/set_managed/$",
+        r"^actions/set_managed/$",
         access="create",
         validate={"ids": ListOfParameter(element=ModelParameter(ManagedObject), convert=True)},
     )
@@ -597,7 +597,7 @@ class ManagedObjectApplication(ExtModelApplication):
         return "Selected objects set to managed state"
 
     @api.post(
-        url=r"^actions/set_unmanaged/$",
+        r"^actions/set_unmanaged/$",
         access="create",
         validate={"ids": ListOfParameter(element=ModelParameter(ManagedObject), convert=True)},
     )
@@ -609,7 +609,7 @@ class ManagedObjectApplication(ExtModelApplication):
             o.save()
         return "Selected objects set to unmanaged state"
 
-    @api.post(url=r"^(?P<id>\d+)/discovery/run/$", access="change_discovery")
+    @api.post(r"^(?P<id>\d+)/discovery/run/$", access="change_discovery")
     def api_run_discovery(self, request: HttpRequest, id):
         o = self.get_object_or_404(ManagedObject, id=id)
         if not o.has_access(request.user):
@@ -635,7 +635,7 @@ class ManagedObjectApplication(ExtModelApplication):
             Job.submit("discovery", jcls, key=o.id, pool=o.pool.name, shard=shard)
         return {"success": True}
 
-    @api.post(url=r"^(?P<id>\d+)/discovery/stop/$", access="change_discovery")
+    @api.post(r"^(?P<id>\d+)/discovery/stop/$", access="change_discovery")
     def api_stop_discovery(self, request: HttpRequest, id):
         o = self.get_object_or_404(ManagedObject, id=id)
         if not o.has_access(request.user):
@@ -658,7 +658,7 @@ class ManagedObjectApplication(ExtModelApplication):
             Job.remove("discovery", jcls, key=o.id, pool=o.pool.name)
         return {"success": True}
 
-    @api.get(url=r"^(?P<id>\d+)/interface/$", access="read")
+    @api.get(r"^(?P<id>\d+)/interface/$", access="read")
     def api_interface(self, request: HttpRequest, id):
         """
         GET interfaces
@@ -797,7 +797,7 @@ class ManagedObjectApplication(ExtModelApplication):
             "l3": sorted_iname(l3),
         }
 
-    @api.delete(url=r"^(?P<id>\d+)/interface/(?P<if_id>[0-9a-f]{24})/$", access="change_interface")
+    @api.delete(r"^(?P<id>\d+)/interface/(?P<if_id>[0-9a-f]{24})/$", access="change_interface")
     def api_delete_interface(self, request: HttpRequest, id, if_id):
         o = self.get_object_or_404(ManagedObject, id=int(id))
         if not o.has_access(request.user):
@@ -807,7 +807,7 @@ class ManagedObjectApplication(ExtModelApplication):
             iface.delete()
         return {"success": True}
 
-    @api.post(url=r"^(?P<id>\d+)/interface/$", access="change_interface")
+    @api.post(r"^(?P<id>\d+)/interface/$", access="change_interface")
     def api_set_interface(self, request: HttpRequest, id):
         def get_or_none(c, v):
             if not v:
@@ -841,7 +841,7 @@ class ManagedObjectApplication(ExtModelApplication):
         i.save()
         return {"success": True}
 
-    @api.delete(url=r"^(?P<id>\d+)/?$", access="delete")
+    @api.delete(r"^(?P<id>\d+)/?$", access="delete")
     def api_delete(self, request: HttpRequest, id):
         """
         Override default method
@@ -865,7 +865,7 @@ class ManagedObjectApplication(ExtModelApplication):
         return HttpResponse(orjson.dumps({"status": True}), status=self.DELETED)
 
     @api.post(
-        url=r"^actions/run_discovery/$",
+        r"^actions/run_discovery/$",
         access="launch",
         validate={"ids": ListOfParameter(element=ModelParameter(ManagedObject), convert=True)},
     )
@@ -954,7 +954,7 @@ class ManagedObjectApplication(ExtModelApplication):
             r["leaf"] = True
         return r
 
-    @api.get(url=r"^(?P<id>\d+)/inventory/$", access="read")
+    @api.get(r"^(?P<id>\d+)/inventory/$", access="read")
     def api_inventory(self, request: HttpRequest, id):
         o = self.get_object_or_404(ManagedObject, id=id)
         if not o.has_access(request.user):
@@ -966,7 +966,7 @@ class ManagedObjectApplication(ExtModelApplication):
             r += [c]
         return {"expanded": True, "children": r}
 
-    @api.get(url=r"^(?P<id>\d+)/confdb/$", access="config")
+    @api.get(r"^(?P<id>\d+)/confdb/$", access="config")
     def api_confdb(self, request: HttpRequest, id):
         o = self.get_object_or_404(ManagedObject, id=id)
         if not o.has_access(request.user):
@@ -979,7 +979,7 @@ class ManagedObjectApplication(ExtModelApplication):
         return self.render_plain_text(cdb.dump("json"), content_type="text/json")
 
     @api.post(
-        url=r"^(?P<id>\d+)/confdb/$",
+        r"^(?P<id>\d+)/confdb/$",
         validate={
             "query": StringParameter(),
             "cleanup": BooleanParameter(default=True),
@@ -1001,7 +1001,7 @@ class ManagedObjectApplication(ExtModelApplication):
             result = {"status": False, "message": str(e)}
         return result
 
-    @api.get(url=r"^(?P<id>\d+)/job_log/(?P<job>\S+)/$", access="read")
+    @api.get(r"^(?P<id>\d+)/job_log/(?P<job>\S+)/$", access="read")
     def api_job_log(self, request: HttpRequest, id, job):
         o = self.get_object_or_404(ManagedObject, id=id)
         if not o.has_access(request.user):
@@ -1013,7 +1013,7 @@ class ManagedObjectApplication(ExtModelApplication):
             return self.render_plain_text(zlib.decompress(smart_bytes(d["log"])))
         return self.render_plain_text("No data")
 
-    @api.get(url=r"^(?P<id>\d+)/interactions/$", access="interactions")
+    @api.get(r"^(?P<id>\d+)/interactions/$", access="interactions")
     def api_interactions(self, request: HttpRequest, id):
         o = self.get_object_or_404(ManagedObject, id=id)
         if not o.has_access(request.user):
@@ -1023,7 +1023,7 @@ class ManagedObjectApplication(ExtModelApplication):
             for i in InteractionLog.objects.filter(object=o.id).order_by("-timestamp")
         ]
 
-    @api.get(url=r"^(?P<id>\d+)/scripts/$", access="script")
+    @api.get(r"^(?P<id>\d+)/scripts/$", access="script")
     def api_scripts(self, request: HttpRequest, id):
         o = self.get_object_or_404(ManagedObject, id=id)
         if not o.has_access(request.user):
@@ -1046,7 +1046,7 @@ class ManagedObjectApplication(ExtModelApplication):
             r += [ss]
         return r
 
-    @api.post(url=r"^(?P<id>\d+)/scripts/(?P<name>[^/]+)/$", access="script")
+    @api.post(r"^(?P<id>\d+)/scripts/(?P<name>[^/]+)/$", access="script")
     def api_run_script(self, request: HttpRequest, id, name):
         o = self.get_object_or_404(ManagedObject, id=id)
         if not o.has_access(request.user):
@@ -1060,7 +1060,7 @@ class ManagedObjectApplication(ExtModelApplication):
             return {"error": str(e)}
         return {"result": result}
 
-    @api.post(url=r"^(?P<id>\d+)/console/$", access="console")
+    @api.post(r"^(?P<id>\d+)/console/$", access="console")
     def api_console_command(self, request: HttpRequest, id):
         o = self.get_object_or_404(ManagedObject, id=id)
         if not o.has_access(request.user):
@@ -1074,7 +1074,7 @@ class ManagedObjectApplication(ExtModelApplication):
             return {"error": str(e)}
         return {"result": result}
 
-    @api.get(url=r"(?P<id>\d+)/caps/$", access="read")
+    @api.get(r"(?P<id>\d+)/caps/$", access="read")
     def api_get_caps(self, request: HttpRequest, id):
         o = self.get_object_or_404(ManagedObject, id=id)
         if not o.has_access(request.user):
@@ -1088,7 +1088,7 @@ class ManagedObjectApplication(ExtModelApplication):
             r.append(caps)
         return sorted(r, key=lambda x: x["capability"])
 
-    @api.post(url=r"(?P<id>\d+)/actions/(?P<action>\S+)/$", access="action")
+    @api.post(r"(?P<id>\d+)/actions/(?P<action>\S+)/$", access="action")
     def api_action(self, request: HttpRequest, id, action):
         def execute(o, a, args):
             return a.execute(o, **args)
@@ -1105,7 +1105,7 @@ class ManagedObjectApplication(ExtModelApplication):
         return self.submit_slow_op(request, execute, o, a, args)
 
     @api.post(
-        url=r"(?P<id>\d+)/mappings/$",
+        r"(?P<id>\d+)/mappings/$",
         access="change_mappings",
         validate={
             "mappings": DictListParameter(
@@ -1126,7 +1126,7 @@ class ManagedObjectApplication(ExtModelApplication):
         r = [m.get_object_form(o) for m in o.iter_remote_mappings()]
         return {"status": True, "data": r}
 
-    @api.post(url=r"^link/fix/(?P<link_id>[0-9a-f]{24})/$", access="change_link")
+    @api.post(r"^link/fix/(?P<link_id>[0-9a-f]{24})/$", access="change_link")
     def api_fix_links(self, request: HttpRequest, link_id):
         def get_mac(arp, ip):
             for r in arp:
@@ -1208,7 +1208,7 @@ class ManagedObjectApplication(ExtModelApplication):
         iface1.link_ptp(iface2, method="macfix")
         return success_status("Relinked")
 
-    @api.get(url=r"^(?P<id>\d+)/cpe/$", access="read")
+    @api.get(r"^(?P<id>\d+)/cpe/$", access="read")
     def api_cpe(self, request: HttpRequest, id):
         """
         GET CPEs
@@ -1260,7 +1260,7 @@ class ManagedObjectApplication(ExtModelApplication):
             return True
         return ManagedObject.objects.filter(id=obj.id).filter(UserAccess.Q(user)).exists()
 
-    @api.get(url=r"^(?P<id>\d+)/map_lookup/$", access="read")
+    @api.get(r"^(?P<id>\d+)/map_lookup/$", access="read")
     def api_map_lookup(self, request: HttpRequest, id):
         o: ManagedObject = self.get_object_or_404(ManagedObject, id=id)
         if not o.has_access(request.user):

--- a/services/web/apps/sa/monitor.py
+++ b/services/web/apps/sa/monitor.py
@@ -13,7 +13,7 @@ import zlib
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.apps.sa.objectlist import ObjectListApplication, view
+from noc.services.web.apps.sa.objectlist import ObjectListApplication, api
 from noc.core.scheduler.scheduler import Scheduler
 from noc.core.scheduler.job import Job
 from noc.core.mongo.connection import get_db
@@ -94,7 +94,7 @@ class MonitorApplication(ObjectListApplication):
             )
         return result
 
-    @view(url=r"^(?P<id>\d+)/discovery_job_log/$", method=["GET"], access="read", api=True)
+    @api.get(url=r"^(?P<id>\d+)/discovery_job_log/$", access="read")
     def api_job_log(self, request: HttpRequest, id):
         o = self.get_object_or_404(ManagedObject, id=id)
         if not o.has_access(request.user):

--- a/services/web/apps/sa/monitor.py
+++ b/services/web/apps/sa/monitor.py
@@ -94,7 +94,7 @@ class MonitorApplication(ObjectListApplication):
             )
         return result
 
-    @api.get(url=r"^(?P<id>\d+)/discovery_job_log/$", access="read")
+    @api.get(r"^(?P<id>\d+)/discovery_job_log/$", access="read")
     def api_job_log(self, request: HttpRequest, id):
         o = self.get_object_or_404(ManagedObject, id=id)
         if not o.has_access(request.user):

--- a/services/web/apps/sa/objectlist.py
+++ b/services/web/apps/sa/objectlist.py
@@ -170,16 +170,12 @@ class ObjectListApplication(ExtApplication):
         self.logger.info(f"Extra: {extra}")
         return extra, [] if "order_by" in extra else order
 
-<<<<<<< HEAD
     @view(method=["POST"], url="^$", access="read", api=True)
-=======
-    @view(method=["GET", "POST"], url="^$", access="read")
->>>>>>> 943534c252 (Refactor @view to @api.XXX)
     def api_list(self, request: HttpRequest):
         return self.list_data(request, self.instance_to_dict)
 
     @api.post(
-        url="^iplist/$",
+        "^iplist/$",
         access="launch",
         validate={
             "query": DictParameter(

--- a/services/web/apps/sa/objectlist.py
+++ b/services/web/apps/sa/objectlist.py
@@ -10,7 +10,7 @@ from django.db.models import Q as d_Q
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extapplication import ExtApplication, view
+from noc.services.web.base.extapplication import ExtApplication, view, api
 from noc.sa.models.managedobject import ManagedObject
 from noc.sa.models.administrativedomain import AdministrativeDomain
 from noc.inv.models.resourcegroup import ResourceGroup
@@ -170,15 +170,17 @@ class ObjectListApplication(ExtApplication):
         self.logger.info(f"Extra: {extra}")
         return extra, [] if "order_by" in extra else order
 
+<<<<<<< HEAD
     @view(method=["POST"], url="^$", access="read", api=True)
+=======
+    @view(method=["GET", "POST"], url="^$", access="read")
+>>>>>>> 943534c252 (Refactor @view to @api.XXX)
     def api_list(self, request: HttpRequest):
         return self.list_data(request, self.instance_to_dict)
 
-    @view(
-        method=["POST"],
+    @api.post(
         url="^iplist/$",
         access="launch",
-        api=True,
         validate={
             "query": DictParameter(
                 attrs={"addresses": ListOfParameter(element=IPv4Parameter(), convert=True)}

--- a/services/web/apps/sa/reportobjectdetail.py
+++ b/services/web/apps/sa/reportobjectdetail.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # fm.reportobjectdetail application
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2023 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -20,7 +20,7 @@ from django.http import HttpResponse
 
 # NOC modules
 from noc.main.models.pool import Pool
-from noc.services.web.base.extapplication import ExtApplication, view
+from noc.services.web.base.extapplication import ExtApplication, api
 from noc.services.web.base.reportdatasources.base import ReportModelFilter
 from noc.services.web.base.reportdatasources.report_objectlinkcount import ReportObjectLinkCount
 from noc.services.web.base.reportdatasources.report_objectifacestypestat import (
@@ -143,11 +143,9 @@ class ReportObjectDetailApplication(ExtApplication):
                 mos = mos.filter(segment__in=segment.get_nested_ids())
         return mos
 
-    @view(
+    @api.get(
         "^download/$",
-        method=["GET"],
         access="launch",
-        api=True,
         validate={
             "administrative_domain": StringParameter(required=False),
             "pool": StringParameter(required=False),

--- a/services/web/apps/sa/runcommands.py
+++ b/services/web/apps/sa/runcommands.py
@@ -10,7 +10,7 @@ from django.http import HttpRequest
 
 # NOC modules
 from noc.services.web.base.extapplication import ExtApplication
-from noc.services.web.base.application import view
+from noc.services.web.base.application import api
 from noc.core.translation import ugettext as _
 from noc.core.models.valuetype import ValueType
 from noc.sa.models.managedobject import ManagedObject
@@ -41,7 +41,7 @@ class RunCommandsApplication(ExtApplication):
             },
         }
 
-    @view(url=r"^form/snippet/(?P<snippet_id>\d+)/$", method=["GET"], access="launch", api=True)
+    @api.get(url=r"^form/snippet/(?P<snippet_id>\d+)/$", access="launch")
     def api_form_snippet(self, request: HttpRequest, snippet_id):
         snippet = self.get_object_or_404(CommandSnippet, id=int(snippet_id))
         r = []
@@ -56,9 +56,7 @@ class RunCommandsApplication(ExtApplication):
             r += [cfg]
         return r
 
-    @view(
-        url=r"^form/action/(?P<action_id>[0-9a-f]{24})/$", method=["GET"], access="launch", api=True
-    )
+    @api.get(url=r"^form/action/(?P<action_id>[0-9a-f]{24})/$", access="launch")
     def api_form_action(self, request: HttpRequest, action_id):
         action = self.get_object_or_404(Action, id=action_id)
         r = []
@@ -75,15 +73,13 @@ class RunCommandsApplication(ExtApplication):
             r += [cfg]
         return r
 
-    @view(
+    @api.post(
         url=r"^render/snippet/(?P<snippet_id>\d+)/$",
-        method=["POST"],
         validate={
             "objects": ListOfParameter(element=ModelParameter(ManagedObject)),
             "config": DictParameter(),
         },
         access="launch",
-        api=True,
     )
     def api_render_snippet(self, request: HttpRequest, snippet_id, objects, config):
         snippet = self.get_object_or_404(CommandSnippet, id=int(snippet_id))
@@ -93,15 +89,13 @@ class RunCommandsApplication(ExtApplication):
             r[mo.id] = snippet.expand(config)
         return r
 
-    @view(
+    @api.post(
         url=r"^render/action/(?P<action_id>[0-9a-f]{24})/$",
-        method=["POST"],
         validate={
             "objects": ListOfParameter(element=ModelParameter(ManagedObject)),
             "config": DictParameter(),
         },
         access="launch",
-        api=True,
     )
     def api_render_action(self, request: HttpRequest, action_id, objects, config):
         action = self.get_object_or_404(Action, id=action_id)

--- a/services/web/apps/sa/runcommands.py
+++ b/services/web/apps/sa/runcommands.py
@@ -41,7 +41,7 @@ class RunCommandsApplication(ExtApplication):
             },
         }
 
-    @api.get(url=r"^form/snippet/(?P<snippet_id>\d+)/$", access="launch")
+    @api.get(r"^form/snippet/(?P<snippet_id>\d+)/$", access="launch")
     def api_form_snippet(self, request: HttpRequest, snippet_id):
         snippet = self.get_object_or_404(CommandSnippet, id=int(snippet_id))
         r = []
@@ -56,7 +56,7 @@ class RunCommandsApplication(ExtApplication):
             r += [cfg]
         return r
 
-    @api.get(url=r"^form/action/(?P<action_id>[0-9a-f]{24})/$", access="launch")
+    @api.get(r"^form/action/(?P<action_id>[0-9a-f]{24})/$", access="launch")
     def api_form_action(self, request: HttpRequest, action_id):
         action = self.get_object_or_404(Action, id=action_id)
         r = []
@@ -74,7 +74,7 @@ class RunCommandsApplication(ExtApplication):
         return r
 
     @api.post(
-        url=r"^render/snippet/(?P<snippet_id>\d+)/$",
+        r"^render/snippet/(?P<snippet_id>\d+)/$",
         validate={
             "objects": ListOfParameter(element=ModelParameter(ManagedObject)),
             "config": DictParameter(),
@@ -90,7 +90,7 @@ class RunCommandsApplication(ExtApplication):
         return r
 
     @api.post(
-        url=r"^render/action/(?P<action_id>[0-9a-f]{24})/$",
+        r"^render/action/(?P<action_id>[0-9a-f]{24})/$",
         validate={
             "objects": ListOfParameter(element=ModelParameter(ManagedObject)),
             "config": DictParameter(),

--- a/services/web/apps/sa/service.py
+++ b/services/web/apps/sa/service.py
@@ -183,7 +183,7 @@ class ServiceApplication(ExtDocApplication):
         # Clean other
         return super().clean(data)
 
-    @view("^(?P<id>[0-9a-f]{24})/get_path/$", access="read")
+    @api.get("^(?P<id>[0-9a-f]{24})/get_path/$", access="read")
     def api_get_path(self, request: HttpRequest, id):
         o = self.get_object_or_404(Service, id=id)
         path = [Service.get_by_id(ns) for ns in o.get_path()]
@@ -233,7 +233,7 @@ class ServiceApplication(ExtDocApplication):
             ]
         return r
 
-    @view(r"^(?P<sid>[0-9a-f]{24})/resource/(?P<r_type>\S+)/", access="read")
+    @api.get(r"^(?P<sid>[0-9a-f]{24})/resource/(?P<r_type>\S+)/", access="read")
     def api_get_instance_resources(self, request: HttpRequest, sid: str, r_type: str):
         # o = self.get_object_or_404(Service, id=sid)
         q = self.parse_request_query(request)
@@ -261,7 +261,7 @@ class ServiceApplication(ExtDocApplication):
             )
         return r
 
-    @view("^(?P<sid>[0-9a-f]{24})/instance/$", access="read")
+    @api.get("^(?P<sid>[0-9a-f]{24})/instance/$", access="read")
     def api_get_instance(self, request: HttpRequest, sid: str):
         o = self.get_object_or_404(Service, id=sid)
         r = []

--- a/services/web/apps/sa/service.py
+++ b/services/web/apps/sa/service.py
@@ -270,7 +270,7 @@ class ServiceApplication(ExtDocApplication):
         return r
 
     @api.put(
-        url=r"^(?P<sid>[0-9a-f]{24})/instance/(?P<iid>[0-9a-f]{24})/$",
+        r"^(?P<sid>[0-9a-f]{24})/instance/(?P<iid>[0-9a-f]{24})/$",
         access="update",
         validate={
             "name": UnicodeParameter(required=False),
@@ -298,7 +298,7 @@ class ServiceApplication(ExtDocApplication):
         return {"success": True, "data": self.instance_to_dict_si(si)}
 
     @api.post(
-        url=r"^(?P<sid>[0-9a-f]{24})/register_instance/(?P<i_type>\S+)/$",
+        r"^(?P<sid>[0-9a-f]{24})/register_instance/(?P<i_type>\S+)/$",
         access="register_instance",
         validate={
             "name": UnicodeParameter(required=False),
@@ -322,7 +322,7 @@ class ServiceApplication(ExtDocApplication):
         return {"success": True, "data": self.instance_to_dict_si(si)}
 
     @api.post(
-        url=r"^(?P<sid>[0-9a-f]{24})/unregister_instance/(?P<iid>[0-9a-f]{24})/$",
+        r"^(?P<sid>[0-9a-f]{24})/unregister_instance/(?P<iid>[0-9a-f]{24})/$",
         access="unregister_instance",
     )
     def api_unregister_instance(
@@ -338,7 +338,7 @@ class ServiceApplication(ExtDocApplication):
 
     # Resource Working
     @api.put(
-        url=r"^(?P<sid>[0-9a-f]{24})/instance/(?P<iid>[0-9a-f]{24})/bind/$",
+        r"^(?P<sid>[0-9a-f]{24})/instance/(?P<iid>[0-9a-f]{24})/bind/$",
         access="update",
         validate=DictParameter(
             attrs={
@@ -379,7 +379,7 @@ class ServiceApplication(ExtDocApplication):
         return {"success": True, "data": self.instance_to_dict_si(si)}
 
     @api.put(
-        url=r"^(?P<sid>[0-9a-f]{24})/instance/(?P<iid>[0-9a-f]{24})/unbind/(?P<r_type>\S+)/",
+        r"^(?P<sid>[0-9a-f]{24})/instance/(?P<iid>[0-9a-f]{24})/unbind/(?P<r_type>\S+)/",
         access="update",
     )
     def api_instance_unbind(

--- a/services/web/apps/sa/service.py
+++ b/services/web/apps/sa/service.py
@@ -13,7 +13,7 @@ from mongoengine.queryset import Q
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view, api
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.services.web.base.decorators.state import state_handler
 from noc.services.web.base.decorators.caps import capabilities_handler
 from noc.services.web.base.decorators.watch import watch_handler

--- a/services/web/apps/sa/service.py
+++ b/services/web/apps/sa/service.py
@@ -13,7 +13,7 @@ from mongoengine.queryset import Q
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, view, api
 from noc.services.web.base.decorators.state import state_handler
 from noc.services.web.base.decorators.caps import capabilities_handler
 from noc.services.web.base.decorators.watch import watch_handler
@@ -183,7 +183,7 @@ class ServiceApplication(ExtDocApplication):
         # Clean other
         return super().clean(data)
 
-    @view("^(?P<id>[0-9a-f]{24})/get_path/$", access="read", api=True)
+    @view("^(?P<id>[0-9a-f]{24})/get_path/$", access="read")
     def api_get_path(self, request: HttpRequest, id):
         o = self.get_object_or_404(Service, id=id)
         path = [Service.get_by_id(ns) for ns in o.get_path()]
@@ -233,7 +233,7 @@ class ServiceApplication(ExtDocApplication):
             ]
         return r
 
-    @view(r"^(?P<sid>[0-9a-f]{24})/resource/(?P<r_type>\S+)/", access="read", api=True)
+    @view(r"^(?P<sid>[0-9a-f]{24})/resource/(?P<r_type>\S+)/", access="read")
     def api_get_instance_resources(self, request: HttpRequest, sid: str, r_type: str):
         # o = self.get_object_or_404(Service, id=sid)
         q = self.parse_request_query(request)
@@ -261,7 +261,7 @@ class ServiceApplication(ExtDocApplication):
             )
         return r
 
-    @view("^(?P<sid>[0-9a-f]{24})/instance/$", access="read", api=True)
+    @view("^(?P<sid>[0-9a-f]{24})/instance/$", access="read")
     def api_get_instance(self, request: HttpRequest, sid: str):
         o = self.get_object_or_404(Service, id=sid)
         r = []
@@ -269,16 +269,14 @@ class ServiceApplication(ExtDocApplication):
             r.append(self.instance_to_dict_si(si))
         return r
 
-    @view(
-        "^(?P<sid>[0-9a-f]{24})/instance/(?P<iid>[0-9a-f]{24})/$",
-        method=["PUT"],
+    @api.put(
+        url=r"^(?P<sid>[0-9a-f]{24})/instance/(?P<iid>[0-9a-f]{24})/$",
         access="update",
         validate={
             "name": UnicodeParameter(required=False),
             "fqdn": UnicodeParameter(required=False),
             "port": IntParameter(required=False, min_value=0, max_value=65536),
         },
-        api=True,
     )
     def api_update_instance(
         self,
@@ -299,16 +297,13 @@ class ServiceApplication(ExtDocApplication):
         si.save()
         return {"success": True, "data": self.instance_to_dict_si(si)}
 
-    # New Instance working
-    @view(
-        r"^(?P<sid>[0-9a-f]{24})/register_instance/(?P<i_type>\S+)/$",
-        method=["POST"],
+    @api.post(
+        url=r"^(?P<sid>[0-9a-f]{24})/register_instance/(?P<i_type>\S+)/$",
         access="register_instance",
         validate={
             "name": UnicodeParameter(required=False),
             "fqdn": UnicodeParameter(required=False),
         },
-        api=True,
     )
     def api_register_instance(
         self,
@@ -326,11 +321,9 @@ class ServiceApplication(ExtDocApplication):
         si = o.register_instance(i_type, name=name, fqdn=fqdn)
         return {"success": True, "data": self.instance_to_dict_si(si)}
 
-    @view(
-        r"^(?P<sid>[0-9a-f]{24})/unregister_instance/(?P<iid>[0-9a-f]{24})/$",
-        method=["POST"],
+    @api.post(
+        url=r"^(?P<sid>[0-9a-f]{24})/unregister_instance/(?P<iid>[0-9a-f]{24})/$",
         access="unregister_instance",
-        api=True,
     )
     def api_unregister_instance(
         self,
@@ -344,9 +337,8 @@ class ServiceApplication(ExtDocApplication):
         return {"success": True}
 
     # Resource Working
-    @view(
-        r"^(?P<sid>[0-9a-f]{24})/instance/(?P<iid>[0-9a-f]{24})/bind/$",
-        method=["PUT"],
+    @api.put(
+        url=r"^(?P<sid>[0-9a-f]{24})/instance/(?P<iid>[0-9a-f]{24})/bind/$",
         access="update",
         validate=DictParameter(
             attrs={
@@ -361,7 +353,6 @@ class ServiceApplication(ExtDocApplication):
                 "resources": StringListParameter(required=False),
             },
         ),
-        api=True,
     )
     def api_instance_bind(
         self,
@@ -387,11 +378,9 @@ class ServiceApplication(ExtDocApplication):
             si.update_resources(r, source=InputSource.MANUAL)
         return {"success": True, "data": self.instance_to_dict_si(si)}
 
-    @view(
-        r"^(?P<sid>[0-9a-f]{24})/instance/(?P<iid>[0-9a-f]{24})/unbind/(?P<r_type>\S+)/",
-        method=["PUT"],
+    @api.put(
+        url=r"^(?P<sid>[0-9a-f]{24})/instance/(?P<iid>[0-9a-f]{24})/unbind/(?P<r_type>\S+)/",
         access="update",
-        api=True,
     )
     def api_instance_unbind(
         self,

--- a/services/web/apps/support/account.py
+++ b/services/web/apps/support/account.py
@@ -23,7 +23,7 @@ class AccountApplication(ExtApplication):
     title = _("Account")
     menu = [_("Setup"), _("Account")]
 
-    @api.get(url=r"^$", access="launch")
+    @api.get(r"^$", access="launch")
     def api_get(self, request: HttpRequest):
         c = CPClient()
         data = {}
@@ -36,7 +36,7 @@ class AccountApplication(ExtApplication):
         return data
 
     @api.post(
-        url="^account/attach/$",
+        "^account/attach/$",
         access="launch",
         validate={"name": StringParameter(), "password": StringParameter(required=False)},
     )
@@ -51,7 +51,7 @@ class AccountApplication(ExtApplication):
         return {"status": True, "message": "Ok"}
 
     @api.post(
-        url="^account/$",
+        "^account/$",
         access="launch",
         validate={
             "name": REStringParameter(r"^[a-zA-Z0-9\.\-_]+$"),
@@ -100,7 +100,7 @@ class AccountApplication(ExtApplication):
         return {"status": True, "message": "Account saved"}
 
     @api.post(
-        url=r"^account/change_password/$",
+        r"^account/change_password/$",
         access="launch",
         validate={"old_password": StringParameter(), "new_password": StringParameter()},
     )
@@ -116,7 +116,7 @@ class AccountApplication(ExtApplication):
         return {"status": True, "message": "Password has been changed"}
 
     @api.post(
-        url=r"^system/$",
+        r"^system/$",
         access="launch",
         validate={
             "name": REStringParameter(r"^[a-zA-Z0-9\.\-_]+$"),

--- a/services/web/apps/support/account.py
+++ b/services/web/apps/support/account.py
@@ -9,7 +9,7 @@
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extapplication import ExtApplication, view
+from noc.services.web.base.extapplication import ExtApplication, api
 from noc.support.cp import CPClient
 from noc.sa.interfaces.base import StringParameter, REStringParameter
 from noc.core.translation import ugettext as _
@@ -23,7 +23,7 @@ class AccountApplication(ExtApplication):
     title = _("Account")
     menu = [_("Setup"), _("Account")]
 
-    @view(url=r"^$", method=["GET"], access="launch", api=True)
+    @api.get(url=r"^$", access="launch")
     def api_get(self, request: HttpRequest):
         c = CPClient()
         data = {}
@@ -35,11 +35,9 @@ class AccountApplication(ExtApplication):
             data["system"] = c.system_info()
         return data
 
-    @view(
+    @api.post(
         url="^account/attach/$",
-        method=["POST"],
         access="launch",
-        api=True,
         validate={"name": StringParameter(), "password": StringParameter(required=False)},
     )
     def api_attach_account(self, request: HttpRequest, name, password):
@@ -52,11 +50,9 @@ class AccountApplication(ExtApplication):
             return {"status": False, "message": str(e)}
         return {"status": True, "message": "Ok"}
 
-    @view(
+    @api.post(
         url="^account/$",
-        method=["POST"],
         access="launch",
-        api=True,
         validate={
             "name": REStringParameter(r"^[a-zA-Z0-9\.\-_]+$"),
             "email": StringParameter(),
@@ -103,11 +99,9 @@ class AccountApplication(ExtApplication):
                 return {"status": False, "message": str(e)}
         return {"status": True, "message": "Account saved"}
 
-    @view(
+    @api.post(
         url=r"^account/change_password/$",
-        method=["POST"],
         access="launch",
-        api=True,
         validate={"old_password": StringParameter(), "new_password": StringParameter()},
     )
     def api_change_password(
@@ -121,11 +115,9 @@ class AccountApplication(ExtApplication):
         c.change_password(new_password)
         return {"status": True, "message": "Password has been changed"}
 
-    @view(
+    @api.post(
         url=r"^system/$",
-        method=["POST"],
         access="launch",
-        api=True,
         validate={
             "name": REStringParameter(r"^[a-zA-Z0-9\.\-_]+$"),
             "type": StringParameter(required=False),

--- a/services/web/apps/support/crashinfo.py
+++ b/services/web/apps/support/crashinfo.py
@@ -12,7 +12,7 @@ import uuid
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.support.models.crashinfo import Crashinfo
 from noc.core.translation import ugettext as _
 
@@ -26,7 +26,7 @@ class CrashinfoApplication(ExtDocApplication):
     menu = _("Crashinfo")
     model = Crashinfo
 
-    @view(url=r"^(?P<id>\S+)/traceback/", method=["GET"], access="read", api=True)
+    @api.get(url=r"^(?P<id>\S+)/traceback/", access="read")
     def api_traceback(self, request: HttpRequest, id):
         ci = self.get_object_or_404(Crashinfo, uuid=uuid.UUID(id))
         return ci.traceback

--- a/services/web/apps/support/crashinfo.py
+++ b/services/web/apps/support/crashinfo.py
@@ -26,7 +26,7 @@ class CrashinfoApplication(ExtDocApplication):
     menu = _("Crashinfo")
     model = Crashinfo
 
-    @api.get(url=r"^(?P<id>\S+)/traceback/", access="read")
+    @api.get(r"^(?P<id>\S+)/traceback/", access="read")
     def api_traceback(self, request: HttpRequest, id):
         ci = self.get_object_or_404(Crashinfo, uuid=uuid.UUID(id))
         return ci.traceback

--- a/services/web/apps/vc/vlan.py
+++ b/services/web/apps/vc/vlan.py
@@ -13,7 +13,7 @@ from django.http import HttpResponse, HttpRequest
 from mongoengine import Q
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.services.web.base.decorators.state import state_handler
 from noc.inv.models.subinterface import SubInterface
 from noc.inv.models.resourcepool import ResourcePool
@@ -130,7 +130,7 @@ class VLANApplication(ExtDocApplication):
             ]
         return data
 
-    @view(url=r"^(?P<vlan_id>[0-9a-f]{24})/interfaces/$", method=["GET"], access="read", api=True)
+    @api.get(url=r"^(?P<vlan_id>[0-9a-f]{24})/interfaces/$", access="read")
     def api_interfaces(self, request: HttpRequest, vlan_id: int):
         """
         Returns a dict of {untagged: ..., tagged: ...., l3: ...}
@@ -191,11 +191,9 @@ class VLANApplication(ExtDocApplication):
             "l3": sorted(l3, key=lambda x: x["managed_object_name"]),
         }
 
-    @view(
+    @api.get(
         url="^allocate/$",
-        method=["GET"],
         access="allocate",
-        api=True,
         validate={
             "l2_domain": DocumentParameter(L2Domain),
             "pool": DocumentParameter(ResourcePool, required=True),

--- a/services/web/apps/vc/vlan.py
+++ b/services/web/apps/vc/vlan.py
@@ -130,7 +130,7 @@ class VLANApplication(ExtDocApplication):
             ]
         return data
 
-    @api.get(url=r"^(?P<vlan_id>[0-9a-f]{24})/interfaces/$", access="read")
+    @api.get(r"^(?P<vlan_id>[0-9a-f]{24})/interfaces/$", access="read")
     def api_interfaces(self, request: HttpRequest, vlan_id: int):
         """
         Returns a dict of {untagged: ..., tagged: ...., l3: ...}
@@ -192,7 +192,7 @@ class VLANApplication(ExtDocApplication):
         }
 
     @api.get(
-        url="^allocate/$",
+        "^allocate/$",
         access="allocate",
         validate={
             "l2_domain": DocumentParameter(L2Domain),

--- a/services/web/apps/wf/workflow.py
+++ b/services/web/apps/wf/workflow.py
@@ -13,7 +13,7 @@ from copy import deepcopy
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtDocApplication, view
+from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.main.models.label import Label
 from noc.wf.models.workflow import Workflow
 from noc.wf.models.state import State
@@ -40,7 +40,7 @@ class WorkflowApplication(ExtDocApplication):
 
     NEW_ID = "000000000000000000000000"
 
-    @view(r"^(?P<id>[0-9a-f]{24})/config/", method=["GET"], access="write", api=True)
+    @api.get(r"^(?P<id>[0-9a-f]{24})/config/", access="write")
     def api_get_config(self, request: HttpRequest, id):
         wf = self.get_object_or_404(Workflow, id=id)
         r = {
@@ -104,11 +104,9 @@ class WorkflowApplication(ExtDocApplication):
             r["transitions"] += [tr]
         return r
 
-    @view(
+    @api.post(
         r"^(?P<id>[0-9a-f]{24})/config/",
-        method=["POST"],
         access="write",
-        api=True,
         validate={
             "name": StringParameter(),
             "description": StringParameter(default=""),
@@ -254,7 +252,7 @@ class WorkflowApplication(ExtDocApplication):
 
     rx_clone_name = re.compile(r"\(Copy #(\d+)\)$")
 
-    @view(r"^(?P<id>[0-9a-f]{24})/clone/", method=["POST"], access="write", api=True)
+    @api.post(r"^(?P<id>[0-9a-f]{24})/clone/", access="write")
     def api_clone(self, request: HttpRequest, id):
         wf = self.get_object_or_404(Workflow, id=id)
         # Get all clone names

--- a/services/web/base/api.py
+++ b/services/web/base/api.py
@@ -89,8 +89,7 @@ class ViewAPI:
     using the common :func:`view` decorator.
 
     Example:
-        @api.get(
-            url="^brief_lookup/$",
+        @api.get("^brief_lookup/$",
             access="lookup",
         )
         def api_brief(self, request: HttpRequest):

--- a/services/web/base/application.py
+++ b/services/web/base/application.py
@@ -557,7 +557,7 @@ class Application(metaclass=ApplicationBase):
             return v.astimezone(self.TZ).isoformat()
         raise Exception("Invalid to_json type")
 
-    @view(url="^launch_info/$", method=["GET"], access="launch", api=True)
+    @api.get(url="^launch_info/$", access="launch")
     def api_launch_info(self, request):
         return self.get_launch_info(request)
 

--- a/services/web/base/application.py
+++ b/services/web/base/application.py
@@ -557,7 +557,7 @@ class Application(metaclass=ApplicationBase):
             return v.astimezone(self.TZ).isoformat()
         raise Exception("Invalid to_json type")
 
-    @api.get(url="^launch_info/$", access="launch")
+    @api.get("^launch_info/$", access="launch")
     def api_launch_info(self, request):
         return self.get_launch_info(request)
 

--- a/services/web/base/extapplication.py
+++ b/services/web/base/extapplication.py
@@ -318,7 +318,7 @@ class ExtApplication(Application):
         """
         return self.apply_bulk_fields(data)
 
-    @api.post(url=r"^favorites/app/(?P<action>set|reset)/$", access=PermitLogged())
+    @api.post(r"^favorites/app/(?P<action>set|reset)/$", access=PermitLogged())
     def api_favorites_app(self, request, action):
         """
         Set/reset favorite app status
@@ -333,9 +333,7 @@ class ExtApplication(Application):
             Favorites(user=request.user, app=self.app_id, favorite_app=v).save()
         return True
 
-    @api.post(
-        url=r"^favorites/item/(?P<item>[0-9a-f]+)/(?P<action>set|reset)/$", access=PermitLogged()
-    )
+    @api.post(r"^favorites/item/(?P<item>[0-9a-f]+)/(?P<action>set|reset)/$", access=PermitLogged())
     def api_favorites_items(self, request, item, action):
         """
         Set/reset favorite items
@@ -347,7 +345,7 @@ class ExtApplication(Application):
             Favorites.remove_item(request.user, self.app_id, item)
         return True
 
-    @api.get(url=r"^futures/(?P<f_id>[0-9a-f]{24})/$", access="launch")
+    @api.get(r"^futures/(?P<f_id>[0-9a-f]{24})/$", access="launch")
     def api_future_status(self, request, f_id):
         op = self.get_object_or_404(
             SlowOp, id=f_id, app_id=self.get_app_id(), user=request.user.username

--- a/services/web/base/extapplication.py
+++ b/services/web/base/extapplication.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # ExtApplication implementation
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2024 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -318,12 +318,7 @@ class ExtApplication(Application):
         """
         return self.apply_bulk_fields(data)
 
-    @view(
-        url=r"^favorites/app/(?P<action>set|reset)/$",
-        method=["POST"],
-        access=PermitLogged(),
-        api=True,
-    )
+    @api.post(url=r"^favorites/app/(?P<action>set|reset)/$", access=PermitLogged())
     def api_favorites_app(self, request, action):
         """
         Set/reset favorite app status
@@ -338,11 +333,8 @@ class ExtApplication(Application):
             Favorites(user=request.user, app=self.app_id, favorite_app=v).save()
         return True
 
-    @view(
-        url=r"^favorites/item/(?P<item>[0-9a-f]+)/(?P<action>set|reset)/$",
-        method=["POST"],
-        access=PermitLogged(),
-        api=True,
+    @api.post(
+        url=r"^favorites/item/(?P<item>[0-9a-f]+)/(?P<action>set|reset)/$", access=PermitLogged()
     )
     def api_favorites_items(self, request, item, action):
         """
@@ -355,7 +347,7 @@ class ExtApplication(Application):
             Favorites.remove_item(request.user, self.app_id, item)
         return True
 
-    @view(url=r"^futures/(?P<f_id>[0-9a-f]{24})/$", method=["GET"], access="launch", api=True)
+    @api.get(url=r"^futures/(?P<f_id>[0-9a-f]{24})/$", access="launch")
     def api_future_status(self, request, f_id):
         op = self.get_object_or_404(
             SlowOp, id=f_id, app_id=self.get_app_id(), user=request.user.username

--- a/services/web/base/extdocapplication.py
+++ b/services/web/base/extdocapplication.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # ExtDocApplication implementation
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2025 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -422,18 +422,18 @@ class ExtDocApplication(ExtApplication):
             r["row_class"] = o.get_css_class() or ""
         return r
 
-    @view(method=["GET"], url=r"^$", access="read", api=True)
+    @api.get(url=r"^$", access="read")
     def api_list(self, request):
         return self.list_data(request, self.instance_to_dict_list)
 
-    @view(method=["GET"], url=r"^lookup/$", access="lookup", api=True)
+    @api.get(url=r"^lookup/$", access="lookup")
     def api_lookup(self, request):
         try:
             return self.list_data(request, self.instance_to_lookup)
         except ValueError:
             return self.response(self.lookup_default, status=self.OK)
 
-    @view(method=["GET"], url=r"^tree_lookup/$", access="lookup", api=True)
+    @api.get(url=r"^tree_lookup/$", access="lookup")
     def api_lookup_tree(self, request):
         def trim(s):
             return smart_text(s).rsplit(" | ")[-1]
@@ -457,7 +457,7 @@ class ExtDocApplication(ExtApplication):
         data = [{"id": str(o.id), "label": trim(o)} for o in data]
         return {"total": count, "status": True, "data": data}
 
-    @view(method=["POST"], url="^$", access="create", api=True)
+    @api.post(url="^$", access="create")
     def api_create(self, request):
         is_json = self.site.is_json(request.META.get("CONTENT_TYPE"))
         try:
@@ -506,11 +506,9 @@ class ExtDocApplication(ExtApplication):
             r = self.instance_to_dict(o)
         return self.response(r, status=self.CREATED)
 
-    @view(
-        method=["GET"],
+    @api.get(
         url=r"^(?P<id>[0-9a-f]{24}|\d+|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/?$",
         access="read",
-        api=True,
     )
     def api_read(self, request, id):
         """
@@ -527,11 +525,9 @@ class ExtDocApplication(ExtApplication):
             only = only.split(",")
         return self.response(self.instance_to_dict(o, fields=only), status=self.OK)
 
-    @view(
-        method=["PUT"],
+    @api.put(
         url=r"^(?P<id>[0-9a-f]{24}|\d+|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/?$",
         access="update",
-        api=True,
     )
     def api_update(self, request, id):
         try:
@@ -568,11 +564,9 @@ class ExtDocApplication(ExtApplication):
             r = self.instance_to_dict(o)
         return self.response(r, status=self.OK)
 
-    @view(
-        method=["DELETE"],
+    @api.delete(
         url=r"^(?P<id>[0-9a-f]{24}|\d+|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/?$",
         access="delete",
-        api=True,
     )
     def api_delete(self, request, id):
         try:
@@ -633,7 +627,7 @@ class ExtDocApplication(ExtApplication):
             x["is_builtin"] = u and u in builtins
         return data
 
-    @view(url=r"^actions/group_edit/$", method=["POST"], access="update", api=True)
+    @api.post(url=r"^actions/group_edit/$", access="update")
     def api_action_group_edit(self, request):
         validator = DictParameter(
             attrs={"ids": ListOfParameter(element=DocumentParameter(self.model), convert=True)}

--- a/services/web/base/extdocapplication.py
+++ b/services/web/base/extdocapplication.py
@@ -422,18 +422,18 @@ class ExtDocApplication(ExtApplication):
             r["row_class"] = o.get_css_class() or ""
         return r
 
-    @api.get(url=r"^$", access="read")
+    @api.get(r"^$", access="read")
     def api_list(self, request):
         return self.list_data(request, self.instance_to_dict_list)
 
-    @api.get(url=r"^lookup/$", access="lookup")
+    @api.get(r"^lookup/$", access="lookup")
     def api_lookup(self, request):
         try:
             return self.list_data(request, self.instance_to_lookup)
         except ValueError:
             return self.response(self.lookup_default, status=self.OK)
 
-    @api.get(url=r"^tree_lookup/$", access="lookup")
+    @api.get(r"^tree_lookup/$", access="lookup")
     def api_lookup_tree(self, request):
         def trim(s):
             return smart_text(s).rsplit(" | ")[-1]
@@ -457,7 +457,7 @@ class ExtDocApplication(ExtApplication):
         data = [{"id": str(o.id), "label": trim(o)} for o in data]
         return {"total": count, "status": True, "data": data}
 
-    @api.post(url="^$", access="create")
+    @api.post("^$", access="create")
     def api_create(self, request):
         is_json = self.site.is_json(request.META.get("CONTENT_TYPE"))
         try:
@@ -507,7 +507,7 @@ class ExtDocApplication(ExtApplication):
         return self.response(r, status=self.CREATED)
 
     @api.get(
-        url=r"^(?P<id>[0-9a-f]{24}|\d+|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/?$",
+        r"^(?P<id>[0-9a-f]{24}|\d+|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/?$",
         access="read",
     )
     def api_read(self, request, id):
@@ -526,7 +526,7 @@ class ExtDocApplication(ExtApplication):
         return self.response(self.instance_to_dict(o, fields=only), status=self.OK)
 
     @api.put(
-        url=r"^(?P<id>[0-9a-f]{24}|\d+|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/?$",
+        r"^(?P<id>[0-9a-f]{24}|\d+|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/?$",
         access="update",
     )
     def api_update(self, request, id):
@@ -565,7 +565,7 @@ class ExtDocApplication(ExtApplication):
         return self.response(r, status=self.OK)
 
     @api.delete(
-        url=r"^(?P<id>[0-9a-f]{24}|\d+|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/?$",
+        r"^(?P<id>[0-9a-f]{24}|\d+|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/?$",
         access="delete",
     )
     def api_delete(self, request, id):
@@ -627,7 +627,7 @@ class ExtDocApplication(ExtApplication):
             x["is_builtin"] = u and u in builtins
         return data
 
-    @api.post(url=r"^actions/group_edit/$", access="update")
+    @api.post(r"^actions/group_edit/$", access="update")
     def api_action_group_edit(self, request):
         validator = DictParameter(
             attrs={"ids": ListOfParameter(element=DocumentParameter(self.model), convert=True)}

--- a/services/web/base/extmodelapplication.py
+++ b/services/web/base/extmodelapplication.py
@@ -580,7 +580,7 @@ class ExtModelApplication(ExtApplication):
     def instance_to_dict_list(self, o, fields=None):
         return self.instance_to_dict(o, fields=fields)
 
-    @view(method=["GET"], url=r"^$", access="read", api=True)
+    @api.get(url=r"^$", access="read")
     def api_list(self, request):
         try:
             return self.list_data(request, self.instance_to_dict_list)
@@ -588,7 +588,7 @@ class ExtModelApplication(ExtApplication):
             error_report()
             return self.response({"status": False, "message": str(e)}, status=self.INTERNAL_ERROR)
 
-    @view(method=["GET"], url=r"^lookup/$", access="lookup", api=True)
+    @api.get(url=r"^lookup/$", access="lookup")
     def api_lookup(self, request):
         try:
             return self.list_data(request, self.instance_to_lookup)
@@ -598,7 +598,7 @@ class ExtModelApplication(ExtApplication):
             error_report()
             return self.response({"status": False, "message": str(e)}, status=self.INTERNAL_ERROR)
 
-    @view(method=["POST"], url=r"^$", access="create", api=True)
+    @api.post(url=r"^$", access="create")
     def api_create(self, request):
         if self.site.is_json(request.META.get("CONTENT_TYPE")):
             attrs, m2m_attrs = self.split_mtm(self.deserialize(request.body))
@@ -668,7 +668,7 @@ class ExtModelApplication(ExtApplication):
                 rs = self.instance_to_dict(o)
             return self.response(rs, status=self.CREATED)
 
-    @view(method=["GET"], url=r"^(?P<id>\d+)/?$", access="read", api=True)
+    @api.get(url=r"^(?P<id>\d+)/?$", access="read")
     def api_read(self, request, id):
         """
         Returns dict with object's fields and values
@@ -686,7 +686,7 @@ class ExtModelApplication(ExtApplication):
             error_report()
             return self.response({"status": False, "message": str(e)}, status=self.INTERNAL_ERROR)
 
-    @view(method=["PUT"], url=r"^(?P<id>\d+)/?$", access="update", api=True)
+    @api.put(url=r"^(?P<id>\d+)/?$", access="update")
     def api_update(self, request, id):
         if self.site.is_json(request.META.get("CONTENT_TYPE")):
             attrs, m2m_attrs = self.split_mtm(self.deserialize(request.body))
@@ -760,7 +760,7 @@ class ExtModelApplication(ExtApplication):
             r = self.instance_to_dict(o)
         return self.response(r, status=self.OK)
 
-    @view(method=["DELETE"], url=r"^(?P<id>\d+)/?$", access="delete", api=True)
+    @api.delete(url=r"^(?P<id>\d+)/?$", access="delete")
     def api_delete(self, request, id):
         try:
             o = self.queryset(request).get(**{self.pk: int(id)})
@@ -813,7 +813,7 @@ class ExtModelApplication(ExtApplication):
             x["is_builtin"] = u and u in builtins
         return data
 
-    @view(url=r"^actions/group_edit/$", method=["POST"], access="update", api=True)
+    @api.post(url=r"^actions/group_edit/$", access="update")
     def api_action_group_edit(self, request):
         validator = DictParameter(
             attrs={"ids": ListOfParameter(element=ModelParameter(self.model), convert=True)}

--- a/services/web/base/extmodelapplication.py
+++ b/services/web/base/extmodelapplication.py
@@ -580,7 +580,7 @@ class ExtModelApplication(ExtApplication):
     def instance_to_dict_list(self, o, fields=None):
         return self.instance_to_dict(o, fields=fields)
 
-    @api.get(url=r"^$", access="read")
+    @api.get(r"^$", access="read")
     def api_list(self, request):
         try:
             return self.list_data(request, self.instance_to_dict_list)
@@ -588,7 +588,7 @@ class ExtModelApplication(ExtApplication):
             error_report()
             return self.response({"status": False, "message": str(e)}, status=self.INTERNAL_ERROR)
 
-    @api.get(url=r"^lookup/$", access="lookup")
+    @api.get(r"^lookup/$", access="lookup")
     def api_lookup(self, request):
         try:
             return self.list_data(request, self.instance_to_lookup)
@@ -598,7 +598,7 @@ class ExtModelApplication(ExtApplication):
             error_report()
             return self.response({"status": False, "message": str(e)}, status=self.INTERNAL_ERROR)
 
-    @api.post(url=r"^$", access="create")
+    @api.post(r"^$", access="create")
     def api_create(self, request):
         if self.site.is_json(request.META.get("CONTENT_TYPE")):
             attrs, m2m_attrs = self.split_mtm(self.deserialize(request.body))
@@ -668,7 +668,7 @@ class ExtModelApplication(ExtApplication):
                 rs = self.instance_to_dict(o)
             return self.response(rs, status=self.CREATED)
 
-    @api.get(url=r"^(?P<id>\d+)/?$", access="read")
+    @api.get(r"^(?P<id>\d+)/?$", access="read")
     def api_read(self, request, id):
         """
         Returns dict with object's fields and values
@@ -686,7 +686,7 @@ class ExtModelApplication(ExtApplication):
             error_report()
             return self.response({"status": False, "message": str(e)}, status=self.INTERNAL_ERROR)
 
-    @api.put(url=r"^(?P<id>\d+)/?$", access="update")
+    @api.put(r"^(?P<id>\d+)/?$", access="update")
     def api_update(self, request, id):
         if self.site.is_json(request.META.get("CONTENT_TYPE")):
             attrs, m2m_attrs = self.split_mtm(self.deserialize(request.body))
@@ -760,7 +760,7 @@ class ExtModelApplication(ExtApplication):
             r = self.instance_to_dict(o)
         return self.response(r, status=self.OK)
 
-    @api.delete(url=r"^(?P<id>\d+)/?$", access="delete")
+    @api.delete(r"^(?P<id>\d+)/?$", access="delete")
     def api_delete(self, request, id):
         try:
             o = self.queryset(request).get(**{self.pk: int(id)})
@@ -813,7 +813,7 @@ class ExtModelApplication(ExtApplication):
             x["is_builtin"] = u and u in builtins
         return data
 
-    @api.post(url=r"^actions/group_edit/$", access="update")
+    @api.post(r"^actions/group_edit/$", access="update")
     def api_action_group_edit(self, request):
         validator = DictParameter(
             attrs={"ids": ListOfParameter(element=ModelParameter(self.model), convert=True)}


### PR DESCRIPTION
Refactor `@view` decorators across the web service layer to use method-specific `@api.get/post/put/delete(url, ...)` shortcuts. The new `ViewAPI` class eliminates boilerplate `method=[...]` + `api=True` kwargs, making API endpoints cleaner and more explicit.

**Key Changes**
- Replace `@view(..., method=["GET"], api=True)` → `@api.get(...)` across 78 files in `services/web/apps/`
- All domains covered: aaa, bi, cm, crm, dns, dev, fm, gis, inv, ip, kb, maintenance, nbi, peer, phone, pm, sa, sla, support, vc, wf

**Notable Implementation Details**
- Multi-method endpoints correctly preserved as `@view(..., api=True)` where they can't use single-method decorators (e.g., managedobject.py)
- Non-API views (refbook, calculator, csv, ip/tools, reportapplication) left untouched
- All imports updated: `from ... import ..., api` replaces `..., view` where needed
