### PR TITLE
Add Juniper.JUNOS.get_interface_properties script

### DIFF
--- a/sa/profiles/Juniper/JUNOS/get_interface_properties.py
+++ b/sa/profiles/Juniper/JUNOS/get_interface_properties.py
@@ -1,0 +1,16 @@
+# ----------------------------------------------------------------------
+# Juniper.JUNOS.get_interface_properties script
+# ----------------------------------------------------------------------
+# Copyright (C) 2007-2026 The NOC Project
+# See LICENSE for details
+# ----------------------------------------------------------------------
+
+# NOC modules
+from noc.sa.profiles.Generic.get_interface_properties import Script as BaseScript
+
+
+class Script(BaseScript):
+    name = "Juniper.JUNOS.get_interface_properties"
+
+    def interface_filter(self, interface):
+        return self.profile.valid_interface_name(self, interface)


### PR DESCRIPTION
Add a device script for Juniper JUNOS that filters out Juniper-internal/virtual interface names during interface-property collection, so SNMP-derived interface data for Juniper devices excludes internal pseudo-interfaces (e.g. `em`, `gre`, `reth`, `demux`, `dsc`, … depending on platform).

## Key changes
- New file `sa/profiles/Juniper/JUNOS/get_interface_properties.py`
- Subclasses `noc.sa.profiles.Generic.get_interface_properties.Script` (`BaseScript`)
- Overrides `interface_filter(interface)` to delegate to `self.profile.valid_interface_name(self, interface)`, returning `False` for internal/unsupported interfaces

## Implementation notes
- Mirrors the existing `sa/profiles/Cisco/IOS/get_interface_properties.py` per-vendor pattern.
- `valid_interface_name` (`sa/profiles/Juniper/JUNOS/profile.py:145`) selects an internal-interface regex set by platform (`is_olive` / `is_work_em` matchers) and validates sub-interface units against `logical-interface-unit-range`.
- No new test added (consistent with the existing `Cisco/IOS` variant).
