### PR TITLE
Remove unnecessary smart_bytes() usage

### DIFF
--- a/core/crypto.py
+++ b/core/crypto.py
@@ -30,11 +30,11 @@ def md5crypt(password: bytes, salt: bytes | None = None, magic: bytes = b"$1$") 
     MD5 password hash
     (Used for RIPE authentication)
     >>> md5crypt(b"test", salt=b"1234")
-    '$1$1234$InX9CGnHSFgHD3OZHTyt3.'
+    b'$1$1234$InX9CGnHSFgHD3OZHTyt3.'
     >>> md5crypt(b"test", salt=b"1234")
-    '$1$1234$InX9CGnHSFgHD3OZHTyt3.'
+    b'$1$1234$InX9CGnHSFgHD3OZHTyt3.'
     >>> md5crypt(b"test", salt=b"1234", magic=b"$5$")
-    '$5$1234$x29w4cwzSDnesjss/m2O1.'
+    b'$5$1234$x29w4cwzSDnesjss/m2O1.'
     """
     salt = salt if salt else gen_salt(8)
     # /* The password first, since that is what is most unknown */ /* Then our magic string */ /* Then the raw salt */

--- a/core/crypto.py
+++ b/core/crypto.py
@@ -29,11 +29,11 @@ def md5crypt(password: bytes, salt: bytes | None = None, magic: bytes = b"$1$") 
     """
     MD5 password hash
     (Used for RIPE authentication)
-    >>> md5crypt("test", salt="1234")
+    >>> md5crypt(b"test", salt=b"1234")
     '$1$1234$InX9CGnHSFgHD3OZHTyt3.'
-    >>> md5crypt("test", salt="1234")
+    >>> md5crypt(b"test", salt=b"1234")
     '$1$1234$InX9CGnHSFgHD3OZHTyt3.'
-    >>> md5crypt("test", salt="1234", magic="$5$")
+    >>> md5crypt(b"test", salt=b"1234", magic=b"$5$")
     '$5$1234$x29w4cwzSDnesjss/m2O1.'
     """
     salt = salt if salt else gen_salt(8)

--- a/core/crypto.py
+++ b/core/crypto.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # Crypto-related snippets
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -9,10 +9,6 @@
 import random
 import hashlib
 
-# Third-party modules
-
-# NOC modules
-from noc.core.comp import smart_bytes
 
 # Symbols used in salt
 ITOA64 = b"./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
@@ -20,7 +16,7 @@ SALT_SYMBOLS = list(ITOA64)
 REARRANGED_BITS = ((0, 6, 12), (1, 7, 13), (2, 8, 14), (3, 9, 15), (4, 10, 5))
 
 
-def gen_salt(salt_len):
+def gen_salt(salt_len: int) -> bytes:
     """
     Generate random salt of given length
     >>> len(gen_salt(10)) == 10
@@ -40,13 +36,11 @@ def md5crypt(password: bytes, salt: bytes | None = None, magic: bytes = b"$1$") 
     >>> md5crypt("test", salt="1234", magic="$5$")
     '$5$1234$x29w4cwzSDnesjss/m2O1.'
     """
-    password = smart_bytes(password)
-    magic = smart_bytes(magic)
-    salt = smart_bytes(salt) if salt else gen_salt(8)
+    salt = salt if salt else gen_salt(8)
     # /* The password first, since that is what is most unknown */ /* Then our magic string */ /* Then the raw salt */
-    m = hashlib.md5(smart_bytes(password + magic + salt))
+    m = hashlib.md5(password + magic + salt)
     # /* Then just as many characters of the MD5(pw,salt,pw) */
-    mixin = hashlib.md5(smart_bytes(password + salt + password)).digest()
+    mixin = hashlib.md5(password + salt + password).digest()
     for i in range(len(password)):
         m.update(bytes([mixin[i % 16]]))
     # /* Then something really weird... */
@@ -63,17 +57,17 @@ def md5crypt(password: bytes, salt: bytes | None = None, magic: bytes = b"$1$") 
     for i in range(1000):
         m2 = hashlib.md5()
         if i & 1:
-            m2.update(smart_bytes(password))
+            m2.update(password)
         else:
-            m2.update(smart_bytes(final))
+            m2.update(final)
         if i % 3:
-            m2.update(smart_bytes(salt))
+            m2.update(salt)
         if i % 7:
-            m2.update(smart_bytes(password))
+            m2.update(password)
         if i & 1:
-            m2.update(smart_bytes(final))
+            m2.update(final)
         else:
-            m2.update(smart_bytes(password))
+            m2.update(password)
         final = m2.digest()
     # This is the bit that uses to64() in the original code.
     rearranged = []

--- a/core/debug.py
+++ b/core/debug.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # Various debugging and error logging utilities
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2025 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -376,7 +376,7 @@ def error_fingerprint():
         tb_function,
         str(tb_lineno),  # Absolute code point
     ]
-    eh = hashlib.sha1(smart_bytes(b"|".join(smart_bytes(p if p else "") for p in parts))).digest()
+    eh = hashlib.sha1(b"|".join(smart_bytes(p if p else "") for p in parts)).digest()
     return str(uuid.UUID(bytes=eh[:16], version=5))
 
 

--- a/core/gridvcs/base.py
+++ b/core/gridvcs/base.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # GridVCS
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -110,11 +110,11 @@ class GridVCS:
 
     @staticmethod
     def compress_z(data: bytes) -> bytes:
-        return zlib.compress(smart_bytes(data))
+        return zlib.compress(data)
 
     @staticmethod
     def decompress_z(data: bytes) -> bytes:
-        return zlib.decompress(smart_bytes(data))
+        return zlib.decompress(data)
 
     def put(self, object: int, data: str, ts: datetime.datetime | None = None) -> bool:
         """

--- a/core/script/cli/ssh.py
+++ b/core/script/cli/ssh.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # SSH CLI
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2021 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -77,7 +77,7 @@ class SSHStream(BaseStream):
         try:
             self.session.handshake(self.socket)
             host_hash = smart_bytes(self.session.hostkey_hash(LIBSSH2_HOSTKEY_HASH_SHA1))
-            hex_hash = smart_text(codecs.encode(host_hash, "hex"))
+            hex_hash = codecs.encode(host_hash, "hex").decode()
             self.logger.debug("Connected. Host fingerprint is %s", hex_hash)
             # libssh2's userauth_list implementation tries to authenticate
             # using `none` method internally. So calling `userauth_list`

--- a/core/script/cli/ssh.py
+++ b/core/script/cli/ssh.py
@@ -21,7 +21,7 @@ from ssh2.error_codes import LIBSSH2_ERROR_EAGAIN
 # NOC modules
 from noc.config import config
 from noc.core.perf import metrics
-from noc.core.comp import smart_bytes, smart_text
+from noc.core.comp import smart_bytes
 from .cli import CLI
 from .base import BaseStream
 from .error import CLIAuthFailed, CLISSHProtocolError

--- a/core/script/http/middleware/digestauth.py
+++ b/core/script/http/middleware/digestauth.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # HTTP Digest Auth Middleware
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -78,7 +78,7 @@ class DigestAuthMiddeware(BaseMiddleware):
         s = nonce.encode("utf-8")
         # s += time.ctime().encode('utf-8')
         s += os.urandom(8)
-        cnonce = hashlib.sha1(smart_bytes(s)).hexdigest()[:16]
+        cnonce = hashlib.sha1(s).hexdigest()[:16]
 
         if not qop:
             respdig = hashlib.md5(smart_bytes(f"{HA1}:{nonce}:{HA2}")).hexdigest()

--- a/peer/models/maintainer.py
+++ b/peer/models/maintainer.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------------------
 # Peer module models
 # ---------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ---------------------------------------------------------------------
 
@@ -44,7 +44,7 @@ class Maintainer(NOCModel):
         s += [f"mntner: {self.maintainer}"]
         s += [f"descr: {self.description}"]
         if self.password:
-            s += [f"auth: MD5-PW {md5crypt(self.password)}"]
+            s += [f"auth: MD5-PW {md5crypt(self.password.encode())}"]
         s += [f"admins: {x.nic_hdl}" for x in self.admins.all()]
         s += [f"mnt-by: {self.maintainer}"]
         if self.extra:

--- a/services/ui/paths/avatar.py
+++ b/services/ui/paths/avatar.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # /api/ui/avatar endpoint
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2021 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -13,7 +13,6 @@ from noc.config import config
 from noc.aaa.models.user import User
 from noc.core.service.deps.user import get_current_user
 from noc.main.models.avatar import Avatar
-from noc.core.comp import smart_bytes
 from noc.core.ioloop.util import run_sync
 from noc.core.mime import ContentType
 from ..models.status import StatusResponse
@@ -35,7 +34,7 @@ def get_avatar(user_id: str, _: User = Depends(get_current_user)):
 @router.post("/api/ui/avatar", response_model=StatusResponse, tags=["ui", "avatar"])
 def save_avatar(user: User = Depends(get_current_user), image: UploadFile = File(...)):
     async def read_file() -> bytes:
-        return smart_bytes(await image.read(config.ui.max_avatar_size + 1))
+        return await image.read(config.ui.max_avatar_size + 1)
 
     data = run_sync(read_file)
     if len(data) > config.ui.max_avatar_size:

--- a/services/web/base/reportdatasources/base.py
+++ b/services/web/base/reportdatasources/base.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # BaseReportDatasource
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2025 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -22,7 +22,6 @@ from django.db.models import Q as d_Q
 
 # NOC modules
 from noc.aaa.models.user import User
-from noc.core.comp import smart_bytes
 from noc.sa.models.managedobject import ManagedObject
 from .report_objectstat import (
     AttributeIsolator,
@@ -445,7 +444,7 @@ class ReportDataSource:
         for row in self.extract():
             writer.writerow(row[f] for f in self.fields if not self.fields[f].hidden)
 
-        return smart_bytes(response.getvalue())
+        return response.getvalue().encode()
 
     def report_xlsx(self, fmt: Callable | None = None) -> bytes:
         import xlsxwriter

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -22,8 +22,11 @@ def test_salt_length(raw, value):
 @pytest.mark.parametrize(
     ("raw", "value"),
     [
-        ({"password": "test", "salt": "1234"}, b"$1$1234$InX9CGnHSFgHD3OZHTyt3."),
-        ({"password": "test", "salt": "1234", "magic": "$5$"}, b"$5$1234$x29w4cwzSDnesjss/m2O1."),
+        ({"password": b"test", "salt": b"1234"}, b"$1$1234$InX9CGnHSFgHD3OZHTyt3."),
+        (
+            {"password": b"test", "salt": b"1234", "magic": b"$5$"},
+            b"$5$1234$x29w4cwzSDnesjss/m2O1.",
+        ),
     ],
 )
 def test_md5_crypt(raw, value):


### PR DESCRIPTION
**Purpose:** Remove redundant `smart_bytes()` and `smart_text()` wrapper calls where inputs are already explicitly typed as `bytes`, eliminating unnecessary encoding overhead on zero-copy paths.

**Key changes:**
- **core/crypto.py:** Strip all `smart_bytes()` calls from `md5crypt()` — the function signature explicitly requires `password: bytes`, `salt: bytes | None`, `magic: bytes`. Added return type annotation to `gen_salt()`. Updated doctest examples with correct byte literals for both inputs and outputs.
- **core/debug.py:** Remove redundant outer `smart_bytes(b"|")` in `error_fingerprint()` — the join separator is already bytes.
- **core/gridvcs/base.py:** Replace `smart_bytes(data)` → `data` in `compress_z()` / `decompress_z()` — `data` parameter already typed as `bytes`.
- **core/script/cli/ssh.py:** Replace `smart_text(codecs.encode(host_hash, "hex"))` with `.decode()`, remove unused `smart_text` import.
- **core/script/http/middleware/digestauth.py:** Remove unnecessary `smart_bytes()` on line 78 where input is already bytes; intentionally preserve lines 84/87 — those wrap f-string expressions (`.hexdigest()` returns `str`) so encoding is required.
- **peer/models/maintainer.py:** Add `.encode()` to `self.password` before `md5crypt()` call (function now requires explicit bytes).
- **services/ui/paths/avatar.py:** Remove `smart_bytes()` around `await image.read()` — FastAPI's `UploadFile` already returns bytes.
- **services/web/base/reportdatasources/base.py:** Replace `smart_bytes(response.getvalue())` with `.getvalue().encode()` where response is a StringIO buffer.

**Notable implementation details:**
- Full signature alignment of `md5crypt()` from implicit type coercion to explicit `bytes` parameters — technically a breaking API change, although only one internal production caller exists (`peer/models/maintainer.py`), which has been updated.
- All type annotations remain consistent with the new explicit `bytes` contract.
