### PR TITLE
deploy: Fix bool filter usage

### DIFF
--- a/ansible/molecule/common/cache.yml
+++ b/ansible/molecule/common/cache.yml
@@ -6,7 +6,7 @@
   tasks:
     - name: export use_cache var
       set_fact:
-        use_cache: "{{ lookup('env','USE_CACHE') or True | bool }}"
+        use_cache: "{{ (lookup('env','USE_CACHE') or True) | bool }}"
         minio_bucket: "myminio/{{ inventory_hostname | replace('_','-') }}"
         pip_cache_dir: "{{ lookup('env','PIP_CACHE') }}"
         pkg_cache_dir: "{{ lookup('env','PKG_CACHE') }}"

--- a/ansible/molecule/common/prepare.yml
+++ b/ansible/molecule/common/prepare.yml
@@ -6,7 +6,7 @@
   tasks:
     - name: expose vars to playbook
       set_fact:
-        use_cache: "{{ lookup('env','USE_CACHE') or True | bool }}"
+        use_cache: "{{ (lookup('env','USE_CACHE') or True) | bool }}"
 
     - name: download caches
       import_tasks: cache_download.yml

--- a/ansible/molecule/freebsd/cache.yml
+++ b/ansible/molecule/freebsd/cache.yml
@@ -6,7 +6,7 @@
   tasks:
     - name: export use_cache var
       set_fact:
-        use_cache: "{{ lookup('env','USE_CACHE') or True | bool }}"
+        use_cache: "{{ (lookup('env','USE_CACHE') or True) | bool }}"
         minio_bucket: "myminio/{{ inventory_hostname | replace('_','-') }}"
         pip_cache_dir: "{{ lookup('env','PIP_CACHE') }}"
         pkg_cache_dir: "{{ lookup('env','PKG_CACHE') }}"

--- a/ansible/molecule/freebsd/prepare.yml
+++ b/ansible/molecule/freebsd/prepare.yml
@@ -6,7 +6,7 @@
   tasks:
     - name: expose vars to playbook
       set_fact:
-        use_cache: "{{ lookup('env','USE_CACHE') or True | bool }}"
+        use_cache: "{{ (lookup('env','USE_CACHE') or True) | bool }}"
 
     - name: download caches
       import_tasks: cache_download.yml

--- a/ansible/vars/main.yml
+++ b/ansible/vars/main.yml
@@ -15,11 +15,11 @@ tower_cache: "{{ lookup('env', 'TOWER_CACHE') | default(tower_home + '/var/tower
 tower_src_dist: "{{ tower_cache }}/src_dist"
 tower_dist_dir: "{{ tower_src_dist }}"
 tower_version: "{{ lookup('env','TOWER_VERSION') }}"
-tower_show_secrets: "{{ not lookup('env','TOWER_SHOW_SECRETS') or False | bool }}"
-tower_run_checks: "{{ lookup('env','TOWER_RUN_CHECKS') or False | bool }}"
-tower_run_tests: "{{ lookup('env','TOWER_RUN_TESTS') or False | bool }}"
-tower_stop_noc: "{{ lookup('env','TOWER_STOP_NOC') or True | bool }}"
-tower_serial_restart_noc: "{{ lookup('env','TOWER_SERIAL_RESTART_NOC') or False | bool }}"
+tower_show_secrets: "{{ (not lookup('env','TOWER_SHOW_SECRETS')) | bool }}"
+tower_run_checks: "{{ lookup('env','TOWER_RUN_CHECKS') | bool }}"
+tower_run_tests: "{{ lookup('env','TOWER_RUN_TESTS') | bool }}"
+tower_stop_noc: "{{ (lookup('env','TOWER_STOP_NOC') or True) | bool }}"
+tower_serial_restart_noc: "{{ lookup('env','TOWER_SERIAL_RESTART_NOC') | bool }}"
 tower_minimum_version: "1.0.9"
 
 noc_system_service: noc


### PR DESCRIPTION
Correct a latent Jinja2 operator-precedence bug in Ansible `set_fact` statements used to configure cache and Tower-deploy flags. The bug was latent (silently wrong only when an environment variable is explicitly set to a string such as `"false"`/`"0"`/`"1"`), which is why it was not caught earlier.

**Root cause**

In Jinja2 the pipe filter `|` binds **tighter** than the `or` operator, so:

```
use_cache: "{{ lookup('env','USE_CACHE') or True | bool }}"
```

is parsed as `X or (True | bool)`, i.e. `| bool` is applied to the literal `True` — **not** to the looked-up value. The result collapses to `X or True`, which is always truthy, and when the env var *is* set the raw string (`"false"`, `"0"`) is passed through uncoerced. Those strings are truthy in Ansible, so `when: use_cache` (and the `tower_*` `when:` guards) evaluated incorrectly.

**Key changes (5 files, +9/−9)**

- Wrap the conditional so the `bool` filter applies to the whole expression:
  - `X or True  | bool` → `(X or True) | bool`   — `ansible/molecule/common/cache.yml`, `ansible/molecule/freebsd/cache.yml`, `ansible/molecule/common/prepare.yml`, `ansible/molecule/freebsd/prepare.yml`
  - `X or False | bool` → `X | bool`            — `ansible/vars/main.yml` (`tower_run_checks`, `tower_run_tests`, `tower_serial_restart_noc`); the `or False` default is redundant since an unset/empty env value is already falsy.
  - `not X or False | bool` → `(not X) | bool`  — `ansible/vars/main.yml` (`tower_show_secrets`).
  - `X or True | bool` → `(X or True) | bool`   — `ansible/vars/main.yml` (`tower_stop_noc`).

**Implementation notes**

- Default semantics are preserved: `use_cache` and `tower_stop_noc` still default to `True` when unset; `tower_run_checks`/`tower_run_tests`/`tower_serial_restart_noc` default to `False` when unset.
- No logic, imports, or config sections added or removed — purely a precedence correction.
- These 5 lines are the complete set of the buggy idiom in the `ansible/` tree; `ansible/molecule/yc/prepare.yml` already uses the correct `| bool if … is defined else true` form.