### PR TITLE
gh macro

### DIFF
--- a/macros.py
+++ b/macros.py
@@ -84,8 +84,8 @@ def define_env(env):
         ```
         """
         if isinstance(iid, int):
-            return f"{GITHUB_ROOT}/pull/{iid}"
-        return f"{GITHUB_ROOT}/commit/{iid}"
+            return f"[#{iid}]({GITHUB_ROOT}/pull/{iid})"
+        return f"[{iid}]({GITHUB_ROOT}/commit/{iid})"
 
     @env.macro
     def supported_scripts(profile: str) -> str:

--- a/macros.py
+++ b/macros.py
@@ -18,6 +18,7 @@ PROFILES_ROOT = ROOT / "sa" / "profiles"
 DOC_ROOT = ROOT / "docs"
 COLLECTIONS_ROOT = ROOT / "collections"
 GITLAB_ROOT = "https://code.getnoc.com/noc/noc"
+GITHUB_ROOT = "https://github.com/gufolabs/noc"
 
 logger = logging.getLogger("mkdocs")
 logger.info("[NOC] - Initializing NOC macroses")
@@ -54,6 +55,37 @@ def define_env(env):
         :return:
         """
         return f"[MR{iid}]({GITLAB_ROOT}/merge_requests/{iid})"
+
+    @env.macro
+    def gh(iid: str | int) -> str:
+        """
+        Create a link to a GitHub commit or pull request.
+
+        The argument can be:
+        - a short commit SHA (usually the first 6 characters);
+        - a pull request number.
+
+        Args:
+            iid: GitHub commit short SHA or pull request number.
+
+        Returns:
+            Markdown link to the corresponding GitHub commit or pull request.
+
+        Usage:
+
+        Commit:
+        ```text
+        {{ gh("123456") }}
+        ```
+
+        Pull request:
+        ```text
+        {{ gh(123) }}
+        ```
+        """
+        if isinstance(iid, int):
+            return f"{GITHUB_ROOT}/pull/{iid}"
+        return f"{GITHUB_ROOT}/commit/{iid}"
 
     @env.macro
     def supported_scripts(profile: str) -> str:


### PR DESCRIPTION
Add a `gh()` macro to the MkDocs environment for generating Markdown links to GitHub commits and pull requests. This complements the existing `mr()` macro (which links to GitLab merge requests) by providing GitHub-specific link generation.

**Key changes**

- New `GITHUB_ROOT` constant (`https://github.com/gufolabs/noc`)
- New `gh(iid: str | int)` macro that produces Markdown links:
  - Integer input → pull request link (e.g., `[#{iid}](…/pull/{iid})`)
  - String input → commit link (e.g., `[{sha}](…/commit/{sha})`)

**Notable implementation details**

- The macro distinguishes between int (PR numbers) and string (commit SHAs) using `isinstance(iid, int)` — string values are treated as commit references by default.
- Follows the same structural pattern as the existing `mr()` macro for consistency.
