### PR TITLE
Remove unused facter

### DIFF
--- a/ansible/noc_roles/pre/tasks/facts.yml
+++ b/ansible/noc_roles/pre/tasks/facts.yml
@@ -1,9 +1,4 @@
 ---
-- name: Collect facts returned by facter
-  setup:
-    gather_subset:
-      - facter
-
 - name: Set tower_ip
   set_fact:
     tower_ip: "{{ hostvars[inventory_hostname]['ansible_env']['SSH_CLIENT'].split(' ')[0] | default('127.0.0.1') }}"


### PR DESCRIPTION
Remove the unused Facter fact-collection task from the `pre` pre-deployment Ansible role.

## What this does
Deletes the `Collect facts returned by facter` task (`setup: gather_subset: [facter]`) from `ansible/noc_roles/pre/tasks/facts.yml`. The task ran Facter 

 ## Details
- Removes only the 5-line Facter task; the two `tower_ip` `set_fact` tasks in the same file are untouched.
- Verified `facter` no longer appears anywhere in the repository after the change, and no role consumes Facter-produced facts.
- No module/import breakage: `setup`/`gather_subset` are core Ansible modules not referenced elsewhere.
