### PR TITLE
Move SupportsStr protocol to noc.core.typing

### DIFF
--- a/core/comp.py
+++ b/core/comp.py
@@ -5,14 +5,11 @@
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
-# Python modules
-from typing import Protocol
+
+# NOC modules
+from noc.core.typing import SupportsStr
 
 DEFAULT_ENCODING = "utf-8"
-
-
-class SupportsStr(Protocol):
-    def __str__(self) -> str: ...
 
 
 def smart_bytes(s: bytes | str | SupportsStr, encoding: str = DEFAULT_ENCODING) -> bytes:

--- a/core/typing.py
+++ b/core/typing.py
@@ -49,3 +49,11 @@ class AsResource(Protocol):
     """
 
     def as_resource(self, path: str | None = None) -> str: ...
+
+
+class SupportsStr(Protocol):
+    """
+    Defines `__str__` function and supports `str()`
+    """
+
+    def __str__(self) -> str: ...


### PR DESCRIPTION
Introduce a shared `SupportsStr` Protocol type in `core.typing` for objects that implement `__str__()`, enabling type-safe function signatures across modules without importing duplicates.

### Key changes

- Add `SupportsStr(Protocol)` class to `core/typing.py` defining `__str__ -> str`.
