### PR TITLE
ansible: Fix loop usage

### DIFF
--- a/ansible/noc_roles/noc/tasks/config.yml
+++ b/ansible/noc_roles/noc/tasks/config.yml
@@ -42,8 +42,7 @@
     - (noc_services)
   vars:
     pool_name: "{{ item.name }}"
-  loop:
-    - "{{ noc_all_pools }}"
+  loop: "{{ noc_all_pools }}"
 
 - name: Build pools config
   template:


### PR DESCRIPTION
Repair a latent deploy-time bug in NOC pooled-service configuration generation that was introduced by the earlier `with_items` → `loop` migration (PR #517).

**Problem**
In `ansible/noc_roles/noc/tasks/config.yml`, the "Generate NOC config for pooled services" task was converted to the new `loop:` keyword using the **block** form:

```yaml
  loop:
    - "{{ noc_all_pools }}"
```

The block form wraps the entire `noc_all_pools` value into a **single-element list**, so Ansible iterates once over the stringified representation of the whole list instead of over each pool. Because the task accesses `item.name` (in `dest: "pool-{{ item.name }}.yml"` and `vars: pool_name: "{{ item.name }}"`, where `pool_name` is consumed by `etc/pooled.yml.j2`), that access no longer resolves per pool — only one (broken) `pool-<...>.yml` is generated instead of one per pool.

**Change**
Collapse it to the scalar `loop:` form, which iterates per element of the list:

```yaml
  loop: "{{ noc_all_pools }}"
```

This matches the already-correct form used for the same `noc_all_pools` variable in `activator/tasks/main.yml` (the "Create ssh keys directories" task, which also relies on `item.name`).