### PR TITLE
Replace several @view with @app

### DIFF
--- a/services/web/apps/inv/macdb.py
+++ b/services/web/apps/inv/macdb.py
@@ -14,7 +14,7 @@ from django.http import HttpRequest
 import orjson
 
 # NOC modules
-from noc.services.web.base.extdocapplication import ExtApplication, view, api
+from noc.services.web.base.extdocapplication import ExtApplication, api
 from noc.sa.models.managedobject import ManagedObject
 from noc.sa.interfaces.base import MACAddressParameter
 from noc.core.mac import MAC
@@ -183,7 +183,7 @@ class MACApplication(ExtApplication):
             )
         return out, rows_count
 
-    @view(method=["GET"], url="^$", access="read", api=True)
+    @api.get("^$", access="read")
     def api_list(self, request: HttpRequest):
         q = self.parse_request_query(request)
         query = q.get("__query")

--- a/services/web/apps/sa/managedobject.py
+++ b/services/web/apps/sa/managedobject.py
@@ -19,7 +19,7 @@ from django.db.models import Q as d_Q
 from mongoengine.queryset import Q as MQ
 
 # NOC modules
-from noc.services.web.base.extmodelapplication import ExtModelApplication, view, api
+from noc.services.web.base.extmodelapplication import ExtModelApplication, api
 from noc.services.web.base.decorators.state import state_handler
 from noc.services.web.base.decorators.caps import capabilities_handler
 from noc.sa.models.administrativedomain import AdministrativeDomain
@@ -1293,7 +1293,7 @@ class ManagedObjectApplication(ExtModelApplication):
             ]
         return r
 
-    @view(url=r"^full/", method=["POST"], access="read", api=True)
+    @api.post("^full/", access="read")
     def api_list_full(self, request: HttpRequest):
         try:
             return self.list_data(request, self.instance_to_dict)
@@ -1301,7 +1301,7 @@ class ManagedObjectApplication(ExtModelApplication):
             error_report()
             return self.response({"status": False, "message": str(e)}, status=self.INTERNAL_ERROR)
 
-    @view(url=r"^list/", method=["POST"], access="read", api=True)
+    @api.post(r"^list/", access="read")
     def api_list_short(self, request: HttpRequest):
         try:
             return self.list_data(request, self.instance_to_dict_list)

--- a/services/web/apps/sa/objectlist.py
+++ b/services/web/apps/sa/objectlist.py
@@ -10,7 +10,7 @@ from django.db.models import Q as d_Q
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.extapplication import ExtApplication, view, api
+from noc.services.web.base.extapplication import ExtApplication, api
 from noc.sa.models.managedobject import ManagedObject
 from noc.sa.models.administrativedomain import AdministrativeDomain
 from noc.inv.models.resourcegroup import ResourceGroup
@@ -170,7 +170,7 @@ class ObjectListApplication(ExtApplication):
         self.logger.info(f"Extra: {extra}")
         return extra, [] if "order_by" in extra else order
 
-    @view(method=["POST"], url="^$", access="read", api=True)
+    @api.post("^$", access="read")
     def api_list(self, request: HttpRequest):
         return self.list_data(request, self.instance_to_dict)
 


### PR DESCRIPTION
### Purpose
Continue the migration from legacy `@view(..., api=True)` decorators to the new `@api.get()` / `@api.post()` API introduced in PR #436. This PR replaces 4 endpoint-level decorator occurrences across 3 files.

### Key changes
- **`services/web/apps/inv/macdb.py`** — replace 1 `@view` call on `api_list` (GET) with `@api.get()`
- **`services/web/apps/sa/managedobject.py`** — replace 2 `@view` calls (`api_list_full`, `api_list_short`, both POST) with `@api.post()`
- **`services/web/apps/sa/objectlist.py`** — replace 1 `@view` call on `api_list` (POST) with `@api.post()`

### Notable implementation details
- All original decorators had `api=True`, so semantically they all route to the same underlying `view()` factory via `ViewAPI`. The behavioral effect is identical.
- Removed `view` from import lines in each file as no `@view` references remain post-change.
