### PR TITLE
bi decorators typing

### DIFF
--- a/core/bi/decorator.py
+++ b/core/bi/decorator.py
@@ -16,6 +16,7 @@ import bson
 from noc.config import config
 from noc.models import is_document
 from noc.core.comp import smart_bytes
+from noc.core.typing import SupportsStr
 
 _ZEROx16 = b"\x00" * 16
 
@@ -33,23 +34,39 @@ def _get_siphash_seed():
 
 SIPHASH_SEED = _get_siphash_seed()
 BI_ID_FIELD = "bi_id"
+BI_HASH_MASK = 0x7FFFFFFFFFFFFFFF
 
 
-def bi_hash(v):
+def bi_hash(v: str | SupportsStr) -> int:
     """
-    Calculate BI hash from given value
-    :return:
+    Calculate a stable BI hash value for the given object.
+
+    The object is converted to its string representation and mapped to a
+    fixed-size integer hash value. Objects with the same string
+    representation produce the same hash value.
+
+    Args:
+        v: Object to hash. Must be a string or provide a string representation
+            via `__str__`.
+
+    Returns:
+        Stable integer hash value limited to the BI hash range.
     """
     if not isinstance(v, str):
         v = str(v)
-    bh = siphash24(smart_bytes(v), key=SIPHASH_SEED).digest()
-    return int(struct.unpack("!Q", bh)[0] & 0x7FFFFFFFFFFFFFFF)
+    bh = siphash24(v.encode(), key=SIPHASH_SEED).digest()
+    return int(struct.unpack("!Q", bh)[0] & BI_HASH_MASK)
 
 
-def new_bi_id():
+def new_bi_id() -> int:
     """
-    Generate new bi_id
-    :return:
+    Generate a new BI identifier.
+
+    A unique ObjectId is converted into a stable BI hash value to produce
+    a compact integer identifier.
+
+    Returns:
+        New BI identifier.
     """
     return bi_hash(bson.ObjectId())
 

--- a/core/bi/decorator.py
+++ b/core/bi/decorator.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # BI decorators
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2020 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
@@ -15,7 +15,6 @@ import bson
 # NOC modules
 from noc.config import config
 from noc.models import is_document
-from noc.core.comp import smart_bytes
 from noc.core.typing import SupportsStr
 
 _ZEROx16 = b"\x00" * 16


### PR DESCRIPTION
**Purpose:** Add type annotations and modernize docstrings for the `bi_hash()` and `new_bi_id()` functions in `core/bi/decorator.py`.

**Key changes:**
- Replace `smart_bytes` import with `SupportsStr` Protocol (`noc.core.typing`) — aligns with PR #449 which moved `SupportsStr` to this module.
- Annotate `bi_hash(v: str | SupportsStr) -> int` and `new_bi_id() -> int`.
- Extract magic constant `0x7FFFFFFFFFFFFFFF` into named `BI_HASH_MASK`.
- Replace `smart_bytes(v)` with `v.encode()` — behavior identical because the function already converts non-str inputs via `str()` before reaching the encode step.
- Rewrite docstrings from reST-style to Google-style with proper Args/Returns sections.

**Notable implementation details:**
- Runtime behavior is unchanged: both paths decode through UTF-8 with `siphash24`.
- All 20+ existing call sites remain compatible as they pass types with `__str__` (strings, integers, ObjectId, tuples, f-strings).
- The type signature uses `SupportsStr` Protocol rather than `object` for better static analysis while still accepting any object that provides `__str__`.
