### PR TITLE
deploy: Fix system python handling

### DIFF
--- a/ansible/noc_roles/noc/tasks/init_venv_python3.yml
+++ b/ansible/noc_roles/noc/tasks/init_venv_python3.yml
@@ -42,7 +42,7 @@
 # If there is a system python with needed family (3.X)
 - name: We'll try to use system's python
   set_fact:
-    noc_init_python_path: "{{ system_python3_path.stat.path }}}"
+    noc_init_python_path: "{{ system_python3_path.stat.path }}"
   when:
     - system_python3_version.stdout is defined
     - system_python3_existing_family_version is defined

--- a/ansible/noc_roles/noc/tasks/init_venv_python3.yml
+++ b/ansible/noc_roles/noc/tasks/init_venv_python3.yml
@@ -42,7 +42,7 @@
 # If there is a system python with needed family (3.X)
 - name: We'll try to use system's python
   set_fact:
-    noc_init_python_path: system_python3_path
+    noc_init_python_path: "{{ system_python3_path }}"
   when:
     - system_python3_version.stdout is defined
     - system_python3_existing_family_version is defined

--- a/ansible/noc_roles/noc/tasks/init_venv_python3.yml
+++ b/ansible/noc_roles/noc/tasks/init_venv_python3.yml
@@ -42,7 +42,7 @@
 # If there is a system python with needed family (3.X)
 - name: We'll try to use system's python
   set_fact:
-    noc_init_python_path: "{{ system_python3_path }}"
+    noc_init_python_path: "{{ system_python3_path.stat.path }}}"
   when:
     - system_python3_version.stdout is defined
     - system_python3_existing_family_version is defined


### PR DESCRIPTION
Correct the value assigned to `noc_init_python_path` in the "use system Python" branch of the NOC virtualenv bootstrap, so the correct system interpreter is used when the host provides one.

## Background
`system_python3_path` (`init_venv_python3.yml:27`) is the \`register:\` of a \`stat\` module call, not a path string. The original bare-scalar form `noc_init_python_path: system_python3_path` assigned the literal string \`"system_python3_path"\`; the first fix attempt `{{ system_python3_path }}` stringifies the entire register dict. Either way the interpreter string fed to `virtualenv_command` (line 156) is invalid and `venv` creation fails on systems where the host has a matching system Python3.

## Change
- `ansible/noc_roles/noc/tasks/init_venv_python3.yml` (+1/−1)
   - `noc_init_python_path: "{{ system_python3_path.stat.path }}"` — extracts the resolved path from the \`stat\` register, consistent with `.stat` / `.stdout` extraction already used elsewhere in this file.
