### PR TITLE
Fix port list in DGS-1100-10/ME

### DIFF
--- a/sa/profiles/DLink/DxS/profile.py
+++ b/sa/profiles/DLink/DxS/profile.py
@@ -145,7 +145,7 @@ class Profile(BaseProfile):
             if "/" not in name:
                 r += [name.replace(":", "/")]
         else:
-            r += ["1/%s" % name, "1:%s" % name]
+            r += [f"1/{name}", f"1:{name}"]
         return r
 
     @classmethod
@@ -180,9 +180,9 @@ class Profile(BaseProfile):
                     match.group("re_platform").startswith(p) for p in platforms_with_stacked_ports
                 )
             ):
-                return "%s:%s" % (match.group("re_slot"), match.group("re_port"))
+                return "{}:{}".format(match.group("re_slot"), match.group("re_port"))
             if match.group("re_port"):
-                return "%s" % match.group("re_port")
+                return "{}".format(match.group("re_port"))
         elif s.startswith("Slot0/"):
             return s[6:]
         else:
@@ -240,8 +240,8 @@ class Profile(BaseProfile):
                     self.cluster_member = p[8:].strip()
         # Switch to cluster member, if necessary
         if self.cluster_member:
-            script.logger.debug("Switching to SIM member %s" % script.cluster_member)
-            script.cli("reconfig member_id %s" % script.cluster_member)
+            script.logger.debug(f"Switching to SIM member {script.cluster_member}")
+            script.cli(f"reconfig member_id {script.cluster_member}")
 
     def shutdown_session(self, script):
         if self.cluster_member:
@@ -308,7 +308,7 @@ class Profile(BaseProfile):
                 "trap_state": match.group("trap_state"),
                 "desc": descr,
             }
-            key = "%s-%s" % (port, media_type)
+            key = f"{port}-{media_type}"
             return key, obj, s[match.end() :]
         return None
 
@@ -328,7 +328,7 @@ class Profile(BaseProfile):
         ) and not script.match_version(DES3200, platform="DES-3200-28F"):
             objects = []
             if interface is not None:
-                c = script.cli(("show ports %s description" % interface))
+                c = script.cli(f"show ports {interface} description")
             else:
                 c = script.cli("show ports description")
             for match in self.rx_port.finditer(c):
@@ -382,7 +382,7 @@ class Profile(BaseProfile):
             try:
                 if interface is not None:
                     objects = script.cli(
-                        "show ports %s description" % interface,
+                        f"show ports {interface} description",
                         obj_parser=self.parse_interface,
                         cmd_next="n",
                         cmd_stop="q",
@@ -498,7 +498,6 @@ class Profile(BaseProfile):
 def DES1210(v):
     """
     DES-1210-series
-    :param v:
     :return:
     """
     return v["platform"].startswith("DES-1210")
@@ -507,7 +506,6 @@ def DES1210(v):
 def DES30xx(v):
     """
     DES-30xx-series
-    :param v:
     :return:
     """
     return (
@@ -521,7 +519,6 @@ def DES30xx(v):
 def DES3028(v):
     """
     DES-3028-series
-    :param v:
     :return:
     """
     return v["platform"].startswith("DES-3028")
@@ -530,7 +527,6 @@ def DES3028(v):
 def DES3x2x(v):
     """
     DES-3x2x-series
-    :param v:
     :return:
     """
     return (
@@ -544,7 +540,6 @@ def DES3x2x(v):
 def DES3500(v):
     """
     DES-3500-series
-    :param v:
     :return:
     """
     return v["platform"].startswith("DES-35")
@@ -553,7 +548,6 @@ def DES3500(v):
 def DES3200(v):
     """
     DES-3200-series
-    :param v:
     :return:
     """
     return v["platform"].startswith("DES-3200")
@@ -562,7 +556,6 @@ def DES3200(v):
 def DGS3120(v):
     """
     DGS-3120-series
-    :param v:
     :return:
     """
     return v["platform"].startswith("DGS-3120")
@@ -571,7 +564,6 @@ def DGS3120(v):
 def DGS3400(v):
     """
     DGS-3400-series
-    :param v:
     :return:
     """
     return "DGS-3420" not in v["platform"] and v["platform"].startswith("DGS-34")
@@ -580,7 +572,6 @@ def DGS3400(v):
 def DGS3420(v):
     """
     DGS-3420-series
-    :param v:
     :return:
     """
     return v["platform"].startswith("DGS-3420")
@@ -589,7 +580,6 @@ def DGS3420(v):
 def DGS3600(v):
     """
     DGS-3600-series
-    :param v:
     :return:
     """
     return (
@@ -602,7 +592,6 @@ def DGS3600(v):
 def DGS3620(v):
     """
     DGS-3620-series
-    :param v:
     :return:
     """
     return v["platform"].startswith("DGS-3620")
@@ -637,9 +626,9 @@ def get_platform(platform, hw_revision):
         or platform.startswith("DGS-3620-")
     ):
         if hw_revision is not None:
-            if platform.endswith("/%s" % hw_revision):
+            if platform.endswith(f"/{hw_revision}"):
                 return platform
         elif platform.startswith("DES-1210-"):
             hw_revision = "A1"
-        return "%s/%s" % (platform, hw_revision)
+        return f"{platform}/{hw_revision}"
     return platform

--- a/sa/profiles/DLink/DxS/profile.py
+++ b/sa/profiles/DLink/DxS/profile.py
@@ -145,7 +145,7 @@ class Profile(BaseProfile):
             if "/" not in name:
                 r += [name.replace(":", "/")]
         else:
-            r += [f"1/{name}", f"1:{name}"]
+            r += ["1/%s" % name, "1:%s" % name]
         return r
 
     @classmethod
@@ -180,9 +180,9 @@ class Profile(BaseProfile):
                     match.group("re_platform").startswith(p) for p in platforms_with_stacked_ports
                 )
             ):
-                return "{}:{}".format(match.group("re_slot"), match.group("re_port"))
+                return "%s:%s" % (match.group("re_slot"), match.group("re_port"))
             if match.group("re_port"):
-                return "{}".format(match.group("re_port"))
+                return "%s" % match.group("re_port")
         elif s.startswith("Slot0/"):
             return s[6:]
         else:
@@ -240,8 +240,8 @@ class Profile(BaseProfile):
                     self.cluster_member = p[8:].strip()
         # Switch to cluster member, if necessary
         if self.cluster_member:
-            script.logger.debug(f"Switching to SIM member {script.cluster_member}")
-            script.cli(f"reconfig member_id {script.cluster_member}")
+            script.logger.debug("Switching to SIM member %s" % script.cluster_member)
+            script.cli("reconfig member_id %s" % script.cluster_member)
 
     def shutdown_session(self, script):
         if self.cluster_member:
@@ -252,7 +252,7 @@ class Profile(BaseProfile):
     rx_port = re.compile(
         r"^\s*(?P<port>\d+(/|:)?\d*)\s*"
         r"(\((?P<media_type>(C|F))\))?\s+(?P<admin_state>Enabled|Disabled)\s+"
-        r"(?P<admin_speed>Auto|10M|100M|1000M|1G|10G)/"
+        r"(?P<admin_speed>Auto|10M|100M|1000M|1G|10G|Disabled)/"
         r"((?P<admin_duplex>Half|Full)/)?"
         r"(?P<admin_flowctrl>Enabled|Disabled)\s+"
         r"(?P<status>LinkDown|Link\sDown|(?:Err|Loop)\-Disabled|Empty)?"
@@ -308,7 +308,7 @@ class Profile(BaseProfile):
                 "trap_state": match.group("trap_state"),
                 "desc": descr,
             }
-            key = f"{port}-{media_type}"
+            key = "%s-%s" % (port, media_type)
             return key, obj, s[match.end() :]
         return None
 
@@ -328,7 +328,7 @@ class Profile(BaseProfile):
         ) and not script.match_version(DES3200, platform="DES-3200-28F"):
             objects = []
             if interface is not None:
-                c = script.cli(f"show ports {interface} description")
+                c = script.cli(("show ports %s description" % interface))
             else:
                 c = script.cli("show ports description")
             for match in self.rx_port.finditer(c):
@@ -382,7 +382,7 @@ class Profile(BaseProfile):
             try:
                 if interface is not None:
                     objects = script.cli(
-                        f"show ports {interface} description",
+                        "show ports %s description" % interface,
                         obj_parser=self.parse_interface,
                         cmd_next="n",
                         cmd_stop="q",
@@ -498,6 +498,7 @@ class Profile(BaseProfile):
 def DES1210(v):
     """
     DES-1210-series
+    :param v:
     :return:
     """
     return v["platform"].startswith("DES-1210")
@@ -506,6 +507,7 @@ def DES1210(v):
 def DES30xx(v):
     """
     DES-30xx-series
+    :param v:
     :return:
     """
     return (
@@ -519,6 +521,7 @@ def DES30xx(v):
 def DES3028(v):
     """
     DES-3028-series
+    :param v:
     :return:
     """
     return v["platform"].startswith("DES-3028")
@@ -527,6 +530,7 @@ def DES3028(v):
 def DES3x2x(v):
     """
     DES-3x2x-series
+    :param v:
     :return:
     """
     return (
@@ -540,6 +544,7 @@ def DES3x2x(v):
 def DES3500(v):
     """
     DES-3500-series
+    :param v:
     :return:
     """
     return v["platform"].startswith("DES-35")
@@ -548,6 +553,7 @@ def DES3500(v):
 def DES3200(v):
     """
     DES-3200-series
+    :param v:
     :return:
     """
     return v["platform"].startswith("DES-3200")
@@ -556,6 +562,7 @@ def DES3200(v):
 def DGS3120(v):
     """
     DGS-3120-series
+    :param v:
     :return:
     """
     return v["platform"].startswith("DGS-3120")
@@ -564,6 +571,7 @@ def DGS3120(v):
 def DGS3400(v):
     """
     DGS-3400-series
+    :param v:
     :return:
     """
     return "DGS-3420" not in v["platform"] and v["platform"].startswith("DGS-34")
@@ -572,6 +580,7 @@ def DGS3400(v):
 def DGS3420(v):
     """
     DGS-3420-series
+    :param v:
     :return:
     """
     return v["platform"].startswith("DGS-3420")
@@ -580,6 +589,7 @@ def DGS3420(v):
 def DGS3600(v):
     """
     DGS-3600-series
+    :param v:
     :return:
     """
     return (
@@ -592,6 +602,7 @@ def DGS3600(v):
 def DGS3620(v):
     """
     DGS-3620-series
+    :param v:
     :return:
     """
     return v["platform"].startswith("DGS-3620")
@@ -626,9 +637,9 @@ def get_platform(platform, hw_revision):
         or platform.startswith("DGS-3620-")
     ):
         if hw_revision is not None:
-            if platform.endswith(f"/{hw_revision}"):
+            if platform.endswith("/%s" % hw_revision):
                 return platform
         elif platform.startswith("DES-1210-"):
             hw_revision = "A1"
-        return f"{platform}/{hw_revision}"
+        return "%s/%s" % (platform, hw_revision)
     return platform


### PR DESCRIPTION
Admin-down ports on the D-Link DGS-1100-xx/ME series are missing from the parsed port
list. The D-Link `show ports` output prints `Disabled` in the administrative-speed column
for such ports, but the `rx_port` regex in the D-Link DxS profile did not expect that
value, so the whole line failed to match and the port was silently dropped from
`get_ports()`.

**Key changes**
- `sa/profiles/DLink/DxS/profile.py` (1 file, +1/−1): extend the `admin_speed`
  alternation in `rx_port` to include `Disabled`:
  `Auto|10M|100M|1000M|1G|10G` → `Auto|10M|100M|1000M|1G|10G|Disabled`.

**Implementation details**
- The change is a strict widening of one regex alternative; previously matching lines are
  unaffected, and the new case only adds matches.
- `rx_port` is the shared parser for the D-Link DxS family (DES/DGS 1100/12/15/30/32/37,
  incl. DES-1210, DGS-3120/3420/3620); the new alternative is safe across the whole
  family because the device only emits `Disabled` in this column for disabled ports.
- `admin_speed` is captured but consumed nowhere outside `sa/profiles/`, so the new value
  cannot affect any downstream consumer.