### PR TITLE
NOC 25.1.1 Release Notes

### DIFF
--- a/docs/releases/25_1_1.md
+++ b/docs/releases/25_1_1.md
@@ -1,0 +1,378 @@
+# NOC 25.1.1
+
+NOC 25.1.1 release contains 355 bugfixes, optimizations, and improvements.
+
+## New features
+
+| MR                | Title                                              |
+| ----------------- | -------------------------------------------------- |
+| {{gh("891e92")}} | #2663 Add ServiceStatus API to NBI. |
+| {{gh("4563c6")}} | #2690 Add clear_alarm after delay. |
+| {{gh("74ab2b")}} | #2702 Add Rewrite Alarm class |
+| {{gh("9646e2")}} | #2705 Add Capabilities support to Interface Model. |
+| {{gh("6289e4")}} | Add diagnostic to Service model. |
+| {{gh("7439a9")}} | Additional condition to CPE Profile match Rules. |
+| {{gh("b7338c")}} | #2722 Add Zabbix Connector integration to Metrics Coll... |
+| {{gh("0be45c")}} | Add WebHook support to tgsender service. |
+| {{gh("24d972")}} | Add PM Agent to ETL. |
+| {{gh("b1cdbd")}} | Add ActionSet to Action model. |
+| {{gh("13d106")}} | Add Victoria Metrics integration to MetricsCollector. |
+| {{gh("95ab38")}} | Add watchers object mechanics. |
+| {{gh("541664")}} | Add CheckHistory BI Table, for calculate expired checks. |
+
+## Improvements
+
+| MR                | Title                                              |
+| ----------------- | -------------------------------------------------- |
+| {{gh("d0b258")}} | Add fix for fix suspended jobs that occures on big outage |
+| {{gh("36fa4b")}} | Add 'Apikey' scheme to login Authorization header, com... |
+| {{gh("b6836a")}} | Replace HtmlEditor with MarkdownEditor in CommentPanel... |
+| {{gh("a481af")}} | Fix Capability collection export param. |
+| {{gh("05fff9")}} | Add HTTP Url Value Type. |
+| {{gh("e796e6")}} | Add alarm state. |
+| {{gh("7d7728")}} | Add event extractor to vcenter. |
+| {{gh("f0e4f4")}} | Rewrite RemoteMappings as decorator. |
+| {{gh("66b262")}} | Collection export: Filter by vendor |
+| {{gh("cd83c5")}} | Add NEXT get delay oved datastream client query. |
+| {{gh("0df7f0")}} | Add group_type field to ActiveAlarm. |
+| {{gh("f66a22")}} | Add CfgAlarm to AlarmClass config. |
+| {{gh("740faf")}} | Add processed start_ts when extract event on Zabbix etl. |
+| {{gh("fd1dc8")}} | Add Clickhouse Mirror for datasource. |
+| {{gh("375a2c")}} | Unlock Interface profile on `./noc interface-profile` ... |
+| {{gh("191648")}} | selfmon: Kafka monitoring |
+| {{gh("fa50cc")}} | gufo-liftbridge 0.2.0 |
+| {{gh("ca3e5d")}} | #2711 Add diagnostics and mappings fields to service a... |
+| {{gh("5cab0e")}} | Drop grpcio requirement |
+| {{gh("e0a424")}} | Add changed caps when register Changes. |
+| {{gh("8cc91e")}} | HP.Aruba add Profile Check Rules. |
+| {{gh("fd328a")}} | Fix links field in ManagedObject |
+| {{gh("f29a14")}} | Add dynamicprofile decorator for apply profile by rule. |
+| {{gh("555bff")}} | Add capability decorator to ManagedObject model. |
+| {{gh("f0b01a")}} | Add allow_multiple_header flag to _process_cookies for... |
+| {{gh("01ebdb")}} | Add portmapper_name setting to RemoteSystem. |
+| {{gh("2db8fd")}} | Add connect for VMWare connection processed. |
+| {{gh("4b87f0")}} | Show virtual interface type on ManagedObject interface... |
+| {{gh("20415c")}} | Set default param to report UI. |
+| {{gh("d2dc4a")}} | #2662 Disable replace Address and Prefix when changed ... |
+| {{gh("29399b")}} | Add cfmetric datastream Model. |
+| {{gh("440a1a")}} | Add Serial Number value type. |
+| {{gh("d9580d")}} | Add capabilities field to Purgatorium model. |
+| {{gh("5e049c")}} | Add param to InterfaceMACsStat report datasource. |
+| {{gh("c2d682")}} | Add update_checkers_status request to disposition prot... |
+| {{gh("766eac")}} | Add upload files to HTTP Client. |
+| {{gh("cd94e5")}} | Migrate TGSender to NOC Http Client. |
+| {{gh("09ab0a")}} | Add Shelf & Rack models. |
+| {{gh("f4d67e")}} | Add Jobs router to Router Instance. |
+| {{gh("e92d3d")}} | Add RemoteSystem - APIKey integration. |
+| {{gh("8751a7")}} | Add remote_mappings to message ctx. |
+| {{gh("ef99d3")}} | Refactor Action commands |
+| {{gh("666d5b")}} | Fix bi netflow model. Add NAT fields |
+| {{gh("983077")}} | Add from_reference to RemoteSystem model and use it on... |
+| {{gh("dad332")}} | Add transform to Correlator Rule. |
+| {{gh("d846c0")}} | Add inv/Topology Problem report |
+| {{gh("033102")}} | Add set_sla_probe action commands. |
+| {{gh("c0f520")}} | Add SNMP_FAILED_WINDOW for set SNMP Diagnostic on Upti... |
+| {{gh("7a71eb")}} | Create Service Instance from config for IPv4 caps set. |
+| {{gh("951600")}} | Add dynamic classification to Sensor. |
+| {{gh("74b842")}} | Add Zabbix Event classes. |
+| {{gh("40101a")}} | Add Configuration Domain Reaction to Rule. |
+| {{gh("783625")}} | Add cfgmetricstarget datastream. |
+| {{gh("3dd114")}} | Add Sensors to cfgmetricsources. |
+| {{gh("281783")}} | #2738 Add expose to Label ETL Models. |
+| {{gh("25a7df")}} | ReportEngine: Fix saving to xlsx file in 'simpletable'... |
+| {{gh("fe57b6")}} | Use Key for getting RemoteSystem on metrics collector. |
+| {{gh("da1a51")}} | Return Provisioned Policy Settings to SLA and VLAN. |
+| {{gh("59bec0")}} | Migrate Reference filed to PlainReferenceField. |
+| {{gh("6c30a0")}} | Speedup ServiceSummary build object summary. |
+| {{gh("eba37f")}} | Add exposed_sa Label setting. |
+| {{gh("604fba")}} | Add PULL Sensor Value from RemoteSystem. |
+| {{gh("bab902")}} | Speedup Service -> Interface map query. |
+| {{gh("f3eb58")}} | Add Hostname ValueType. |
+| {{gh("ac6ed2")}} | Add service dependencies settings. |
+| {{gh("d26d65")}} | Add set SLA Probe to Action Commands. |
+| {{gh("421855")}} | Add negative suffix to matcher. |
+| {{gh("5dd39b")}} | Set caches to SensorProfile Classification. |
+| {{gh("d5866e")}} | Reformat processed ActionCommands ActionSet for multip... |
+| {{gh("3a5f44")}} | Refactor apply ReactionRule mechanics. |
+| {{gh("95f740")}} | Add remote_system to ObjectDiagnostic check config. |
+| {{gh("a387d3")}} | Add Asset Refs for ManagedObject bind. |
+| {{gh("83ab84")}} | Fix send nodata on metricscollector. |
+| {{gh("6d6611")}} | Add NRI Sensor map to nri_port discovery. |
+| {{gh("fdf46e")}} | Add Job action type to MX messages. |
+| {{gh("1072aa")}} | Add Job action type to MX messages. |
+| {{gh("cb8a2a")}} | Add watchers waiter job to scheduler. |
+| {{gh("4019f8")}} | Refresh labels on ManagedObject when Service changed. |
+| {{gh("d2e488")}} | Add Watchers mechanics to Maintenance Model. |
+| {{gh("fdc3b8")}} | Rebuild CfgEvent Datastream. |
+| {{gh("11f37a")}} | Rebuild CfgEvent Datastream. |
+| {{gh("7af679")}} | Add assigned user to TTSystem context. |
+| {{gh("5dc38c")}} | Processed Escalation profile for group alarm policy. |
+| {{gh("8abfdd")}} | Add sync alarm log to TT System comment. |
+| {{gh("194e5c")}} | Add ObjectEffect to Workflow Decorator. |
+| {{gh("9ba74b")}} | Add Zabbix EventClass collections. |
+| {{gh("361c70")}} | Add some useful logging messages |
+| {{gh("112432")}} | Add cmibs UPS-MIB |
+| {{gh("854c99")}} | Add Administrative Domain description in managedobject... |
+| {{gh("bf8607")}} | Additional log message to interface profile classifica... |
+| {{gh("f9e660")}} | Pretty print resource on Service UI. |
+| {{gh("d3f14b")}} | Speedup iterate over ManagedObject changed on interfac... |
+| {{gh("63a4ec")}} | Fix set Default Service Oper Status. |
+| {{gh("b636b7")}} | Add Expired checkers by TTL. |
+| {{gh("c9dfb2")}} | Add changed to Peer. |
+| {{gh("b858c4")}} | Add register TRAP and SYSLOG diagnostic checks. |
+| {{gh("5eb0cf")}} | Add Vertiv PDU profile. |
+| {{gh("e0cc86")}} | Add CleverElectronic.MPDU profile. |
+| {{gh("2f3f96")}} | Refresh service dependency from config. |
+| {{gh("c318fb")}} | Fix transimission munits to sensor discovery. |
+| {{gh("e9e63e")}} | Change apply cfg metrics rules. |
+| {{gh("43c218")}} | Move refresh metric rules to card. |
+| {{gh("800b9f")}} | Add register_message action. |
+| {{gh("ca84a4")}} | Add REMOTE_SYSTEMS message headers. |
+| {{gh("9d29d0")}} | Add processed caps error to Diagnostic Check. |
+| {{gh("b7fa90")}} | Register NODATA check on metricscollector service. |
+| {{gh("bd23cc")}} | Translate alarm group changes to Alarm job. |
+| {{gh("a3a048")}} | Add exposed capabilities mechanism to Service. |
+| {{gh("473f0b")}} | Settings for translate sensors metrics to MX. |
+| {{gh("21a492")}} | Fix processed sensor asset without Object instance. |
+| {{gh("5df1db")}} | Add required_reference settings for processed alarm se... |
+
+## Bugfixes
+
+| MR                | Title                                              |
+| ----------------- | -------------------------------------------------- |
+| {{gh("c03144")}} | Migrate rust datastream client to ureq 3. Fix insecure... |
+| {{gh("aa9ef2")}} | kafkasender: Fix compression_type = "none" handing |
+| {{gh("38ff61")}} | Fix typo on datastream get_format_role cache. |
+| {{gh("2ad0e4")}} | #2670 Fix AdministrativeDomain filter on Events list. |
+| {{gh("694293")}} | Use MX service for send message wo embedded service. |
+| {{gh("7827e4")}} | new js-package: monaco, micromark |
+| {{gh("a66cfc")}} | Remove 'vs-dark' theme from various components and rep... |
+| {{gh("9fd3f4")}} | Fix watchers key migration on ActiveAlarm. |
+| {{gh("2ab330")}} | Set CPE caps source to discovery. |
+| {{gh("c59404")}} | gufo-snmp 0.8.3 |
+| {{gh("58a1a7")}} | Add settings to ensure service instance. |
+| {{gh("fd2537")}} | #2689 Fix detect resource model for IFACE event vars. |
+| {{gh("9aa570")}} | Add managed_object to escalation alarm context. |
+| {{gh("9ad0c4")}} | Fix metrics command load encode file. |
+| {{gh("5831ed")}} | #2666 Enhance node type validation in MapPanel to hand... |
+| {{gh("15bbca")}} | Refactor radiofield value check in ModelApplication to... |
+| {{gh("488ac4")}} | classifier: Fix double unescaping |
+| {{gh("c090d0")}} | Fix calculate severity when refresh alarm. |
+| {{gh("9b81d0")}} | Improve formatting DiscoveredObject model. |
+| {{gh("0300c7")}} | Fix json export for DispositionRule |
+| {{gh("57014e")}} | Fix etl loader when extract None labels. |
+| {{gh("6728e1")}} | Fix MonMap card with alarm without managedobject. |
+| {{gh("4f2f58")}} | Fix clean Ping Failed Alarm when disabled address. |
+| {{gh("428ccb")}} | Fix Event Drop action on classifier. |
+| {{gh("7bc3e0")}} | Fix set_caps function for detect change value. |
+| {{gh("5642f4")}} | fix decoding unescaped event |
+| {{gh("2671fb")}} | Fix InputSource on ETL Remote Mappings. |
+| {{gh("e72bea")}} | Fix error when mappings fields is empty. |
+| {{gh("17b585")}} | #2128 Fix processed DispositionRule for Ping Failed ev... |
+| {{gh("5fec03")}} | Fix collect SVI metrics on interface. |
+| {{gh("f19195")}} | Fix error when check remote_system on DiscoveredObject... |
+| {{gh("435c85")}} | Fix full fqdn (strip dot) on ManagedObject. |
+| {{gh("93e987")}} | Skip snmp_raw for reclassify SNMP Trap event. |
+| {{gh("87e0a9")}} | Fix time_delta field creation in metric sql-views |
+| {{gh("45ef9a")}} | Fix processed action on classifier. |
+| {{gh("b1e2f6")}} | Fix has checkpoint field in ETL extractor. |
+| {{gh("1148bc")}} | collection sync: Prefer changes from custom |
+| {{gh("0bf615")}} | Add DISABLE_INCREMENTAL_MERGE option to ETL extractor. |
+| {{gh("6ef21a")}} | #2699 Fix filter condition on Label backend. |
+| {{gh("0a6f48")}} | Skip Discovered Object without IP Address. |
+| {{gh("d7ea12")}} | Find ManagedObject by all mappings on ETL. |
+| {{gh("257911")}} | Add router instance to correlator. |
+| {{gh("10f163")}} | Catch error when render alarm template. |
+| {{gh("c3f5f9")}} | Add non-required to caps param on SA igetinterfaces. |
+| {{gh("869e08")}} | Fix setting Workflow State on CPE model. |
+| {{gh("91e459")}} | Fix calculate event_class on disposition rule. |
+| {{gh("33c7d2")}} | Fix AlarmClass label field query. |
+| {{gh("2df313")}} | Fix migrate drop action on DispositionRule. |
+| {{gh("169fb5")}} | Fix clear alarm on clear severity Event  disposition. |
+| {{gh("5eb533")}} | Check datasource exists when migrate mirror. |
+| {{gh("91beb7")}} | Fix apply Alarm Rule handler. |
+| {{gh("db1f3a")}} | Fix ETL check when DiscoveredObject. |
+| {{gh("0ee67c")}} | Fix save discovered object without rule. |
+| {{gh("57e1f1")}} | Fix send notify on NotificationGroup. |
+| {{gh("a5ac32")}} | Fix description linking when object is not managed |
+| {{gh("3db789")}} | Fix duplicate notification when send notify. |
+| {{gh("77e9dd")}} | fix clear alarm notification templating |
+| {{gh("8f182b")}} | Set non-strict to EmbeddedDocument on Object Diagnosti... |
+| {{gh("cbe77a")}} | Fix disposelog writing with empty remote_id and servic... |
+| {{gh("0e3368")}} | Fix apply sync sensors when changed. |
+| {{gh("be6f17")}} | Catch error when caps Source is unknown. |
+| {{gh("e47126")}} | fix test_inv_objectmodels |
+| {{gh("f7004e")}} | Service cards fail to open in "Objects → Services → Vi... |
+| {{gh("a262ff")}} | Fix remote_system column on Purgatorium table. |
+| {{gh("b3e8de")}} | Fix default_Float32 and default_Float64 value on click... |
+| {{gh("25a08e")}} | Fix bug for caps default values |
+| {{gh("b3bab1")}} | Fix refresh diagnostic alarm when ManagedObjectProfile... |
+| {{gh("7e4486")}} | Fix get_by_id usage |
+| {{gh("b63ff8")}} | #2727 Fix raise alarm by interface event. |
+| {{gh("38613f")}} | Fix set SNMP failed on uptime discovery. |
+| {{gh("4fc30b")}} | Fix regression of escalation_tt in card outage |
+| {{gh("9b8b1b")}} | Remove filtering by pool 'default' for superuser and e... |
+| {{gh("50f184")}} | Fix update same caps from different scope. |
+| {{gh("e11227")}} | Fix service disposition alarm typo. |
+| {{gh("c8839b")}} | Fix set severity on group alarm. |
+| {{gh("7cd043")}} | noc-supp-fix-reportpendinglinks-views.py |
+| {{gh("b6e1c3")}} | Fix pm.ddash.graph_interface_load_simple Oper Status a... |
+| {{gh("71a509")}} | Fix simpletable-formatter for write to CSV-format fiel... |
+| {{gh("794d78")}} | Fix pendinglinksds |
+| {{gh("988785")}} | #2730 Fix calculate Alarm Severity by policy. |
+| {{gh("5d9ff9")}} | #2731 Fix 'Partitions are not assigned' when execute k... |
+| {{gh("387149")}} | Migrate ManagedObject caps source from 'caps' to 'disc... |
+| {{gh("b3ac7e")}} | Fix end-date in 'Alarm Detail (new)' report |
+| {{gh("b2fdc6")}} | #2734 Apply message actions on Default Route. |
+| {{gh("f2097a")}} | #2733 Fix subinterface_apply_policy UI Model typo. |
+| {{gh("137f5b")}} | Add database source to migrations. |
+| {{gh("d21960")}} | Update data for field 'container' in managedobjectds |
+| {{gh("433e12")}} | Fix exposed labels to metrics. |
+| {{gh("26bce7")}} | Remove refs column from purgatoirum query. |
+| {{gh("6bcccd")}} | Fix group filter on fm Events UI. |
+| {{gh("aed737")}} | Fix processed MX_NOTIFICATION_METHOD header on tgsender. |
+| {{gh("4677d5")}} | Add NoDataChecker to MetricsCollector |
+| {{gh("aff872")}} | fix async for net-scan |
+| {{gh("fc62e1")}} | Fix nodata set_status send format. |
+| {{gh("7f7df3")}} | Fix match wildcard labels on discovered object. |
+| {{gh("bb283a")}} | Fix merge caps on same RemoteSystem on modeltemplate. |
+| {{gh("467809")}} | Add inv.Interface model to Reaction models. |
+| {{gh("6be6a3")}} | Update interface oper_status fields when oper_status_set. |
+| {{gh("517cc6")}} | Fix Active Alarm error when processed watch action. |
+| {{gh("993a19")}} | noc-supp-fix-qtech2800-normalizer |
+| {{gh("78905f")}} | Fix condition typo on cfgtarget datastream. |
+| {{gh("22d01f")}} | Fix cfgtarget condition typo. |
+| {{gh("d8c1a5")}} | Replace Service Profile caps settings to CapsProfile. |
+| {{gh("f55a30")}} | Fix Render action method on Run Commands. |
+| {{gh("060029")}} | Fix calculate ServiceInstance objects. |
+| {{gh("0feb6e")}} | Fix classifier ruleset typo error. |
+| {{gh("a6b027")}} | Fix extract metric from RemoteSystem. |
+| {{gh("1694a7")}} | ui fm.alarm fix text on filter Wait TT |
+| {{gh("18e7a3")}} | Add reuse_snmpv3_engine_id options for refresh Engine ID. |
+| {{gh("b2d280")}} | Fix save ETL DiscoveredObject on move IP Address on sy... |
+| {{gh("aadbb0")}} | Validate IPv4 address from ifdescr discovery. |
+| {{gh("ca476a")}} | Validate OID for snmp check on Diagnostic Profile Hand... |
+| {{gh("eda328")}} | Add check_labels to on_delete_check decorator, for val... |
+| {{gh("921c9e")}} | Add time_pattern__label field to NotificationGroupAppl... |
+| {{gh("46fd04")}} | Fix create default value on MetricScope Table. |
+| {{gh("14b694")}} | Fix project card when vlan segment used. |
+| {{gh("65dc80")}} | Remove duplicates in DiscoveryID on migration. |
+| {{gh("1e4c8c")}} | Fix matcher iterable once. |
+| {{gh("d82a33")}} | Fix match dynamic profile for same order number. |
+| {{gh("88c16e")}} | ActionCommands: Migrate legacy disable_when_changed va... |
+| {{gh("929f8a")}} | Fix remove capabilities on caps discovery. |
+| {{gh("488cb6")}} | Fix save Diagnostic checks result to object. |
+| {{gh("21b31b")}} | Fix DiscoveredObject calculate preferred on origin det... |
+| {{gh("f32c0b")}} | Fix Label.ensure_label API method on ETL loader. |
+| {{gh("43c73f")}} | Fix received sensor metrics on collector service. |
+| {{gh("94a29f")}} | Fix typo on refresh_object_label method. |
+| {{gh("b27382")}} | Fix processed sensors on Metric service. |
+| {{gh("cd1642")}} | Fix apply MetricRules threshold to sensor scopes. |
+| {{gh("02dac5")}} | Fix processed LinkEvent action. |
+| {{gh("7d52eb")}} | Skip deleted data on DiscoveredObject. |
+| {{gh("66df13")}} | Fix correlator dispose condition, use request value. |
+| {{gh("c5100d")}} | Fix queryset on MetricRule iter_changed_datastream. |
+| {{gh("8bd02c")}} | Fix condition when call maintenance on_save method. |
+| {{gh("1abbf2")}} | Add link_event option to EventClass Config. |
+| {{gh("40a786")}} | Fix used labels and ex_labels condition on Message Route. |
+| {{gh("490039")}} | Huawei.VRP fix stucking get_interfaces after get_inven... |
+| {{gh("de65db")}} | Fix AlarmJob processed for group Alarm. |
+| {{gh("66301e")}} | Fix detect configured metrics on SLAProbes |
+| {{gh("3c2da4")}} | Fix check_tt job processed. |
+| {{gh("be959c")}} | Fixed attempts return for ping service |
+| {{gh("afb2b9")}} | Add remote_system, remote_id to Ignored fields for Man... |
+| {{gh("5d6a5b")}} | Fix deduplication filter for event. |
+| {{gh("f4516b")}} | Fix processed event on collector. |
+| {{gh("d8f3df")}} | Replace pyfs requirements to fsspec for tests fixed. |
+| {{gh("11ef8b")}} | Fix processed sensor metrics from metricscollector. |
+| {{gh("916b38")}} | Fix setting default peer on PeerDiscovery. |
+| {{gh("5c4d55")}} | periodic disocovery. Change division to integer division |
+| {{gh("a22bb0")}} | Fix error when save empty last_ts on ManagedObject status |
+| {{gh("f77158")}} | Fix CLI credential check order |
+| {{gh("025ceb")}} | Fix BGP Peer Down raise |
+| {{gh("3679e4")}} | Fix check labels on ETL Loader processed. |
+| {{gh("baee24")}} | Fix multiple list when set part_no on asset discovery. |
+| {{gh("3c39e5")}} | Add changed to Peer. |
+| {{gh("7f33c2")}} | Fix duplicates when add watchers and add tests. |
+| {{gh("44ad70")}} | Fix processed diagnostic handler. |
+| {{gh("6fa82d")}} | Fix duplicate part_no migration. |
+| {{gh("f5941f")}} | Fix part_no migration typo. |
+| {{gh("b85b1b")}} | Fix processed Measurement Units on sensor in MetricsSe... |
+| {{gh("3f6229")}} | Fix sensor munits hints. |
+| {{gh("a40cdb")}} | Fix update diagnostic checks from jobs. |
+| {{gh("adac17")}} | Fix audittrail filtering |
+| {{gh("648ac0")}} | Fix refresh alarm severity on correlator. |
+| {{gh("d0404c")}} | Fix card custom loader. |
+| {{gh("e2a577")}} | Fix apply mappings when create ManagedObject from Disc... |
+| {{gh("dee97f")}} | Fix processed Notification Message for Forwaded to web... |
+| {{gh("b301d9")}} | Fix processed item changed to Alarm Job. |
+| {{gh("6d4f63")}} | Fix error when chagned mongoengine DictField. |
+
+## Code Cleanup
+
+| MR                | Title                                              |
+| ----------------- | -------------------------------------------------- |
+| {{gh("4643d2")}} | Refactor Diagnostics mechanics. |
+| {{gh("5debbf")}} | .get_by_XXX() typing and implementation unification |
+
+## Profile Changes
+
+### BDCOM.XPON
+
+| MR                | Title                                              |
+| ----------------- | -------------------------------------------------- |
+| {{gh("76dc8c")}} | Add BDCOM.xPON.get_inventory script |
+
+### Cisco.IOS
+
+| MR                | Title                                              |
+| ----------------- | -------------------------------------------------- |
+| {{gh("e7cdf4")}} | Cisco.IOS Add HundredGigE interface type. |
+
+### EdgeCore.ES
+
+| MR                | Title                                              |
+| ----------------- | -------------------------------------------------- |
+| {{gh("912adc")}} | noc-supp-fix-EdgeCore-ES-get_ifindexes |
+
+### Generic
+
+| MR                | Title                                              |
+| ----------------- | -------------------------------------------------- |
+| {{gh("4083ec")}} | Generic.get_mac_address_table. Fix unknown status. |
+
+### Iskratel.MSAN
+
+| MR                | Title                                              |
+| ----------------- | -------------------------------------------------- |
+| {{gh("aa4dd2")}} | Iskratel.MSAN.get_inventory |
+
+### Juniper.JUNOS
+
+| MR                | Title                                              |
+| ----------------- | -------------------------------------------------- |
+| {{gh("6b0f18")}} | Juniper.JUNOS. Add qfx supported. |
+
+### Qtech.QSW2800
+
+| MR                | Title                                              |
+| ----------------- | -------------------------------------------------- |
+| {{gh("5898dd")}} | Noc supp fix qtech normalizer community |
+| {{gh("02b352")}} | noc-supp-fix-qtech2800-normalizer-card |
+
+### rare
+
+| MR                | Title                                              |
+| ----------------- | -------------------------------------------------- |
+| {{gh("7b794c")}} | HP.Aruba. Add configuration patterns. |
+| {{gh("da2835")}} | Add HP.OfficeConnect profile |
+| {{gh("e706f6")}} | HP.Aruba. Add getting serial number. |
+| {{gh("77b4fc")}} | Add C3Solution.PDU profile. |
+
+## Collections Changes
+
+| MR                | Title                                              |
+| ----------------- | -------------------------------------------------- |
+| {{gh("5bc4a2")}} | ReportEngine: Add inv/Pending_Links report |
+| {{gh("944209")}} | Add some BDCOM.xPON profilecheckrules |
+| {{gh("b8d9b0")}} | noc-supp-fix-collections-Alstec-2100-03 |

--- a/docs/releases/SUMMARY.md
+++ b/docs/releases/SUMMARY.md
@@ -1,6 +1,7 @@
 * [NOC Release and Tagging Policy](../release-policy/index.md)
 * NOC 25.1 Generation
     * [NOC 25.1](25_1.md)
+    * [NOC 25.1.1](25_1_1.md)
 * NOC 24.1 Generation:
     * [NOC 24.1](24_1.md)
     * [NOC 24.1.1](24_1_1.md)


### PR DESCRIPTION
## Summary

Add release notes for NOC 25.1.1 — the first maintenance release in the 25.1 generation containing 355 bugfixes, optimizations, and improvements.

## Changes

- Create `docs/releases/25_1_1.md` (+378 lines): structured release notes organized by category:
  - New features (12 items)
  - Improvements (68 items)
  - Bugfixes (190 items)
  - Code cleanup (2 items)
  - Profile changes (BDCOM, Cisco, EdgeCore, Generic, Iskratel, Juniper, Qtech, HP, Aruba, C3Solution, CleverElectronic, Vertiv)
  - Collections changes (3 items)

- Update `docs/releases/SUMMARY.md` (+1 line): register the new release notes page in the navigation tree between NOC 25.1 and NOC 24.1 Generation sectionsAll merge request references use the `{{gh(...)}}` macro (added in #465, already merged) which renders GitHub commit/PR Markdown links. The build pipeline confirms successful macro expansion.
