### PR TITLE
BDCOM.xPON.get_interfaces - parse management interfaces

### DIFF
--- a/sa/profiles/BDCOM/xPON/get_interfaces.py
+++ b/sa/profiles/BDCOM/xPON/get_interfaces.py
@@ -26,7 +26,7 @@ class Script(BaseScript):
         r"(^\s+protocolstatus.+\n)?"
         r"^\s+Ifindex is (?P<snmp_ifindex>\d+)(, unique port number is \d+)?\s*\n"
         r"(^\s+Description: (?P<descr>.+)\n)?"
-        r"^\s+Hardware is (?P<hw>\S+)(, [Aa]ddress is (?P<mac>\S+)\s*\(.+\))?\s*\n"
+        r"(^\s+Hardware is (?P<hw>\S+)(, [Aa]ddress is (?P<mac>\S+)\s*\(.+\))?\s*\n)?"
         r"(^\s+Interface address is (?P<ip>\S+)\s*\n)?"
         r"^\s+MTU (?P<mtu>\d+) bytes",
         re.MULTILINE,
@@ -55,17 +55,22 @@ class Script(BaseScript):
         "EtherSVI": "SVI",
         "PortAggregator": "aggregated",
         "Null": "null",
+        "management": "management",
     }
 
     def execute_cli(self):
         ifaces = []
         v = self.cli("show interface")
         for match in self.rx_int.finditer(v):
-            ifname = self.profile.convert_interface_name(match.group("ifname"))
-            hw = match.group("hw")
+            ifname = match.group("ifname")
+            if match.group("hw"):
+                hw = match.group("hw")
+            else:
+                hw = "management"
             if hw in ["GPON-ONUID", "Giga-LLID", "GigaEthernet-LLID"] and ":" in ifname:
                 continue
             iftype = self.types[hw]
+            ifname = self.profile.convert_interface_name(ifname)
             i = {
                 "name": ifname,
                 "type": iftype,
@@ -104,17 +109,17 @@ class Script(BaseScript):
                         tagged = [item for item in tagged if int(item) != untagged]
                         if tagged:
                             sub["tagged_vlans"] = tagged
+                if ifname.startswith("GigaEth") or ifname.startswith("TGigaEth"):
+                    time.sleep(1)  # Do not remove this!
+                    c = self.cli(f"show lldp interface {ifname}")
+                    for match1 in self.rx_lldp.finditer(c):
+                        if (
+                            match1.group("lldp_rx") == "enabled"
+                            or match1.groups("lldp_tx") == "enabled"
+                        ):
+                            i["enabled_protocols"] = ["LLDP"]
             if i["type"] == "SVI":
                 sub["vlan_ids"] = ifname[4:]
-            if ifname.startswith("GigaEthernet") or ifname.startswith("TGigaEthernet"):
-                time.sleep(1)  # Do not remove this!
-                c = self.cli(f"show lldp interface {ifname}")
-                for match1 in self.rx_lldp.finditer(c):
-                    if (
-                        match1.group("lldp_rx") == "enabled"
-                        or match1.groups("lldp_tx") == "enabled"
-                    ):
-                        i["enabled_protocols"] = ["LLDP"]
             i["subinterfaces"] = [sub]
             ifaces += [i]
         return [{"interfaces": ifaces}]


### PR DESCRIPTION
BDCOM.xPON devices (e.g. `GP…` CPE routers) print their management L3 interface block without a `Hardware is …` line, so `rx_int` currently fails to match those blocks and the management interface is silently dropped from `sa/profiles/BDCOM/xPON/get_interfaces`. This PR makes the `Hardware` line optional and maps its absence to interface type `management`, which is already used by 11+ other vendor profiles. While in the function the PR also fixes the LLID skip (which was effectively dead because `convert_interface_name` strips the colon post-conversion) and moves the `GigaEth*` LLDP discovery block inside the `physical`-type branch.

## Key changes

- **`rx_int` regex** — the `Hardware is (?P<hw>...)` line is now an optional group, so a block with no Hardware line still parses.
- **`self.types["management"] = "management"`** — new type mapping so `hw` defaults to `"management"` when the Hardware line is absent.
- **Default for missing Hardware** — `hw` falls back to the string `"management"` when the group is `None`.
- **`convert_interface_name` reordering** — the LLID skip (`hw in {"GPON-ONUID","Giga-LLID","GigaEthernet-LLID"}` **and** `":" in ifname`) now runs on the **raw** `ifname` before `convert_interface_name` (which strips the colon). Previously the skip was dead code because the converted name never contained `:`.
- **LLDP block placement** — the `GigaEth*` / `TGigaEth*` `show lldp interface …` block now runs only for `physical`-type interfaces (moved inside `if i["type"] == "physical":`).

## Notable implementation details

- `management` type is consistent with `DLink/DxS`, `ZTE/ZXA10`, `Eltex/LTE`, `Qtech/QSW`, `Cisco/SANOS`, etc. It is correctly excluded from interface-metric discovery (`inv/models/interface.py:605` filters to `["physical","aggregated","tunnel","SVI"]`).
- LLDP relocation narrows LLDP collection to physical interfaces — intentional, flagged in review for confirmation.
- Pre-existing latent bug kept as-is: `match1.groups("lldp_tx")` (line 115) should be `match1.group("lldp_tx")` so LLDP Tx is detected; out of scope here, suggest a separate fix.