### PR TITLE
print-files: --exclude argument

### DIFF
--- a/scripts/print-files.py
+++ b/scripts/print-files.py
@@ -2,33 +2,64 @@
 # ----------------------------------------------------------------------
 # print-files script
 # ----------------------------------------------------------------------
-# Copyright (C) 2007-2025 The NOC Project
+# Copyright (C) 2007-2026 The NOC Project
 # See LICENSE for details
 # ----------------------------------------------------------------------
 
 """Print all files and directories specified by arguments."""
 
 # Python modules
+import argparse
 from pathlib import Path
 from typing import Iterable
 import sys
 
 HEADER_LEN = 72
 NO_NEWLINE_MARKER = r"\ No newline at end of file"  # backslash is to match git output
+SAFE_SUFFIXES = {".py", ".js", ".ts", ".yml", ".yaml", ".json", ".md", ".css", ".html", ".txt"}
 
 
-def iter_files(paths: Iterable[str]) -> Iterable[Path]:
+def iter_files(paths: Iterable[str], exclude: Iterable[str]) -> Iterable[Path]:
+    def is_safe(path: Path) -> bool:
+        return path.is_file() and path.suffix in SAFE_SUFFIXES
+
+    def is_excluded(path: Path) -> bool:
+        return any(path == exclude or exclude in path.parents for exclude in excludes)
+
+    excludes = [Path(p) for p in exclude]
     for arg in paths:
         path = Path(arg)
+        if is_excluded(path):
+            continue
         if path.is_dir():
-            yield from (p for p in path.rglob("*") if p.is_file())
-        elif path.is_file():
+            for p in path.rglob("*"):
+                if is_excluded(p):
+                    continue
+                if is_safe(p):
+                    yield p
+        elif is_safe(path):
             yield path
 
 
 def main(*args: str) -> None:
-    paths = args if args else (str(Path.cwd()),)
-    for path in iter_files(paths):
+    parser = argparse.ArgumentParser(
+        description="Print all files and directories specified by arguments.",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="files and directories to print",
+    )
+    parser.add_argument(
+        "--exclude",
+        action="append",
+        default=[],
+        help="file or directory name to exclude; may be specified multiple times",
+    )
+    options = parser.parse_args(args)
+
+    paths = options.paths or (str(Path.cwd()),)
+    for path in iter_files(paths, exclude=options.exclude):
         header = f"===[ File: {path} ]"
         if len(header) < HEADER_LEN:
             header += "=" * (HEADER_LEN - len(header))

--- a/scripts/print-files.py
+++ b/scripts/print-files.py
@@ -10,13 +10,30 @@
 
 # Python modules
 import argparse
+import sys
 from pathlib import Path
 from typing import Iterable
-import sys
 
 HEADER_LEN = 72
 NO_NEWLINE_MARKER = r"\ No newline at end of file"  # backslash is to match git output
-SAFE_SUFFIXES = {".py", ".js", ".ts", ".yml", ".yaml", ".json", ".md", ".css", ".html", ".txt"}
+SAFE_SUFFIXES = {
+    ".py",
+    ".sql",
+    ".ts",
+    ".json",
+    ".yaml",
+    ".js",
+    ".conf",
+    ".yml",
+    ".css",
+    ".sh",
+    ".toml",
+    ".md",
+    ".html",
+    ".xml",
+    ".txt",
+    ".j2",
+}
 
 
 def iter_files(paths: Iterable[str], exclude: Iterable[str]) -> Iterable[Path]:
@@ -26,7 +43,7 @@ def iter_files(paths: Iterable[str], exclude: Iterable[str]) -> Iterable[Path]:
     def is_excluded(path: Path) -> bool:
         return any(path == exclude or exclude in path.parents for exclude in excludes)
 
-    excludes = [Path(p) for p in exclude]
+    excludes = tuple(Path(p) for p in exclude if p)
     for arg in paths:
         path = Path(arg)
         if is_excluded(path):
@@ -54,11 +71,11 @@ def main(*args: str) -> None:
         "--exclude",
         action="append",
         default=[],
-        help="file or directory name to exclude; may be specified multiple times",
+        help="relative file or directory path to exclude; may be specified multiple times",
     )
     options = parser.parse_args(args)
 
-    paths = options.paths or (str(Path.cwd()),)
+    paths = options.paths or (".",)
     for path in iter_files(paths, exclude=options.exclude):
         header = f"===[ File: {path} ]"
         if len(header) < HEADER_LEN:


### PR DESCRIPTION
Extend the `scripts/print-files.py` utility so operators can exclude specific files or directories from the printed set, and so the tool dumps text sources

## Key changes
- Add a `--exclude` option (repeatable, `action="append"`). Each value is a relative file or directory path to drop from the output; a directory exclude pr
- Add the `SAFE_SUFFIXES` allowlist: `.py .sql .ts .json .yaml .js .conf .yml .css .sh .toml .md .html .xml .txt .j2`. Files are filtered on this list both
- Rework `main` onto `argparse` (variadic positional `paths`, `--exclude`). The default scan base is `"."` (relative) so that relative `--exclude` values m
- Blank `--exclude` values are ignored (`if p`), so a stray empty argument no longer wipes the whole output.
- Bump the copyright year to 2007–2026.

## Notable implementation details
- `is_excluded(path)` returns true when the path equals an exclude entry or has one as an ancestor, so a directory exclude prunes its subtree at every visi
- `is_safe(path)` requires `path.is_file()` and a recognised suffix.
- The relative default base (`"."`) is what makes the `--exclude` matching reliable; an absolute base (the previous behaviour) caused relative excludes to 
