### PR TITLE
Remove trivial smart_text/smart_bytes usage

### DIFF
--- a/commands/convert-moin.py
+++ b/commands/convert-moin.py
@@ -3,7 +3,7 @@
 # USAGE:
 # python manage.py convert-moin [--encoding=charset] [--language=lang] [--tags=<taglist>] <path to moin data/ >
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -23,7 +23,7 @@ from noc.main.models.language import Language
 from noc.main.models.databasestorage import database_storage
 from noc.kb.models.kbentry import KBEntry
 from noc.kb.models.kbentryattachment import KBEntryAttachment
-from noc.core.comp import smart_text, smart_bytes
+from noc.core.comp import smart_text
 
 rx_hexseq = re.compile(r"\(((?:[0-9a-f][0-9a-f])+)\)")
 
@@ -68,7 +68,7 @@ class Command(BaseCommand):
         if isinstance(s, str):
             sys.stdout.write(s.encode("utf-8"))
         else:
-            sys.stdout.write(smart_bytes(smart_text(s, encoding=self.encoding)))
+            sys.stdout.write(smart_text(s, encoding=self.encoding).encode())
         sys.stdout.flush()
 
     #

--- a/commands/datastream.py
+++ b/commands/datastream.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # noc datastream command
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -23,7 +23,6 @@ from noc.core.datastream.loader import loader
 from noc.core.mongo.connection import connect
 from noc.models import get_model, get_model_id
 from noc.models import is_document
-from noc.core.comp import smart_text
 
 BATCH_SIZE = 20000
 
@@ -211,7 +210,7 @@ class Command(BaseCommand):
             gt = change_id.generation_time.strftime("%Y-%m-%d %H:%M:%S")
             self.print(f"===[id: {obj_id}, change id: {change_id}, time: {gt}]================")
             d = orjson.loads(data)
-            self.print(smart_text(orjson.dumps(d, option=orjson.OPT_INDENT_2)))
+            self.print(orjson.dumps(d, option=orjson.OPT_INDENT_2).decode())
 
     def handle_clean(self, datastream, *args, **options):
         if datastream not in self.MODELS:

--- a/core/datastream/base.py
+++ b/core/datastream/base.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # DataStream
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -487,7 +487,7 @@ class DataStream:
                 data = {cls.F_CHANGEID: str(doc[cls.F_CHANGEID])}
                 h = {"delete": cls.get_deleted_object, "move": cls.get_moved_object}[filter_policy]
                 data.update(h(doc[cls.F_ID]))
-                data = smart_text(orjson.dumps(data))
+                data = orjson.dumps(data).decode()
             yield doc[cls.F_ID], doc[cls.F_CHANGEID], data
 
     @classmethod
@@ -542,7 +542,7 @@ class DataStream:
                 data = {cls.F_CHANGEID: str(doc[cls.F_CHANGEID])}
                 h = {"delete": cls.get_deleted_object, "move": cls.get_moved_object}[filter_policy]
                 data.update(h(doc[cls.F_ID]))
-                data = smart_text(orjson.dumps(data))
+                data = orjson.dumps(data).decode()
             yield doc[cls.F_ID], doc[cls.F_CHANGEID], data
 
     @classmethod

--- a/core/http/client.py
+++ b/core/http/client.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # HTTP Client
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2022 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -183,7 +183,7 @@ async def fetch(
         body = body or ""
         content_type = "application/binary"
         if not isinstance(body, (str, bytes)):
-            body = smart_text(orjson.dumps(body))
+            body = orjson.dumps(body).decode()
             content_type = "application/json"
         body = smart_bytes(body)  # Here and below body is binary
         h = {"Host": str(u.netloc), "Connection": "close", "User-Agent": DEFAULT_USER_AGENT}

--- a/docs/card/index.md
+++ b/docs/card/index.md
@@ -90,7 +90,7 @@ class PathCard(BaseCard):
 
     def get_data(self):
         ...
-        return {"mo1": mo1, "mo2": mo2, "path": smart_text(orjson.dumps(path))}
+        return {"mo1": mo1, "mo2": mo2, "path": orjson.dumps(path).decode()}
 ```
 
 In the example, you can see the use of the `leaflet` library for rendering a geographic map in addition to the `path` module that implements functionality in JavaScript.

--- a/docs/card/index.ru.md
+++ b/docs/card/index.ru.md
@@ -95,7 +95,7 @@ class PathCard(BaseCard):
 
     def get_data(self):
         ...
-        return {"mo1": mo1, "mo2": mo2, "path": smart_text(orjson.dumps(path))}
+        return {"mo1": mo1, "mo2": mo2, "path": orjson.dumps(path).decode()}
 ```
 
 На примере можно видеть использование библиотеки `leaflet` для отрисовки географической карты в дополнение модуля `path` реализующего функционал в `JavaScript`.

--- a/sa/profiles/Angtel/Topaz/get_tech_support.py
+++ b/sa/profiles/Angtel/Topaz/get_tech_support.py
@@ -1,14 +1,14 @@
 # ---------------------------------------------------------------------
 # Angtel.Topaz.get_tech_support
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
 # NOC modules
 from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igettechsupport import IGetTechSupport
-from noc.core.comp import smart_bytes, smart_text
+from noc.core.comp import smart_text
 
 
 class Script(BaseScript):
@@ -20,4 +20,4 @@ class Script(BaseScript):
             c = self.cli("show tech-support")
         except self.CLISyntaxError:
             raise self.NotSupportedError()
-        return smart_bytes(smart_text(c, errors="ignore"))
+        return smart_text(c, errors="ignore").encode()

--- a/sa/profiles/Bradbury/HighVideo/get_config.py
+++ b/sa/profiles/Bradbury/HighVideo/get_config.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # Bradbury.HighVideo.get_config
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -11,7 +11,6 @@ import orjson
 # NOC modules
 from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igetconfig import IGetConfig
-from noc.core.comp import smart_text
 
 
 class Script(BaseScript):
@@ -21,8 +20,8 @@ class Script(BaseScript):
     CLI_TIMEOUT = 240
     SECTIONS = ["load-Servers", "load-Channels", "load-Profiles", "load-Multiplexes"]
 
-    def execute(self, **kwargs):
+    def execute(self, **kwargs) -> str:
         result = {}
         for section in self.SECTIONS:
             result[section] = self.http.post("/upload/", data=section, json=True, use_basic=True)
-        return smart_text(orjson.dumps(result, option=orjson.OPT_INDENT_2))
+        return orjson.dumps(result, option=orjson.OPT_INDENT_2).decode()

--- a/sa/profiles/Cisco/IOS/get_tech_support.py
+++ b/sa/profiles/Cisco/IOS/get_tech_support.py
@@ -1,14 +1,14 @@
 # ---------------------------------------------------------------------
 # Cisco.IOS.get_tech_support
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
 # NOC modules
 from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igettechsupport import IGetTechSupport
-from noc.core.comp import smart_bytes, smart_text
+from noc.core.comp import smart_text
 
 
 class Script(BaseScript):
@@ -20,4 +20,4 @@ class Script(BaseScript):
             c = self.cli("show tech-support")
         except self.CLISyntaxError:
             raise self.NotSupportedError()
-        return smart_bytes(smart_text(c, errors="ignore"))
+        return smart_text(c, errors="ignore").encode()

--- a/sa/profiles/DLink/DxS/get_tech_support.py
+++ b/sa/profiles/DLink/DxS/get_tech_support.py
@@ -1,14 +1,14 @@
 # ---------------------------------------------------------------------
 # DLink.DxS.get_tech_support
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
 # NOC modules
 from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igettechsupport import IGetTechSupport
-from noc.core.comp import smart_bytes, smart_text
+from noc.core.comp import smart_text
 
 
 class Script(BaseScript):
@@ -20,4 +20,4 @@ class Script(BaseScript):
             c = self.cli("show tech_support")
         except self.CLISyntaxError:
             raise self.NotSupportedError()
-        return smart_bytes(smart_text(c, errors="ignore"))
+        return smart_text(c, errors="ignore").encode()

--- a/sa/profiles/Eltex/MES/get_interfaces.py
+++ b/sa/profiles/Eltex/MES/get_interfaces.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # Eltex.MES.get_interfaces
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2023 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -15,7 +15,7 @@ from noc.sa.interfaces.igetinterfaces import IGetInterfaces
 from noc.sa.interfaces.base import MACAddressParameter
 from noc.core.text import parse_table
 from noc.core.mib import mib
-from noc.core.comp import smart_text, smart_bytes
+from noc.core.comp import smart_text
 
 
 class Script(BaseScript):
@@ -104,7 +104,7 @@ class Script(BaseScript):
     # if ascii or rus text in description
     def convert_description(self, desc):
         if desc:
-            return smart_bytes(smart_text(desc, errors="replace"))
+            return smart_text(desc, errors="replace").encode()
         return desc
 
     def get_ip_ifindex(self):

--- a/sa/profiles/Eltex/MES5448/get_tech_support.py
+++ b/sa/profiles/Eltex/MES5448/get_tech_support.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # Eltex.MES5448.get_tech_support
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -9,7 +9,7 @@
 # NOC modules
 from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igettechsupport import IGetTechSupport
-from noc.core.comp import smart_text, smart_bytes
+from noc.core.comp import smart_text
 
 
 class Script(BaseScript):
@@ -21,4 +21,4 @@ class Script(BaseScript):
             c = self.cli("show tech-support")
         except self.CLISyntaxError:
             raise self.NotSupportedError()
-        return smart_bytes(smart_text(c, errors="ignore"))
+        return smart_text(c, errors="ignore").encode()

--- a/sa/profiles/Huawei/VRP/get_tech_support.py
+++ b/sa/profiles/Huawei/VRP/get_tech_support.py
@@ -1,14 +1,14 @@
 # ---------------------------------------------------------------------
 # Huawei.VRP.get_tech_support
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
 # NOC modules
 from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igettechsupport import IGetTechSupport
-from noc.core.comp import smart_text, smart_bytes
+from noc.core.comp import smart_text
 
 
 class Script(BaseScript):
@@ -20,4 +20,4 @@ class Script(BaseScript):
             c = self.cli("display diagnostic-information")
         except self.CLISyntaxError:
             raise self.NotSupportedError()
-        return smart_bytes(smart_text(c, errors="ignore"))
+        return smart_text(c, errors="ignore").encode()

--- a/sa/profiles/Huawei/VRP/get_version.py
+++ b/sa/profiles/Huawei/VRP/get_version.py
@@ -1,5 +1,5 @@
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2025 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -129,7 +129,7 @@ class Script(BaseScript):
                 for oid, x in self.snmp.getnext(mib["ENTITY-MIB::entPhysicalSerialNum"]):
                     if not x:
                         continue
-                    r += [x.strip(smart_text(" \x00"))]
+                    r += [x.strip(" \x00")]
                 if r:
                     return r
             except (self.snmp.TimeOutError, self.snmp.SNMPError):
@@ -157,7 +157,7 @@ class Script(BaseScript):
                 for oid, x in self.snmp.getnext(mib["HUAWEI-SYS-MAN-MIB::hwPatchVersion", 0]):
                     if not x:
                         continue
-                    r += [x.strip(smart_text(" \x00"))]
+                    r += [x.strip(" \x00")]
                 if r:
                     return r
             except (self.snmp.TimeOutError, self.snmp.SNMPError):
@@ -240,7 +240,7 @@ class Script(BaseScript):
         for oid, x in self.snmp.getnext(mib["ENTITY-MIB::entPhysicalSerialNum"]):
             if not x:
                 continue
-            serial += [smart_text(x, errors="replace").strip(smart_text(" \x00"))]
+            serial += [smart_text(x, errors="replace").strip(" \x00")]
         if platform in self.hw_series:
             # series name, fix
             platform = self.fix_platform_name(platform)

--- a/sa/profiles/Iskratel/ESCOM/get_tech_support.py
+++ b/sa/profiles/Iskratel/ESCOM/get_tech_support.py
@@ -1,14 +1,14 @@
 # ---------------------------------------------------------------------
 # Iskratel.ESCOM.get_tech_support
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
 # NOC modules
 from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igettechsupport import IGetTechSupport
-from noc.core.comp import smart_text, smart_bytes
+from noc.core.comp import smart_text
 
 
 class Script(BaseScript):
@@ -20,4 +20,4 @@ class Script(BaseScript):
             c = self.cli("show tech-support")
         except self.CLISyntaxError:
             raise self.NotSupportedError()
-        return smart_bytes(smart_text(c, errors="ignore"))
+        return smart_text(c, errors="ignore").encode()

--- a/sa/profiles/Iskratel/MSAN/get_tech_support.py
+++ b/sa/profiles/Iskratel/MSAN/get_tech_support.py
@@ -1,14 +1,14 @@
 # ---------------------------------------------------------------------
 # Iskratel.MSAN.get_tech_support
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
 # NOC modules
 from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igettechsupport import IGetTechSupport
-from noc.core.comp import smart_text, smart_bytes
+from noc.core.comp import smart_text
 
 
 class Script(BaseScript):
@@ -20,4 +20,4 @@ class Script(BaseScript):
             c = self.cli("show tech-support")
         except self.CLISyntaxError:
             raise self.NotSupportedError()
-        return smart_bytes(smart_text(c, errors="ignore"))
+        return smart_text(c, errors="ignore").encode()

--- a/sa/profiles/Juniper/JUNOS/get_tech_support.py
+++ b/sa/profiles/Juniper/JUNOS/get_tech_support.py
@@ -1,14 +1,14 @@
 # ---------------------------------------------------------------------
 # Juniper.JUNOS.get_tech_support
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
 # NOC modules
 from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igettechsupport import IGetTechSupport
-from noc.core.comp import smart_text, smart_bytes
+from noc.core.comp import smart_text
 
 
 class Script(BaseScript):
@@ -17,4 +17,4 @@ class Script(BaseScript):
 
     def execute(self):
         c = self.cli("request support information")
-        return smart_bytes(smart_text(c, errors="ignore"))
+        return smart_text(c, errors="ignore").encode()

--- a/sa/profiles/Juniper/JUNOSe/get_tech_support.py
+++ b/sa/profiles/Juniper/JUNOSe/get_tech_support.py
@@ -1,14 +1,14 @@
 # ---------------------------------------------------------------------
 # Juniper.JUNOSe.get_tech_support
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
 # NOC modules
 from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igettechsupport import IGetTechSupport
-from noc.core.comp import smart_text, smart_bytes
+from noc.core.comp import smart_text
 
 
 class Script(BaseScript):
@@ -20,4 +20,4 @@ class Script(BaseScript):
             c = self.cli("show tech-support")
         except self.CLISyntaxError:
             raise self.NotSupportedError()
-        return smart_bytes(smart_text(c, errors="ignore"))
+        return smart_text(c, errors="ignore").encode()

--- a/sa/profiles/Orion/NOS/get_tech_support.py
+++ b/sa/profiles/Orion/NOS/get_tech_support.py
@@ -1,14 +1,14 @@
 # ---------------------------------------------------------------------
 # Orion.NOS.get_tech_support
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
 # NOC modules
 from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igettechsupport import IGetTechSupport
-from noc.core.comp import smart_text, smart_bytes
+from noc.core.comp import smart_text
 
 
 class Script(BaseScript):
@@ -20,4 +20,4 @@ class Script(BaseScript):
             c = self.cli("show tech-support")
         except self.CLISyntaxError:
             raise self.NotSupportedError()
-        return smart_bytes(smart_text(c, errors="ignore"))
+        return smart_text(c, errors="ignore").encode()

--- a/sa/profiles/Qtech/QOS/get_tech_support.py
+++ b/sa/profiles/Qtech/QOS/get_tech_support.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # Qtech.QOS.get_tech_support
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -9,7 +9,7 @@
 # NOC modules
 from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igettechsupport import IGetTechSupport
-from noc.core.comp import smart_text, smart_bytes
+from noc.core.comp import smart_text
 
 
 class Script(BaseScript):
@@ -21,4 +21,4 @@ class Script(BaseScript):
             c = self.cli("show tech_support")
         except self.CLISyntaxError:
             raise self.NotSupportedError()
-        return smart_bytes(smart_text(c, errors="ignore"))
+        return smart_text(c, errors="ignore").encode()

--- a/sa/profiles/Raisecom/ROS/get_tech_support.py
+++ b/sa/profiles/Raisecom/ROS/get_tech_support.py
@@ -1,14 +1,14 @@
 # ---------------------------------------------------------------------
 # Raisecom.ROS.get_tech_support
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
 # NOC modules
 from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igettechsupport import IGetTechSupport
-from noc.core.comp import smart_text, smart_bytes
+from noc.core.comp import smart_text
 
 
 class Script(BaseScript):
@@ -20,4 +20,4 @@ class Script(BaseScript):
             c = self.cli("show tech-support")
         except self.CLISyntaxError:
             raise self.NotSupportedError()
-        return smart_bytes(smart_text(c, errors="ignore"))
+        return smart_text(c, errors="ignore").encode()

--- a/sa/profiles/SKS/SKS/get_tech_support.py
+++ b/sa/profiles/SKS/SKS/get_tech_support.py
@@ -1,14 +1,14 @@
 # ---------------------------------------------------------------------
 # SKS.SKS.get_tech_support
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
 # NOC modules
 from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igettechsupport import IGetTechSupport
-from noc.core.comp import smart_text, smart_bytes
+from noc.core.comp import smart_text
 
 
 class Script(BaseScript):
@@ -20,4 +20,4 @@ class Script(BaseScript):
             c = self.cli("show tech-support")
         except self.CLISyntaxError:
             raise self.NotSupportedError()
-        return smart_bytes(smart_text(c, errors="ignore"))
+        return smart_text(c, errors="ignore").encode()

--- a/sa/profiles/Vitesse/VSC/get_tech_support.py
+++ b/sa/profiles/Vitesse/VSC/get_tech_support.py
@@ -1,14 +1,14 @@
 # ---------------------------------------------------------------------
 # Vitesse.VSC.get_tech_support
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2021 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
 # NOC modules
 from noc.core.script.base import BaseScript
 from noc.sa.interfaces.igettechsupport import IGetTechSupport
-from noc.core.comp import smart_bytes, smart_text
+from noc.core.comp import smart_text
 
 
 class Script(BaseScript):
@@ -20,4 +20,4 @@ class Script(BaseScript):
             c = self.cli("show tech-support")
         except self.CLISyntaxError:
             raise self.NotSupportedError()
-        return smart_bytes(smart_text(c, errors="ignore"))
+        return smart_text(c, errors="ignore").encode()

--- a/services/card/cards/path.py
+++ b/services/card/cards/path.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 #  Path
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2017 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -12,7 +12,6 @@ import orjson
 from .base import BaseCard
 from noc.sa.models.managedobject import ManagedObject
 from noc.core.topology.path import get_shortest_path
-from noc.core.comp import smart_text
 from noc.config import config
 
 
@@ -61,4 +60,4 @@ class PathCard(BaseCard):
                 path += [{"x": mo.x, "y": mo.y, "objects": [{"id": mo.id, "name": mo.name}]}]
             else:
                 path[-1]["objects"] += [{"id": mo.id, "name": mo.name}]
-        return {"mo1": mo1, "mo2": mo2, "path": smart_text(orjson.dumps(path))}
+        return {"mo1": mo1, "mo2": mo2, "path": orjson.dumps(path).decode()}

--- a/services/mib/paths/mib.py
+++ b/services/mib/paths/mib.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # mib API
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -21,7 +21,7 @@ from noc.config import config
 from noc.core.fileutils import temporary_file, safe_rewrite
 from noc.fm.models.mib import MIB
 from noc.core.error import ERR_MIB_NOT_FOUND, ERR_MIB_MISSED, ERR_MIB_TOOL_MISSED
-from noc.core.comp import smart_text, smart_bytes
+from noc.core.comp import smart_text
 from noc.core.service.jsonrpcapi import JSONRPCAPI, api
 
 router = APIRouter()
@@ -143,7 +143,7 @@ class MIBAPI(JSONRPCAPI):
                     env=self.SMI_ENV,
                 )
                 with open(py_path) as f:
-                    p_data = smart_bytes(smart_text(f.read(), encoding="ascii", errors="ignore"))
+                    p_data = smart_text(f.read(), encoding="ascii", errors="ignore").encode()
                 with open(py_path, "wb") as f:
                     f.write(p_data)
                 m = SourceFileLoader("mib", py_path).load_module()

--- a/services/web/apps/inv/networksegment.py
+++ b/services/web/apps/inv/networksegment.py
@@ -14,7 +14,6 @@ from noc.services.web.base.extdocapplication import ExtDocApplication, api
 from noc.inv.models.networksegment import NetworkSegment
 from noc.sa.models.managedobject import ManagedObject
 from noc.sa.models.useraccess import UserAccess
-from noc.core.comp import smart_text
 from noc.core.middleware.tls import get_user
 from noc.core.validators import is_objectid
 from noc.core.translation import ugettext as _
@@ -47,7 +46,7 @@ class NetworkSegmentApplication(ExtDocApplication):
         return qs
 
     def instance_to_lookup(self, o, fields=None):
-        return {"id": str(o.id), "label": smart_text(o), "has_children": o.has_children}
+        return {"id": str(o.id), "label": str(o), "has_children": o.has_children}
 
     def bulk_field_count(self, data):
         segments = [d["id"] for d in data]
@@ -67,7 +66,7 @@ class NetworkSegmentApplication(ExtDocApplication):
         path = [NetworkSegment.get_by_id(ns) for ns in o.get_path()]
         return {
             "data": [
-                {"level": level + 1, "id": str(p.id), "label": smart_text(p.name)}
+                {"level": level + 1, "id": str(p.id), "label": p.name}
                 for level, p in enumerate(path)
             ]
         }

--- a/services/web/apps/inv/reportmetrics.py
+++ b/services/web/apps/inv/reportmetrics.py
@@ -31,7 +31,6 @@ from noc.sa.models.useraccess import UserAccess
 from noc.sa.interfaces.base import StringParameter, BooleanParameter
 from noc.sa.models.administrativedomain import AdministrativeDomain
 from noc.core.translation import ugettext as _
-from noc.core.comp import smart_text
 from noc.core.datasources.loader import loader as ds_loader
 
 
@@ -155,9 +154,8 @@ class ReportMetricsDetailApplication(ExtApplication):
         d_url = {
             "path": "/ui/grafana/dashboard/script/report.js",
             "rname": map_table[reporttype],
-            "from": smart_text(int(ts_from_date * 1000)),
-            "to": smart_text(int(ts_to_date * 1000)),
-            # o.name.replace("#", "%23")
+            "from": str(int(ts_from_date * 1000)),
+            "to": str(int(ts_to_date * 1000)),
             "biid": "",
             "oname": "",
             "iname": "",

--- a/services/web/apps/ip/prefix.py
+++ b/services/web/apps/ip/prefix.py
@@ -20,7 +20,6 @@ from noc.core.translation import ugettext as _
 from noc.sa.interfaces.base import ModelParameter, PrefixParameter
 from noc.core.ip import IP
 from noc.services.web.base.decorators.state import state_handler
-from noc.core.comp import smart_text
 
 
 @state_handler
@@ -112,8 +111,6 @@ class PrefixApplication(ExtModelApplication):
         o = self.get_object_or_404(Prefix, id=int(id))
         try:
             path = [Prefix.objects.get(id=ns) for ns in o.get_path()]
-            return {
-                "data": [{"id": str(p.id), "name": smart_text(p.name), "afi": p.afi} for p in path]
-            }
+            return {"data": [{"id": str(p.id), "name": p.name, "afi": p.afi} for p in path]}
         except ValueError as e:
             return self.response_bad_request(str(e))

--- a/services/web/apps/sa/administrativedomain.py
+++ b/services/web/apps/sa/administrativedomain.py
@@ -11,7 +11,6 @@ from django.http import HttpRequest
 # NOC modules
 from noc.services.web.base.extmodelapplication import ExtModelApplication, api
 from noc.sa.models.administrativedomain import AdministrativeDomain
-from noc.core.comp import smart_text
 from noc.core.translation import ugettext as _
 
 
@@ -30,15 +29,12 @@ class AdministrativeDomainApplication(ExtModelApplication):
         return o.managedobject_set.count()
 
     def instance_to_lookup(self, o, fields=None):
-        return {"id": o.id, "label": smart_text(o), "has_children": o.has_children}
+        return {"id": o.id, "label": str(o), "has_children": o.has_children}
 
     @api.get(r"^(?P<id>\d+)/get_path/$", access="read")
     def api_get_path(self, request: HttpRequest, id):
         o = self.get_object_or_404(AdministrativeDomain, id=id)
         path = [AdministrativeDomain.objects.get(id=ns) for ns in o.get_path()]
         return {
-            "data": [
-                {"level": path.index(p) + 1, "id": str(p.id), "label": smart_text(p.name)}
-                for p in path
-            ]
+            "data": [{"level": path.index(p) + 1, "id": str(p.id), "label": p.name} for p in path]
         }


### PR DESCRIPTION
**Purpose:** Remove trivial/duplicate usage of `smart_bytes` and `smart_text` helpers that wrap UTF-8-encoded data redundantly. Modern Python handles native strings natively, making these wrappers unnecessary in most cases.

**Key changes:**
- Replace `smart_bytes(smart_text(x))` with direct `.encode()` in 13 SA device profile scripts (`get_tech_support`, `get_interfaces`, etc.)
- Replace `smart_text(orjson.dumps(x))` with `orjson.dumps(x).decode()` in core modules and services
- Remove redundant `smart_text` wrappers where values are already native strings (Django CharField, MongoDB StringField)
- Clean up unused imports where no remaining calls to removed functions exist

**Notable implementation details:**
- All transformations preserve return types (bytes remain bytes, str remains str)
- Default UTF-8 encoding is implicit in `.encode()`/`.decode()` — consistent with project conventions
- One bonus `-> str` return type annotation added in `Bradbury.HighVideo.get_config.execute()`
