### PR TITLE
Deploy: Process TOWER_HOME and TOWER_CACHE environment variables

### DIFF
--- a/ansible/vars/main.yml
+++ b/ansible/vars/main.yml
@@ -10,7 +10,10 @@ consul_template_version: "0.25.1"
 
 tower_ip: 127.0.0.1
 tower_path: /opt/tower
-tower_dist_dir: "{{ tower_path }}/var/tower/data/src_dist"
+tower_home: "{{ lookup('env', 'TOWER_HOME') | default(tower_path, true) }}"
+tower_cache: "{{ lookup('env', 'TOWER_CACHE') | default(tower_home + '/var/tower/data', true) }}"
+tower_src_dist: "{{ tower_cache }}/src_dist"
+tower_dist_dir: "{{ tower_src_dist }}"
 tower_version: "{{ lookup('env','TOWER_VERSION') }}"
 tower_show_secrets: "{{ not lookup('env','TOWER_SHOW_SECRETS') or False | bool }}"
 tower_run_checks: "{{ lookup('env','TOWER_RUN_CHECKS') or False | bool }}"


### PR DESCRIPTION
Allow the Tower distribution and cache directories (source-dist location
and download cache) to be redirected via the `TOWER_HOME` and `TOWER_CACHE`
environment variables, decoupling them from the Tower install path
(`tower_path`). This makes it possible to relocate the cache/dist storage
without changing where Tower itself is installed — useful for putting
dist data on a larger/faster volume or per-deploy isolation.

### Key changes

`ansible/vars/main.yml` — replace the single expression
`tower_dist_dir: "{{ tower_path }}/var/tower/data/src_dist"` with a
four-var chain:

- `tower_home`   = `TOWER_HOME` env, default `tower_path` (`/opt/tower`)
- `tower_cache`  = `TOWER_CACHE` env, default `tower_home + /var/tower/data`
- `tower_src_dist` = `tower_cache + /src_dist`
- `tower_dist_dir` = `tower_src_dist` (unchanged public name)

### Implementation notes

- Each level uses `lookup('env', ...) | default(<fallback>, true)` (strict
  mode) so an unset env var — which the env lookup returns as `''` — falls
  back to the computed default instead of producing an empty path.
- **Backward-compatible:** with both env vars unset, `tower_dist_dir`
  resolves to exactly `{{ tower_path }}/var/tower/data/src_dist` as before.
- `tower_dist_dir` remains the only consumed variable (system roles
  `consul`/`consul-template`/`nats`/`goss`/`liftbridge` and the molecule
  test suites). The new `tower_home`/`tower_cache`/`tower_src_dist` are
  override entry points and have no in-repo consumers by design.
- Matches the existing `TOWER_*` env-override pattern already present in the
  file (`TOWER_VERSION`, `TOWER_SHOW_SECRETS`, …).