### PR TITLE
Remove legacy branding scheme

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -17,6 +17,6 @@ Attributes:
 # Activate custom module loaders
 import noc.core.importer  # noqa
 
-__version__ = "25.1"
+__version__ = "26-dev"
 
 __all__ = ["__version__"]

--- a/config.py
+++ b/config.py
@@ -1110,7 +1110,7 @@ class Config(BaseConfig):
 
             Unauthorized modification or circumvention, distribution of
             software or services incorporating such changes, or use of such
-            derivative products may constitute violations of paragraphs 3–6
+            derivative products may constitute violations of paragraphs 3-6
             of the License and may give rise to legal consequences under
             applicable international and national law.
 

--- a/config.py
+++ b/config.py
@@ -132,8 +132,6 @@ class Config(BaseConfig):
     class biosegmentation(ConfigSection):
         processed_trials_ttl = SecondsParameter(default="1w")
 
-    brand = StringParameter(default="NOC")
-
     class cache(ConfigSection):
         vcinterfacescount = SecondsParameter(default="1h")
         vcprefixes = SecondsParameter(default="1h")

--- a/config.py
+++ b/config.py
@@ -1093,6 +1093,32 @@ class Config(BaseConfig):
         super().__init__(rewrites=rewrites)
 
     @property
+    def brand(self) -> str:
+        """
+        System branding name.
+
+        !!! warning
+
+            LICENSE RESTRICTION: This property is protected by the NOC
+            branding and licensing terms.
+
+            Without prior written authorization from the copyright holder,
+            do not modify, override, replace, patch, bypass, circumvent, or
+            redirect the execution path around this property. This includes
+            changing its call sites to obtain branding information from another
+            source.
+
+            Unauthorized modification or circumvention, distribution of
+            software or services incorporating such changes, or use of such
+            derivative products may constitute violations of paragraphs 3–6
+            of the License and may give rise to legal consequences under
+            applicable international and national law.
+
+            See LICENSE.md for details.
+        """
+        return "NOC"
+
+    @property
     def pg_connection_args(self) -> dict[str, str | int]:
         """
         PostgreSQL database connection arguments

--- a/core/version.py
+++ b/core/version.py
@@ -130,7 +130,7 @@ class Version:
 
     @cached_property
     def package_versions(self) -> dict[str, str]:
-        return {"Python": self.python_version}
+        return {"Python": sys.version.split()[0]}
 
 
 # Singleton instance

--- a/core/version.py
+++ b/core/version.py
@@ -93,10 +93,6 @@ class Version:
         return config.version_format % kw
 
     @cached_property
-    def brand(self) -> str:
-        return "NOC"
-
-    @cached_property
     def os_version(self) -> str:
         return " ".join(os.uname())
 

--- a/core/version.py
+++ b/core/version.py
@@ -9,37 +9,19 @@
 import os
 import sys
 import subprocess
-import platform
+from pathlib import Path
+from functools import cached_property
 
 # NOC modules
 from noc.config import config
 from noc import __version__
 
 CHANGESET_LEN = 8
-BRAND_PATH = config.get_customized_paths("BRAND", prefer_custom=True)
 WHICH = "which"
-if os.name == "nt":
-    WHICH = "where"
-
-
-class cachedproperty:
-    def __init__(self, f) -> None:
-        self.f = f
-        self.n = f"_{f.__name__}"
-        self.__doc__ = f.__doc__
-
-    def __get__(self, instance, owner):
-        if instance is None:
-            return self
-        v = getattr(instance, self.n, None)
-        if v is None:
-            v = self.f(instance)
-            setattr(instance, self.n, v)
-        return v
 
 
 class Version:
-    @cachedproperty
+    @cached_property
     def has_git(self) -> bool:
         """
         Check .git directory is exists and git executable is in $PATH
@@ -50,7 +32,7 @@ class Version:
                 return subprocess.call([WHICH, "git"], stdout=null) == 0
         return False
 
-    @cachedproperty
+    @cached_property
     def branch(self) -> str:
         """
         Returns current branch
@@ -68,7 +50,7 @@ class Version:
                 )
         return ""
 
-    @cachedproperty
+    @cached_property
     def changeset(self) -> str:
         """
         Returns current changeset
@@ -86,7 +68,7 @@ class Version:
                 )
         return ""
 
-    @cachedproperty
+    @cached_property
     def version(self) -> str:
         if not self.has_git:
             return __version__
@@ -110,60 +92,34 @@ class Version:
         }
         return config.version_format % kw
 
-    @cachedproperty
+    @cached_property
     def brand(self) -> str:
-        for p in BRAND_PATH:
-            if os.path.exists(p):
-                with open(p) as f:
-                    return f.read().strip()
-        return config.brand
+        return "NOC"
 
-    @cachedproperty
+    @cached_property
     def os_version(self) -> str:
         return " ".join(os.uname())
 
-    @cachedproperty
+    @cached_property
     def os_brand(self) -> str | None:
-        o = os.uname()[0].lower()
-        if o == "linux":
-            # os-release
-            if os.path.exists("/etc/os-release"):
-                vdata = {}
-                with open("/etc/os-release") as f:
-                    for line in f:
-                        if "=" not in line:
-                            continue
-                        line = line.strip()
+        uname = os.uname()
+        match uname.sysname.lower():
+            case "linux":
+                os_release = Path("/etc/os-release")
+                if not os_release.exists():
+                    return "Unknown Linux"
+                data: dict[str, str] = {}
+                for line in os_release.read_text().splitlines():
+                    if "=" in line:
                         k, v = line.split("=", 1)
-                        if v.startswith('"') and v.endswith('"'):
-                            v = v[1:-1]
-                        vdata[k] = v
-                return "{} {}".format(vdata["NAME"], vdata["VERSION_ID"])
-            # Old SuSE?
-            if os.path.exists("/etc/SuSE-release"):
-                # SuSE
-                with open("/etc/SuSE-release") as f:
-                    return f.readline().strip()
-            # try lsb_release -d
-            try:
-                b = subprocess.check_output(["lsb_release", "-d"], encoding="utf-8")
-                return b.split(":", 1)[1].strip()
-            except OSError:
-                pass
-            return "Unknown Linux"
-        if o == "freebsd":
-            u = os.uname()
-            return f"{u[0]} {u[2]}"
-        if o == "darwin":
-            # OS X
-            return f"Mac OS X {platform.mac_ver()[0]}"
-        return None
+                        data[k] = v.strip('"')
+                return f"{data['NAME']} {data['VERSION_ID']}"
+            case "freebsd":
+                return f"{uname.sysname} {uname.release}"
+            case _:
+                return None
 
-    @cachedproperty
-    def python_version(self) -> str:
-        return sys.version.split()[0]
-
-    @cachedproperty
+    @cached_property
     def process(self) -> str:
         argv = [v for v in sys.argv if v]
         if not argv:
@@ -172,7 +128,7 @@ class Version:
             return argv[1]
         return argv[0]
 
-    @cachedproperty
+    @cached_property
     def package_versions(self) -> dict[str, str]:
         return {"Python": self.python_version}
 

--- a/docs/config-reference/global.md
+++ b/docs/config-reference/global.md
@@ -14,10 +14,6 @@ Hostname.
 
 {{ config_param("loglevel") }}
 
-## brand
-
-{{ config_param("brand") }}
-
 ## global_n_instances
 
 {{ config_param("global_n_instances") }}

--- a/services/web/apps/main/desktop/views.py
+++ b/services/web/apps/main/desktop/views.py
@@ -70,7 +70,7 @@ class DesktopApplication(ExtApplication):
             "desktop.html",
             language=self.get_language(request),
             theme=config.web.theme,
-            brand=version.brand,
+            brand=config.brand,
         )
 
     @api.get("^settings/$", access=True)
@@ -83,7 +83,7 @@ class DesktopApplication(ExtApplication):
         language = self.get_language(request)
         return {
             "system_uuid": cp.system_uuid or None,
-            "brand": version.brand,
+            "brand": config.brand,
             "features": [f.value for f in active_features()],
             "installation_name": config.installation_name,
             "preview_theme": config.customization.preview_theme,


### PR DESCRIPTION
Consolidate the reported product name and drop the legacy branding scheme — the file-based `BRAND_PATH` lookup, the operator-configurable `config.brand` parameter, and the `Version.python_version` member — so branding is locked to `"NOC"` via a hardcoded, license-protected property and the module relies on the stdlib `functools.cached_property` instead of a hand-rolled cached-property helper. Bump `__version__` to `26-dev` in the same change.

### Key changes
- `__init__.py`: bump `__version__` from `25.1` to `26-dev` (release-cadence bump).
- `config.py`: remove the top-level `brand = StringParameter(default="NOC")` parameter and instead expose branding as a read-only `@property brand()` on `Config` that hardcodes `"NOC"` (with a license-restriction docstring). Brand is no longer operator-configurable.
- `core/version.py`:
    - Replace the local `cachedproperty` helper with `functools.cached_property`.
    - Remove the `Version.brand` property (branding now lives on `config.brand`).
    - `os_brand`: rewrite with `match/case` over `os.uname().sysname` (Linux via `/etc/os-release`, FreeBSD, else `None`).
    - Remove the `python_version` property; `package_versions` now inlines `sys.version.split()[0]`.
    - Drop the legacy Windows `where` fallback (use `which` only).
- `services/web/apps/main/desktop/views.py`: use `config.brand` (reverted from `version.brand`).
- `docs/config-reference/global.md`: remove the `brand` configuration section.

### Notable implementation details
- Branding is now a fixed `config.brand` property returning `"NOC"` carrying a license-protecting docstring, rather than a configurable parameter — consistent with the NOC License. All existing `config.brand` consumers (card rendering, web About/home views, KB card templates) resolve through it unchanged.
- `os_brand` no longer probes `lsb_release` / `SuSE-release`; macOS (darwin) now falls through to the `case _` default and returns `None`.
