### PR TITLE
Replace @view with @api

### DIFF
--- a/services/web/apps/ip/ipam.py
+++ b/services/web/apps/ip/ipam.py
@@ -23,7 +23,7 @@ from noc.ip.models.vrf import VRF
 from noc.main.models.customfield import CustomField
 
 # NOC modules
-from noc.services.web.base.extapplication import ExtApplication, view, api
+from noc.services.web.base.extapplication import ExtApplication, api
 
 
 class IPAMApplication(ExtApplication):
@@ -83,8 +83,8 @@ class IPAMApplication(ExtApplication):
         prefix = self.get_object_or_404(Prefix, id=int(prefix_id))
         return self.prefix_contents(request, prefix=prefix)
 
-    @view(url=r"^(?P<vrf_id>\d+)/(?P<afi>[46])/quickjump/$", url_name="quickjump", access="view")
-    def view_quickjump(self, request: HttpRequest, vrf_id, afi):
+    @api.post(r"^(?P<vrf_id>\d+)/(?P<afi>[46])/quickjump/$", access="view")
+    def api_quickjump(self, request: HttpRequest, vrf_id, afi):
         """
         Quickjump to closest suitable block
         """

--- a/services/web/apps/ip/tools/views.py
+++ b/services/web/apps/ip/tools/views.py
@@ -16,7 +16,7 @@ from django import forms
 from django.http import HttpResponse, HttpRequest
 
 # NOC Modules
-from noc.services.web.base.application import Application, HasPerm, view
+from noc.services.web.base.application import Application, HasPerm, api
 from noc.core.ip import IP, IPv4, IPv6
 from noc.core.validators import is_ipv4, is_ipv6
 from noc.ip.models.address import Address
@@ -35,12 +35,12 @@ from noc.core.translation import ugettext as _
 class ToolsAppplication(Application):
     title = _("Tools")
 
-    @view(
-        url=r"^(?P<vrf_id>\d+)/(?P<afi>[46])/(?P<prefix>\S+?/\d+)/$",
+    @api.get(
+        r"^(?P<vrf_id>\d+)/(?P<afi>[46])/(?P<prefix>\S+?/\d+)/$",
         url_name="index",
         access=HasPerm("view"),
     )
-    def view_index(self, request: HttpRequest, vrf_id, afi, prefix):
+    def api_index(self, request: HttpRequest, vrf_id, afi, prefix):
         """
         An index of tools available for block
         :return:
@@ -58,12 +58,12 @@ class ToolsAppplication(Application):
             upload_ips_axfr_form=self.AXFRForm(),
         )
 
-    @view(
-        url=r"^(?P<vrf_id>\d+)/(?P<afi>[46])/(?P<prefix>\S+)/download_ip/$",
+    @api.post(
+        r"^(?P<vrf_id>\d+)/(?P<afi>[46])/(?P<prefix>\S+)/download_ip/$",
         url_name="download_ip",
         access=HasPerm("view"),
     )
-    def view_download_ip(self, request: HttpRequest, vrf_id, afi, prefix):
+    def api_download_ip(self, request: HttpRequest, vrf_id, afi, prefix):
         """
         Download block's allocated IPs in CSV format
         Columns are: ip,fqdn,description,tt
@@ -99,12 +99,12 @@ class ToolsAppplication(Application):
         )
         zone = forms.CharField(label=_("Zone"), help_text=_("DNS Zone name to transfer"))
 
-    @view(
-        url=r"^(?P<vrf_id>\d+)/(?P<afi>[46])/(?P<prefix>\S+)/upload_axfr/$",
+    @api.post(
+        r"^(?P<vrf_id>\d+)/(?P<afi>[46])/(?P<prefix>\S+)/upload_axfr/$",
         url_name="upload_axfr",
         access=HasPerm("view"),
     )
-    def view_upload_axfr(self, request: HttpRequest, vrf_id, afi, prefix):
+    def api_upload_axfr(self, request: HttpRequest, vrf_id, afi, prefix):
         """
         Import via zone transfer
         :return:

--- a/services/web/apps/main/calculator/views.py
+++ b/services/web/apps/main/calculator/views.py
@@ -20,7 +20,7 @@ from .calculators.loader import loader
 class CalculatorApplication(Application):
     title = _("Calculators")
 
-    @api.get(url=r"^$", url_name="index", menu="Calculators", access=HasPerm("view"))
+    @api.get(r"^$", url_name="index", menu="Calculators", access=HasPerm("view"))
     def api_index(self, request: HttpRequest):
         r = [(cn, loader[cn].title) for cn in loader]
         r = sorted(r, key=operator.itemgetter(1))

--- a/services/web/apps/main/calculator/views.py
+++ b/services/web/apps/main/calculator/views.py
@@ -12,7 +12,7 @@ import operator
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.application import Application, HasPerm, view
+from noc.services.web.base.application import Application, HasPerm, view, api
 from noc.core.translation import ugettext as _
 from .calculators.loader import loader
 
@@ -20,8 +20,8 @@ from .calculators.loader import loader
 class CalculatorApplication(Application):
     title = _("Calculators")
 
-    @view(url=r"^$", url_name="index", menu="Calculators", access=HasPerm("view"))
-    def view_index(self, request: HttpRequest):
+    @api.get(url=r"^$", url_name="index", menu="Calculators", access=HasPerm("view"))
+    def api_index(self, request: HttpRequest):
         r = [(cn, loader[cn].title) for cn in loader]
         r = sorted(r, key=operator.itemgetter(1))
         return self.render(request, "index.html", {"calculators": r})

--- a/services/web/apps/main/refbook/views.py
+++ b/services/web/apps/main/refbook/views.py
@@ -11,7 +11,7 @@ from django.shortcuts import get_object_or_404
 from django.http import HttpRequest
 
 # NOC modules
-from noc.services.web.base.application import Application, view
+from noc.services.web.base.application import Application, view, api
 from noc.aaa.models.permission import Permission
 from noc.main.models.refbook import RefBook
 from noc.main.models.refbookdata import RefBookData
@@ -40,8 +40,8 @@ class RefBookList(ListView):
 class RefBookAppplication(Application):
     title = _("Reference Books")
 
-    @view(url=r"^$", url_name="index", menu=[_("Setup"), _("Reference Books")], access="view")
-    def view_index(self, request: HttpRequest):
+    @api.get(r"^$", url_name="index", menu=[_("Setup"), _("Reference Books")], access="view")
+    def api_index(self, request: HttpRequest):
         """
         Render list of refbooks
         :return:
@@ -49,8 +49,8 @@ class RefBookAppplication(Application):
         ref_books = RefBook.objects.filter(is_enabled=True).order_by("name")
         return self.render(request, "index.html", ref_books=ref_books)
 
-    @view(url=r"^(?P<refbook_id>\d+)/$", url_name="view", access="view")
-    def view_view(self, request: HttpRequest, refbook_id):
+    @api.get(r"^(?P<refbook_id>\d+)/$", url_name="view", access="view")
+    def api_view(self, request: HttpRequest, refbook_id):
         """
         Refbook preview
         :return:
@@ -81,8 +81,8 @@ class RefBookAppplication(Application):
         request._gv_ctx = {"rb": rb, "can_edit": can_edit, "query": query, "app": self}
         return RefBookList().get(request)
 
-    @view(url=r"^(?P<refbook_id>\d+)/(?P<record_id>\d+)/$", url_name="item", access="view")
-    def view_item(self, request: HttpRequest, refbook_id, record_id):
+    @api.get(r"^(?P<refbook_id>\d+)/(?P<record_id>\d+)/$", url_name="item", access="view")
+    def api_item(self, request: HttpRequest, refbook_id, record_id):
         """
         Item preview
         :return:


### PR DESCRIPTION
Refactor: migrate @view → @api.get/post in 4 views (#445)

Continue the migration from the generic `@view` decorator to HTTP-method-
specific `@api.get`/`@api.post` decorators, following the pattern established
in PR #436 and PR #439.

Files changed:
- services/web/apps/ip/ipam.py — 1 endpoint (quickjump), remove `view` import
- services/web/apps/ip/tools/views.py — 3 endpoints (index, download_ip, upload_axfr), remove `view` import
- services/web/apps/main/calculator/views.py — 1 endpoint (index)
- services/web/apps/main/refbook/views.py — 3 endpoints (index, view, item)

Import hygiene:
- Remove unused `view` from imports where all decorators migrated
- Retain `view` for files that still have remaining @view usages out of scope

All url arguments passed positionally per ViewAPI positional-only signature.