### PR TITLE
Set version to 26-dev

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -17,6 +17,6 @@ Attributes:
 # Activate custom module loaders
 import noc.core.importer  # noqa
 
-__version__ = "25.1"
+__version__ = "26-dev"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
Bump the NOC version to the `26-dev` development cycle.

## Key changes

- Update the version constant in `__init__.py` from `"25.1"` to `"26-dev"`.

## Notable implementation details

- The version is declared once as `__version__` in the root module and consumed by `pyproject.toml` via `version = {attr = "noc.__version__"}`, so this single edit propagates to the package version automatically.
- `src/noc/__init__.py` symlinks to the root `__init__.py`, so there is no duplicate version definition to update.
- This follows the routine release-cadence pattern (master tracks the active development version), consistent with prior version bumps.