### PR TITLE
Object.get_name_path: Allow empty names

### DIFF
--- a/inv/models/object.py
+++ b/inv/models/object.py
@@ -1151,8 +1151,8 @@ class Object(Document):
         if self.parent and self.parent_connection:
             return [*self.parent.get_name_path(), self.parent_connection]
         if self.parent:
-            return [*self.parent.get_name_path(), self.name]
-        return [self.name]
+            return [*self.parent.get_name_path(), self.name or ""]
+        return [self.name or ""]
 
     def log(self, message, user=None, system=None, managed_object=None, op=None) -> None:
         if not user:


### PR DESCRIPTION
Allow `Object.get_name_path()` to handle objects without a name set. Currently, when an object has `name=None`, the method returns a list containing `None`, which causes `TypeError` when consumers try to join the results (e.g., `" | ".join(o.get_name_path())`).

### Key Changes
- Changed 2 return statements in `get_name_path()` from `self.name` to `self.name or ""` so the method always returns a list of strings.

### Notable Implementation Details
- `Object.name` is defined as `StringField()` (not required), so `None` values are valid per schema.
- The method recurses up the parent chain, so any nameless object anywhere in the tree previously poisoned the entire path result.
- Consistent with `Object.__str__()` which already uses `self.name or str(self.id)` to handle missing names.
