### PR TITLE
Remove unnecessary tuples in net-scan

### DIFF
--- a/commands/net-scan.py
+++ b/commands/net-scan.py
@@ -69,34 +69,26 @@ class Command(BaseCommand):
         parser.add_argument(
             "--jobs", action="store", type=int, default=100, dest="jobs", help="Concurrent jobs"
         )
-        (
-            parser.add_argument(
-                "--dry-run",
-                dest="dry_run",
-                action="store_true",
-                help="Test only. Do not save records",
-            ),
+        parser.add_argument(
+            "--dry-run",
+            dest="dry_run",
+            action="store_true",
+            help="Test only. Do not save records",
         )
-        (
-            parser.add_argument(
-                "--print-out",
-                dest="print_out",
-                action="store_true",
-                help="Printing result to output",
-            ),
+        parser.add_argument(
+            "--print-out",
+            dest="print_out",
+            action="store_true",
+            help="Printing result to output",
         )
-        (
-            parser.add_argument(
-                "--print-file", dest="print_file", help="Printing result to file output"
-            ),
+        parser.add_argument(
+            "--print-file", dest="print_file", help="Printing result to file output"
         )
-        (
-            parser.add_argument(
-                "--ip-scan",
-                dest="ip_scan",
-                action="store_true",
-                help="Address wit prefixes enabled IP Scan",
-            ),
+        parser.add_argument(
+            "--ip-scan",
+            dest="ip_scan",
+            action="store_true",
+            help="Address wit prefixes enabled IP Scan",
         )
         parser.add_argument("--ports", action="store", type=str, help="Check TCP ports")
         parser.add_argument("--rule", action="store", type=str, help="Check Rule. Set rule name")


### PR DESCRIPTION
The `add_arguments()` method in `commands/net-scan.py` wrapped four
`parser.add_argument(...)` calls in redundant outer parentheses. Since
`parser.add_argument()` returns `None`, these produced throwaway single-element
tuples — dead no-op expressions.

Changed:
- Remove the enclosing `(...)` and trailing comma around the `--dry-run`,
  `--print-out`, `--print-file`, and `--ip-scan` argument registrations,
  leaving the bare `parser.add_argument(...)` expression statements.

No behavioral change: `argparse` does not act on the return value, so stripping
the dead tuple wrappers is semantically identical. +17/−25 in a single file,
single commit.