### PR TITLE
Application: Remove unused methods

### DIFF
--- a/services/web/apps/ip/reporthistory.py
+++ b/services/web/apps/ip/reporthistory.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # ip.reporthistory
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2019 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -11,6 +11,7 @@ import re
 
 # Third-party modules
 from django import forms
+from django.utils.html import escape
 
 # NOC modules
 from noc.services.web.base.simplereport import SimpleReport, SectionRow, SafeString
@@ -53,10 +54,7 @@ class ReportHistoryApplication(SimpleReport):
 
     def format_detail(self, o):
         r = [m.groups() for m in self.rx_detail.finditer(o)]
-        s = "<br/>".join(
-            f"<b>{self.html_escape(g[0])}</b>: {self.html_escape(g[1])} &rArr; {self.html_escape(g[2])}"
-            for g in r
-        )
+        s = "<br/>".join(f"<b>{escape(g[0])}</b>: {escape(g[1])} &rArr; {escape(g[2])}" for g in r)
         return SafeString(s)
 
     def get_data(

--- a/services/web/base/application.py
+++ b/services/web/base/application.py
@@ -26,7 +26,6 @@ from django.http import (
 from django.shortcuts import render
 from django.db import connection
 from django.shortcuts import get_object_or_404
-from django.utils.html import escape
 from django.template import loader
 from django import forms
 from django.utils.timezone import get_current_timezone
@@ -359,12 +358,6 @@ class Application(metaclass=ApplicationBase):
             back_url = self.base_url
         return self.response_redirect(request.META.get("HTTP_REFERER", back_url))
 
-    def response_redirect_to_object(self, object):
-        """
-        Redirect to object: {{base.url}}/{{object.id}}/
-        """
-        return self.response_redirect("%s%d/" % (self.base_url, object.id))
-
     def response_forbidden(self, text=None):
         """
         Render Forbidden response
@@ -393,12 +386,6 @@ class Application(metaclass=ApplicationBase):
         if location:
             r["Location"] = location
         return r
-
-    def html_escape(self, s):
-        """
-        Escape HTML
-        """
-        return escape(s)
 
     def debug(self, message):
         self.logger.debug(message)
@@ -453,30 +440,6 @@ class Application(metaclass=ApplicationBase):
         for e in extra:
             p.add(HasPerm(e).get_permission(self))
         return p
-
-    def user_access_list(self, user):
-        """
-        Return a list of user access entries
-        """
-        return []
-
-    def group_access_list(self, group):
-        """
-        Return a list of group access entries
-        """
-        return []
-
-    def user_access_change_url(self, user):
-        """
-        Return an URL to change user access
-        """
-        return
-
-    def group_access_change_url(self, group):
-        """
-        Return an URL to change group access
-        """
-        return
 
     def customize_form(self, form, table, search=False):
         """


### PR DESCRIPTION
Removal of 6 unused methods from `Application` base class (`services/web/base/application.py`) plus cleanup in reporthistory to use `django.utils.html.escape` directly instead of the removed wrapper. Copyright year updated (2019→2026). CI green (labeler, py-lint, py-test all PASS).

## Findings
**No verified issues.** All 6 removed methods (`response_redirect_to_object`, `html_escape`, `user_access_list`, `group_access_list`, `user_access_change_url`, `group_access_change_url`) have zero callers outside the base class definition in both `services/web/` and `src/noc/services/web/`. The one `html_escape` call in `reporthistory.py` is properly replaced with direct `django.utils.html.escape`. No subclass overrides found.

**Severity: info** — The stub methods (`user_access_list`, `group_access_list`, `user_access_change_url`, `group_access_change_url`) all return empty values (`[]` or nothing). Safe removal, no functional impact.

## Checks
- **changed files:** 2 (application.py, reporthistory.py)
- **tests:** py-test PASS, full suite including web app imports exercised
- **affected components:** services/web (Application base class, IP report history)
- **relevant project patterns:** Inheritance chain verified: `ReportHistoryApplication → SimpleReport → ReportApplication → Application`. The `html_escape` call lives on `self` which resolves through this chain — removal is safe as the caller site is updated simultaneously.
