### PR TITLE
Revert __main__ removal in script command

### DIFF
--- a/commands/script.py
+++ b/commands/script.py
@@ -502,3 +502,7 @@ class JSONObject:
 
     def get_controller_credentials(self):
         return None
+
+
+if __name__ == "__main__":
+    Command().run()


### PR DESCRIPTION
This PR restores the command execution logic in the `./noc script` command.

The functionality was unintentionally removed in commit `0d0c27f91941bebdc01dda37f7b7dcd86919dc93`, causing `./noc script` to stop executing commands as expected.

This change reverts that specific part of the previous refactoring and restores the original behavior.
