### PR TITLE
deploy: Replace `with_items` with `loop`

### DIFF
--- a/ansible/molecule/common/create.yml
+++ b/ansible/molecule/common/create.yml
@@ -23,7 +23,7 @@
         wait_for_ip_address: "yes"
         state: poweredon
       register: server
-      with_items: "{{ molecule_yml.platforms }}"
+      loop: "{{ molecule_yml.platforms }}"
 
     - name: Populate instance config dict
       set_fact:
@@ -34,7 +34,7 @@
           'port': "{{ molecule_yml.driver.ssh_port }}",
           'identity_file': "{{ molecule_yml.driver.ssh_identity_file }}"
         }
-      with_items: "{{ server.results }}"
+      loop: "{{ server.results }}"
       register: instance_config_dict
       when: server is changed
 

--- a/ansible/molecule/common/destroy.yml
+++ b/ansible/molecule/common/destroy.yml
@@ -18,7 +18,7 @@
         state: absent
         force: "yes"
       register: server
-      with_items: "{{ molecule_yml.platforms }}"
+      loop: "{{ molecule_yml.platforms }}"
 
     - name: Populate instance config
       set_fact:

--- a/ansible/molecule/common/verify.yml
+++ b/ansible/molecule/common/verify.yml
@@ -33,10 +33,10 @@
       command: "{{ goss_dst }} -g {{ item }} validate --format {{ goss_format }}"
       become: true
       register: test_results
-      with_items: "{{ test_files.stdout_lines }}"
+      loop: "{{ test_files.stdout_lines }}"
 
     - name: Fail when tests fail
       fail:
         msg: "Goss failed to validate"
       when: item.rc != 0
-      with_items: "{{ test_results.results }}"
+      loop: "{{ test_results.results }}"

--- a/ansible/molecule/freebsd/verify.yml
+++ b/ansible/molecule/freebsd/verify.yml
@@ -29,7 +29,7 @@
     - name: Execute Goss tests
       command: "{{ goss_dst }} -g {{ item }} validate"
       register: test_results
-      with_items: "{{ test_files.stdout_lines }}"
+      loop: "{{ test_files.stdout_lines }}"
       ignore_errors: true
       failed_when: false
       when:

--- a/ansible/molecule/yc/create.yml
+++ b/ansible/molecule/yc/create.yml
@@ -9,13 +9,13 @@
       file:
         path: "../yc/{{ item.distr }}"
         state: directory
-      with_items: "{{ molecule_yml.platforms }}"
+      loop: "{{ molecule_yml.platforms }}"
 
     - name: Generate terraform file
       template:
         src: templates/template.tf
         dest: "../yc/{{ item.distr }}/{{ item.distr }}.tf"
-      with_items: "{{ molecule_yml.platforms }}"
+      loop: "{{ molecule_yml.platforms }}"
 
     - name: Create molecule instance(s)
       terraform:
@@ -23,7 +23,7 @@
         state: present
         force_init: true
       register: server
-      with_items: "{{ molecule_yml.platforms }}"
+      loop: "{{ molecule_yml.platforms }}"
 
     - name: Populate instance config dict
       set_fact:
@@ -34,7 +34,7 @@
           'user': "{{ item.item.ssh_user }}"
           'port': "22"
           'identity_file': "{{ molecule_yml.driver.ssh_identity_file }}"
-      with_items: "{{ server.results }}"
+      loop: "{{ server.results }}"
 
     - name: Create instance config
       set_fact:

--- a/ansible/molecule/yc/destroy.yml
+++ b/ansible/molecule/yc/destroy.yml
@@ -10,4 +10,4 @@
         state: absent
         force_init: true  # yamllint disable-line rule:truthy
         purge_workspace: true  # yamllint disable-line rule:truthy
-      with_items: "{{ molecule_yml.platforms }}"
+      loop: "{{ molecule_yml.platforms }}"

--- a/ansible/noc_roles/activator/tasks/main.yml
+++ b/ansible/noc_roles/activator/tasks/main.yml
@@ -10,7 +10,7 @@
     owner: root
     group: "{{ noc_group }}"
     mode: 0550
-  with_items: "{{ noc_all_pools }}"
+  loop: "{{ noc_all_pools }}"
   tags:
     - config
 
@@ -32,7 +32,7 @@
     value: "{{ item.value }}"
     state: present
     reload: "True"
-  with_items:
+  loop:
     - { name: 'net.ipv4.tcp_no_metrics_save', value: 1}
     - { name: 'net.ipv4.tcp_window_scaling', value: 0}
     - { name: 'net.ipv4.tcp_timestamps', value: 1}

--- a/ansible/noc_roles/bi/tasks/main.yml
+++ b/ansible/noc_roles/bi/tasks/main.yml
@@ -8,7 +8,7 @@
     chdir: "{{ noc_root }}"
   register: s
   changed_when: "'CHANGED' in s.stdout"
-  with_items: "{{ required_assets }}"
+  loop: "{{ required_assets }}"
   environment:
     http_proxy: "{{ http_proxy }}"
     https_proxy: "{{ http_proxy }}"

--- a/ansible/noc_roles/card/tasks/main.yml
+++ b/ansible/noc_roles/card/tasks/main.yml
@@ -8,7 +8,7 @@
     chdir: "{{ noc_root }}"
   register: s
   changed_when: "'CHANGED' in s.stdout"
-  with_items: "{{ required_assets }}"
+  loop: "{{ required_assets }}"
   environment:
     http_proxy: "{{ http_proxy }}"
     https_proxy: "{{ http_proxy }}"

--- a/ansible/noc_roles/discovery/tasks/main.yml
+++ b/ansible/noc_roles/discovery/tasks/main.yml
@@ -8,7 +8,7 @@
     value: "{{ item.value }}"
     state: present
     reload: "True"
-  with_items:
+  loop:
     - { name: 'net.ipv4.tcp_keepalive_time', value: 60 }
     - { name: 'net.ipv4.tcp_keepalive_intvl', value: 10 }
     - { name: 'net.ipv4.tcp_keepalive_probes', value: 3 }

--- a/ansible/noc_roles/grafanads/tasks/main.yml
+++ b/ansible/noc_roles/grafanads/tasks/main.yml
@@ -16,7 +16,7 @@
       url: "https://{{ noc_web_host }}/api/grafanads"
       isDefault: False  # yamllint disable-line rule:truthy
       editable: False  # yamllint disable-line rule:truthy
-  with_items: '{{ groups["svc-grafana-exec"] }}'
+  loop: '{{ groups["svc-grafana-exec"] }}'
 
 - name: call grafana for JsonDS
   include_role:
@@ -32,4 +32,4 @@
       url: "https://{{ noc_web_host }}/api/grafanads/grafanajsonds"
       isDefault: False  # yamllint disable-line rule:truthy
       editable: False  # yamllint disable-line rule:truthy
-  with_items: '{{ groups["svc-grafana-exec"] }}'
+  loop: '{{ groups["svc-grafana-exec"] }}'

--- a/ansible/noc_roles/mib/tasks/main.yml
+++ b/ansible/noc_roles/mib/tasks/main.yml
@@ -8,7 +8,7 @@
     path: "{{ item }}"
     owner: root
     mode: 0777
-  with_items:
+  loop:
     - "{{ mib_path }}"
 
 - name: Install mibs for working MIB-import

--- a/ansible/noc_roles/migrate/tasks/configure_consul.yml
+++ b/ansible/noc_roles/migrate/tasks/configure_consul.yml
@@ -37,7 +37,7 @@
     consul_service_internal_key: "Limit"
     consul_service_value: '{{ hostvars | json_query("*.noc_services[] | [?name==''discovery''].{n:pool,num:config.power} | [?n==''"+item+"''] | sum([].num)") }}' # noqa 204
     consul_service_token: None
-  with_items: "{{ hostvars |json_query('*.noc_services[] | [].pool') |unique }}"
+  loop: "{{ hostvars |json_query('*.noc_services[] | [].pool') |unique }}"
   tags:
     - discovery
 
@@ -51,7 +51,7 @@
     consul_service_internal_key: "Limit"
     consul_service_value: '{{ hostvars |json_query("*.noc_services[] | [?name==''ping''].{n:pool,num:config.power} | [?n==''"+item+"''] | sum([].num)") }}' # noqa 204
     consul_service_token: None
-  with_items: "{{ hostvars |json_query('*.noc_services[] | [].pool') |unique }}"
+  loop: "{{ hostvars |json_query('*.noc_services[] | [].pool') |unique }}"
   tags:
     - ping
 
@@ -65,7 +65,7 @@
     consul_service_internal_key: "Limit"
     consul_service_value: '{{ hostvars |json_query("*.noc_services[] | [?name==''classifier''].{n:pool,num:config.power} | [?n==''"+item+"''] | sum([].num)") }}' # noqa 204
     consul_service_token: None
-  with_items: "{{ hostvars |json_query('*.noc_services[] | [].pool') |unique }}"
+  loop: "{{ hostvars |json_query('*.noc_services[] | [].pool') |unique }}"
   tags:
     - classifier
 
@@ -79,7 +79,7 @@
     consul_service_internal_key: "Limit"
     consul_service_value: '{{ hostvars |json_query("*.noc_services[] | [?name==''correlator''].{n:pool,num:config.power} | [?n==''"+item+"''] | sum([].num)") }}' # noqa 204
     consul_service_token: None
-  with_items: "{{ hostvars |json_query('*.noc_services[] | [].pool') |unique }}"
+  loop: "{{ hostvars |json_query('*.noc_services[] | [].pool') |unique }}"
   tags:
     - correlator
 

--- a/ansible/noc_roles/migrate/tasks/main.yml
+++ b/ansible/noc_roles/migrate/tasks/main.yml
@@ -67,7 +67,7 @@
   args:
     chdir: "{{ noc_root }}"
   register: migrate_ch
-  with_items: "{{ groups['svc-clickhouse-exec'] }}"
+  loop: "{{ groups['svc-clickhouse-exec'] }}"
   delegate_to: "{{ groups['svc-chwriter-exec'][0] }}"
   changed_when: "'CHANGED' in migrate_ch.stdout"
   when:

--- a/ansible/noc_roles/noc/tasks/bring_python.yml
+++ b/ansible/noc_roles/noc/tasks/bring_python.yml
@@ -4,7 +4,7 @@
   file:
     path: "{{ item }}"
     state: directory
-  with_items:
+  loop:
     - "{{ noc_dist }}"
     - "/opt/python{{ noc_py3_ver }}"
 

--- a/ansible/noc_roles/noc/tasks/clean_dir.yml
+++ b/ansible/noc_roles/noc/tasks/clean_dir.yml
@@ -24,7 +24,7 @@
   file:
     state: absent
     path: "{{ item }}"
-  with_items:
+  loop:
     - "{{ noc_root }}"
     - /var/lib/noc/var/pkg
   when: noc_root not in host_mount_points
@@ -47,7 +47,7 @@
         perms: true
         owner: true
       delegate_to: "{{ inventory_hostname }}"
-      with_items:
+      loop:
         - /var/lib/noc/var/pkg
         - "{{ noc_root }}/"
 

--- a/ansible/noc_roles/noc/tasks/config.yml
+++ b/ansible/noc_roles/noc/tasks/config.yml
@@ -42,7 +42,7 @@
     - (noc_services)
   vars:
     pool_name: "{{ item.name }}"
-  with_items:
+  loop:
     - "{{ noc_all_pools }}"
 
 - name: Build pools config

--- a/ansible/noc_roles/noc/tasks/dirs.yml
+++ b/ansible/noc_roles/noc/tasks/dirs.yml
@@ -15,7 +15,7 @@
     owner: "{{ noc_user }}"
     group: "{{ noc_group }}"
     mode: 0755
-  with_items:
+  loop:
     - "{{ noc_etc }}"             # /opt/noc/etc
     - "{{ noc_root }}/var"        # /opt/noc/var
     - "{{ noc_logs }}"            # /var/log/noc

--- a/ansible/noc_roles/noc/tasks/hacks.yml
+++ b/ansible/noc_roles/noc/tasks/hacks.yml
@@ -5,7 +5,7 @@
     value: "{{ item.value }}"
     state: present
     reload: "True"
-  with_items:
+  loop:
     - { name: 'net.ipv4.ip_local_port_range', value: '20024 65000'}
   tags:
     - config

--- a/ansible/noc_roles/pre/tasks/os/CentOS_7/firewall.yml
+++ b/ansible/noc_roles/pre/tasks/os/CentOS_7/firewall.yml
@@ -15,7 +15,7 @@
     permanent: "True"
     state: enabled
     immediate: "True"
-  with_items: "{{ groups['all'] }}"
+  loop: "{{ groups['all'] }}"
   become: "True"
   when: "firewalld_state.status.ActiveState == 'active'"
   tags:

--- a/ansible/noc_roles/pre/tasks/os/FreeBSD_12/main.yml
+++ b/ansible/noc_roles/pre/tasks/os/FreeBSD_12/main.yml
@@ -54,6 +54,6 @@
     owner: root
     group: wheel
     mode: 0755
-  with_items:
+  loop:
     - "{{ etc_prefix }}/newsyslog.conf.d"
     - "{{ etc_prefix }}/rc.d"

--- a/ansible/noc_roles/pre/tasks/os/OracleLinux_7/firewall.yml
+++ b/ansible/noc_roles/pre/tasks/os/OracleLinux_7/firewall.yml
@@ -15,7 +15,7 @@
     permanent: "True"
     state: enabled
     immediate: "True"
-  with_items: "{{ groups['all'] }}"
+  loop: "{{ groups['all'] }}"
   become: "True"
   when: "firewalld_state.status.ActiveState == 'active'"
   tags:

--- a/ansible/noc_roles/pre/tasks/os/RED_7/firewall.yml
+++ b/ansible/noc_roles/pre/tasks/os/RED_7/firewall.yml
@@ -15,7 +15,7 @@
     permanent: "True"
     state: enabled
     immediate: "True"
-  with_items: "{{ groups['all'] }}"
+  loop: "{{ groups['all'] }}"
   become: "True"
   when: "firewalld_state.status.ActiveState == 'active'"
   tags:

--- a/ansible/noc_roles/pre/tasks/os/RedHat_7/firewall.yml
+++ b/ansible/noc_roles/pre/tasks/os/RedHat_7/firewall.yml
@@ -15,7 +15,7 @@
     permanent: "True"
     state: enabled
     immediate: "True"
-  with_items: "{{ groups['all'] }}"
+  loop: "{{ groups['all'] }}"
   become: "True"
   when: "firewalld_state.status.ActiveState == 'active'"
   tags:

--- a/ansible/noc_roles/web/tasks/main.yml
+++ b/ansible/noc_roles/web/tasks/main.yml
@@ -9,7 +9,7 @@
     chdir: "{{ noc_root }}"
   register: s
   changed_when: "'CHANGED' in s.stdout"
-  with_items: "{{ required_assets }}"
+  loop: "{{ required_assets }}"
   retries: 5
   delay: 2
   until: s is succeeded

--- a/ansible/system_roles/clickhouse/tasks/ds.yml
+++ b/ansible/system_roles/clickhouse/tasks/ds.yml
@@ -18,4 +18,4 @@
       basicAuthUser: "readonly"
       secureJsonData:
         basicAuthPassword: "{{ clickhouse_ro_password }}"
-  with_items: '{{ groups["svc-grafana-exec"] }}'
+  loop: '{{ groups["svc-grafana-exec"] }}'

--- a/ansible/system_roles/clickhouse/tasks/main.yml
+++ b/ansible/system_roles/clickhouse/tasks/main.yml
@@ -14,7 +14,7 @@
     state: "directory"
     group: clickhouse
     owner: clickhouse
-  with_items:
+  loop:
     - "{{ ch_log_dir }}"
 
 - name: "Include OS-specific tasks"

--- a/ansible/system_roles/clickhouse/tasks/os/FreeBSD_12/main.yml
+++ b/ansible/system_roles/clickhouse/tasks/os/FreeBSD_12/main.yml
@@ -31,5 +31,5 @@
     group: clickhouse
     owner: clickhouse
     recurse: "True"
-  with_items:
+  loop:
     - "{{ ch_run_dir }}"

--- a/ansible/system_roles/consul-template/tasks/main.yml
+++ b/ansible/system_roles/consul-template/tasks/main.yml
@@ -3,7 +3,7 @@
   file:
     state: directory
     path: "{{ item }}"
-  with_items:
+  loop:
     - "{{ consul_template_config_dir }}"
     - "{{ consul_template_templates_dir }}"
 

--- a/ansible/system_roles/consul/tasks/checks.yml
+++ b/ansible/system_roles/consul/tasks/checks.yml
@@ -8,7 +8,7 @@
     - name: check if bootstrap exists
       set_fact:
         consul_bootstrap_count: "{{ consul_bootstrap_count | int+ 1 }}"
-      with_items: "{{ groups['svc-consul-exec'] }}"
+      loop: "{{ groups['svc-consul-exec'] }}"
       when: "'bootstrap' in hostvars[srv]['consul_power']"
       loop_control:
         loop_var: srv
@@ -16,7 +16,7 @@
     - name: count servers
       set_fact:
         consul_servers_count: "{{ consul_servers_count |int + 1 }}"
-      with_items: "{{ groups['svc-consul-exec'] }}"
+      loop: "{{ groups['svc-consul-exec'] }}"
       when: "'bootstrap' in hostvars[srv]['consul_power'] or 'server' in hostvars[srv]['consul_power']"
       loop_control:
         loop_var: srv

--- a/ansible/system_roles/consul/tasks/config.yml
+++ b/ansible/system_roles/consul/tasks/config.yml
@@ -72,7 +72,7 @@
     value: "{{ item.value }}"
     state: present
     reload: "True"
-  with_items:
+  loop:
     - { name: 'net.ipv4.tcp_tw_reuse', value: 1}
     - { name: 'net.ipv4.tcp_rfc1337', value: 1}
   tags:

--- a/ansible/system_roles/consul/tasks/dirs.yml
+++ b/ansible/system_roles/consul/tasks/dirs.yml
@@ -7,7 +7,7 @@
     state: directory
     owner: "{{ consul_user }}"
     group: "{{ consul_group }}"
-  with_items:
+  loop:
     - /var/consul
     - /var/run/consul
     - "{{ consul_configd_path }}"

--- a/ansible/system_roles/consul/tasks/main.yml
+++ b/ansible/system_roles/consul/tasks/main.yml
@@ -6,7 +6,7 @@
   add_host:
     group: svc-consul-server
     host: "{{ item }}"
-  with_items: "{{ groups['svc-consul-exec'] }}"
+  loop: "{{ groups['svc-consul-exec'] }}"
   when: "'bootstrap' in hostvars[item]['consul_power'] or 'server' in hostvars[item]['consul_power']"
   tags:
     - config

--- a/ansible/system_roles/consul/tasks/os/CentOS_7/main.yml
+++ b/ansible/system_roles/consul/tasks/os/CentOS_7/main.yml
@@ -41,7 +41,7 @@
     state: enabled
     immediate: "True"
   when: "firewalld_state.status.ActiveState == 'active'"
-  with_items:
+  loop:
     - 8300/tcp
     - 8301/tcp
     - 8301/udp

--- a/ansible/system_roles/consul/tasks/os/OracleLinux_7/main.yml
+++ b/ansible/system_roles/consul/tasks/os/OracleLinux_7/main.yml
@@ -41,7 +41,7 @@
     state: enabled
     immediate: "True"
   when: "firewalld_state.status.ActiveState == 'active'"
-  with_items:
+  loop:
     - 8300/tcp
     - 8301/tcp
     - 8301/udp

--- a/ansible/system_roles/consul/tasks/os/RED_7/main.yml
+++ b/ansible/system_roles/consul/tasks/os/RED_7/main.yml
@@ -41,7 +41,7 @@
     state: enabled
     immediate: "True"
   when: "firewalld_state.status.ActiveState == 'active'"
-  with_items:
+  loop:
     - 8300/tcp
     - 8301/tcp
     - 8301/udp

--- a/ansible/system_roles/consul/tasks/os/RedHat_7/main.yml
+++ b/ansible/system_roles/consul/tasks/os/RedHat_7/main.yml
@@ -39,7 +39,7 @@
     state: enabled
     immediate: "True"
   when: "firewalld_state.status.ActiveState == 'active'"
-  with_items:
+  loop:
     - 8300/tcp
     - 8301/tcp
     - 8301/udp

--- a/ansible/system_roles/consul/tasks/tests.yml
+++ b/ansible/system_roles/consul/tasks/tests.yml
@@ -30,7 +30,7 @@
       check_mode: "False"
       loop_control:
         loop_var: host
-      with_items: "{{ groups['svc-consul-exec'] }}"
+      loop: "{{ groups['svc-consul-exec'] }}"
 
   when:
     - has_svc_consul is defined

--- a/ansible/system_roles/grafana/tasks/dashboards.yml
+++ b/ansible/system_roles/grafana/tasks/dashboards.yml
@@ -5,7 +5,7 @@
     dest: "{{ item.dest }}"
   no_log: "{{ tower_show_secrets }}"
   diff: "False"
-  with_items:
+  loop:
     - src: noc.js.j2
       dest: "{{ grafana_home }}/public/dashboards/noc.js"
     - src: report.js.j2

--- a/ansible/system_roles/grafana/tasks/main.yml
+++ b/ansible/system_roles/grafana/tasks/main.yml
@@ -34,7 +34,7 @@
     state: directory
     group: grafana
     owner: grafana
-  with_items:
+  loop:
     - "{{ grafana_dashboard_dir }}"
     - "{{ grafana_plugins_dir }}"
     - "{{ grafana_provisioning_dir }}"

--- a/ansible/system_roles/grafana/tasks/os/FreeBSD_12/main.yml
+++ b/ansible/system_roles/grafana/tasks/os/FreeBSD_12/main.yml
@@ -10,7 +10,7 @@
 
 - name: Create Grafana directories
   file: path={{ item }} state=directory owner={{ grafana_user }} mode=0755
-  with_items:
+  loop:
     - /usr/local/share/grafana/data/png
   notify: restart grafana
 

--- a/ansible/system_roles/grafana/tasks/plugins.yml
+++ b/ansible/system_roles/grafana/tasks/plugins.yml
@@ -5,7 +5,7 @@
     version: "{{ item.version }}"
     state: present
     grafana_plugins_dir: "{{ grafana_plugins_dir }}"
-  with_items:
+  loop:
     - name: simpod-json-datasource
       version: "{{ grafana_version_simpod_json_datasource }}"
     - name: vertamedia-clickhouse-datasource

--- a/ansible/system_roles/kafka/tasks/dirs.yml
+++ b/ansible/system_roles/kafka/tasks/dirs.yml
@@ -16,7 +16,7 @@
     group: '{{ kafka_group }}'
     owner: '{{ kafka_user }}'
     mode: 0755
-  with_items: "{{ kafka_log_dir.split(',') }}"
+  loop: "{{ kafka_log_dir.split(',') }}"
   tags:
     - dirs
 

--- a/ansible/system_roles/liftbridge/tasks/dirs.yml
+++ b/ansible/system_roles/liftbridge/tasks/dirs.yml
@@ -7,7 +7,7 @@
     state: directory
     owner: "{{ liftbridge_user }}"
     group: "{{ liftbridge_group }}"
-  with_items:
+  loop:
     - "{{ liftbridge_config_path }}"
     - "{{ liftbridge_data_path }}"
     - "{{ liftbridge_log_path }}"

--- a/ansible/system_roles/mongod/tasks/main.yml
+++ b/ansible/system_roles/mongod/tasks/main.yml
@@ -4,7 +4,7 @@
   add_host:
     group: svc-mongo-primary
     host: "{{ item }}"
-  with_items: "{{ groups['svc-mongod-exec'] }}"
+  loop: "{{ groups['svc-mongod-exec'] }}"
   when:
     - "'bootstrap' in hostvars[item]['mongod_power']"
 
@@ -20,7 +20,7 @@
     path: "{{ item }}"
     state: "directory"
     mode: 0755
-  with_items:
+  loop:
     - "{{ mongo_dir }}"
 
 - name: Setting mongod config

--- a/ansible/system_roles/nats/tasks/checks.yml
+++ b/ansible/system_roles/nats/tasks/checks.yml
@@ -7,7 +7,7 @@
     - name: count servers
       set_fact:
         nats_servers_count: "{{ nats_servers_count | int + 1 }}"
-      with_items: "{{ groups['svc-nats-exec'] }}"
+      loop: "{{ groups['svc-nats-exec'] }}"
 
     - name: Ensure nats setup max server count
       fail:

--- a/ansible/system_roles/nats/tasks/dirs.yml
+++ b/ansible/system_roles/nats/tasks/dirs.yml
@@ -7,7 +7,7 @@
     state: directory
     owner: "{{ nats_user }}"
     group: "{{ nats_group }}"
-  with_items:
+  loop:
     - "{{ nats_config_path }}"
     - "{{ nats_data_path }}"
     - "{{ nats_log_path }}"

--- a/ansible/system_roles/nginx/tasks/main.yml
+++ b/ansible/system_roles/nginx/tasks/main.yml
@@ -27,7 +27,7 @@
     owner: "{{ nginx_user }}"
     force: "{{ item.force }}"
   notify: reload nginx
-  with_items:
+  loop:
     - name: noc.conf.j2
       path: "{{ nginx_conf_path }}"
       force: "True"

--- a/ansible/system_roles/postgres/tasks/checks.yml
+++ b/ansible/system_roles/postgres/tasks/checks.yml
@@ -8,7 +8,7 @@
 - name: count postgres masters set
   set_fact:
     postgres_masters_count: "{{ postgres_masters_count | int+ 1 }}"
-  with_items: "{{ groups['svc-postgres-exec'] }}"
+  loop: "{{ groups['svc-postgres-exec'] }}"
   when: "'master' in hostvars[srv]['postgres_power']"
   loop_control:
     loop_var: srv

--- a/ansible/system_roles/postgres/tasks/main.yml
+++ b/ansible/system_roles/postgres/tasks/main.yml
@@ -18,7 +18,7 @@
     postgres_listen_port: "{{ postgres_listen_port }}"
   delegate_to: "{{ item }}"
   delegate_facts: "True"
-  with_items: "{{ groups['all'] }}"
+  loop: "{{ groups['all'] }}"
   tags:
     - config
 

--- a/ansible/system_roles/postgres/tasks/os/CentOS_7/main.yml
+++ b/ansible/system_roles/postgres/tasks/os/CentOS_7/main.yml
@@ -6,7 +6,7 @@
     value: "{{ item.value }}"
     state: present
     reload: "True"
-  with_items:
+  loop:
     - { name: kernel.shmmax, value: "{{ kernel_shmmax }}" }
     - { name: kernel.shmall, value: "{{ kernel_shmall }}" }
     - { name: kernel.sem, value: '250 256000 400 4096' }

--- a/ansible/system_roles/postgres/tasks/os/Debian_10/main.yml
+++ b/ansible/system_roles/postgres/tasks/os/Debian_10/main.yml
@@ -6,7 +6,7 @@
     value: "{{ item.value }}"
     state: present
     reload: "True"
-  with_items:
+  loop:
     - { name: kernel.shmmax, value: "{{ kernel_shmmax }}" }
     - { name: kernel.shmall, value: "{{ kernel_shmall }}" }
     - { name: kernel.sem, value: '250 256000 400 4096' }

--- a/ansible/system_roles/postgres/tasks/os/Debian_11/main.yml
+++ b/ansible/system_roles/postgres/tasks/os/Debian_11/main.yml
@@ -6,7 +6,7 @@
     value: "{{ item.value }}"
     state: present
     reload: "True"
-  with_items:
+  loop:
     - { name: kernel.shmmax, value: "{{ kernel_shmmax }}" }
     - { name: kernel.shmall, value: "{{ kernel_shmall }}" }
     - { name: kernel.sem, value: '250 256000 400 4096' }

--- a/ansible/system_roles/postgres/tasks/os/OracleLinux_7/main.yml
+++ b/ansible/system_roles/postgres/tasks/os/OracleLinux_7/main.yml
@@ -6,7 +6,7 @@
     value: "{{ item.value }}"
     state: present
     reload: "True"
-  with_items:
+  loop:
     - { name: kernel.shmmax, value: "{{ kernel_shmmax }}" }
     - { name: kernel.shmall, value: "{{ kernel_shmall }}" }
     - { name: kernel.sem, value: '250 256000 400 4096' }

--- a/ansible/system_roles/postgres/tasks/os/RED_7/main.yml
+++ b/ansible/system_roles/postgres/tasks/os/RED_7/main.yml
@@ -6,7 +6,7 @@
     value: "{{ item.value }}"
     state: present
     reload: "True"
-  with_items:
+  loop:
     - { name: kernel.shmmax, value: "{{ kernel_shmmax }}" }
     - { name: kernel.shmall, value: "{{ kernel_shmall }}" }
     - { name: kernel.sem, value: '250 256000 400 4096' }

--- a/ansible/system_roles/postgres/tasks/os/RedHat_7/main.yml
+++ b/ansible/system_roles/postgres/tasks/os/RedHat_7/main.yml
@@ -6,7 +6,7 @@
     value: "{{ item.value }}"
     state: present
     reload: "True"
-  with_items:
+  loop:
     - { name: kernel.shmmax, value: "{{ kernel_shmmax }}" }
     - { name: kernel.shmall, value: "{{ kernel_shmall }}" }
     - { name: kernel.sem, value: '250 256000 400 4096' }

--- a/ansible/system_roles/postgres/tasks/os/Ubuntu_20/main.yml
+++ b/ansible/system_roles/postgres/tasks/os/Ubuntu_20/main.yml
@@ -6,7 +6,7 @@
     value: "{{ item.value }}"
     state: present
     reload: "True"
-  with_items:
+  loop:
     - { name: kernel.shmmax, value: "{{ kernel_shmmax }}" }
     - { name: kernel.shmall, value: "{{ kernel_shmall }}" }
     - { name: kernel.sem, value: '250 256000 400 4096' }

--- a/ansible/system_roles/postgres/tasks/os/Ubuntu_22/main.yml
+++ b/ansible/system_roles/postgres/tasks/os/Ubuntu_22/main.yml
@@ -6,7 +6,7 @@
     value: "{{ item.value }}"
     state: present
     reload: "True"
-  with_items:
+  loop:
     - { name: kernel.shmmax, value: "{{ kernel_shmmax }}" }
     - { name: kernel.shmall, value: "{{ kernel_shmall }}" }
     - { name: kernel.sem, value: '250 256000 400 4096' }


### PR DESCRIPTION
Modernize the Ansible role and playbook tree by replacing the deprecated `with_items` keyword with `loop`. `with_items` was deprecated in Ansible 2.4 and removed in Ansible 2.10; `loop` is the supported replacement and defaults to the same `item` loop variable, so behavior is unchanged.

### Changes
- Convert 71 `with_items` usages to `loop` across 58 files in `ansible/noc_roles/`, `ansible/system_roles/`, and `ansible/molecule/` (create/destroy/verify).
- Rename only — `item`, `register`, `notify`, `when`, and `loop_control`/`loop_var` are all preserved, so no task semantics change.
- Commented-out and documentation `with_*` usages are intentionally left untouched:
  - `ansible/system_roles/nginx/tasks/main.yml:137` (commented task)
  - `ansible/noc_roles/activator/tasks/main.yml:24` (commented `with_fileglob`)
  - `ansible/lookup_plugins/myglob.py` (`with_fileglob` in the docstring EXAMPLES block)

### Notable implementation details
- Loop-variable overrides (`loop_control.loop_var`, e.g. `srv` in `consul`/`postgres` checks and `host` in `consul/tests.yml`) are retained — only the keyword was swapped.
- `register` output (`results`) shape is identical between `with_items` and `loop`, so downstream `when`/`fail` tasks behave the same.
