### PR TITLE
Remove obsolete lookup_solution parameter

### DIFF
--- a/ansible/molecule/debian10/inv.yml
+++ b/ansible/molecule/debian10/inv.yml
@@ -26,7 +26,6 @@ all:
           chwriter_records_buffer: 1000000
           classifier_default_interface_profile: default
           classifier_loglevel: info
-          classifier_lookup_solution: noc.services.classifier.rulelookup.RuleLookup
           classifier_power: 2
           classifier_backup_power: 2
           clickhouse_db: noc
@@ -383,7 +382,6 @@ all:
             - config:
                 default_interface_profile: default
                 loglevel: info
-                lookup_solution: noc.services.classifier.rulelookup.RuleLookup
                 power: 2
               config_order: yaml:///opt/noc/etc/tower.yml,yaml:///opt/noc/etc/settings.yml,yaml:///opt/noc/etc/pool-default.yml,env:///NOC
               environment:

--- a/ansible/molecule/debian11/inv.yml
+++ b/ansible/molecule/debian11/inv.yml
@@ -26,7 +26,6 @@ all:
           chwriter_records_buffer: 1000000
           classifier_default_interface_profile: default
           classifier_loglevel: info
-          classifier_lookup_solution: noc.services.classifier.rulelookup.RuleLookup
           classifier_power: 2
           classifier_backup_power: 2
           clickhouse_db: noc
@@ -384,7 +383,6 @@ all:
             - config:
                 default_interface_profile: default
                 loglevel: info
-                lookup_solution: noc.services.classifier.rulelookup.RuleLookup
                 power: 2
               config_order: yaml:///opt/noc/etc/tower.yml,yaml:///opt/noc/etc/settings.yml,yaml:///opt/noc/etc/pool-default.yml,env:///NOC
               environment:

--- a/ansible/molecule/default/inv.yml
+++ b/ansible/molecule/default/inv.yml
@@ -26,7 +26,6 @@ all:
           chwriter_records_buffer: 1000000
           classifier_default_interface_profile: default
           classifier_loglevel: info
-          classifier_lookup_solution: noc.services.classifier.rulelookup.RuleLookup
           classifier_power: 2
           classifier_backup_power: 2
           clickhouse_db: noc
@@ -382,7 +381,6 @@ all:
             - config:
                 default_interface_profile: default
                 loglevel: info
-                lookup_solution: noc.services.classifier.rulelookup.RuleLookup
                 power: 2
               config_order: yaml:///opt/noc/etc/tower.yml,yaml:///opt/noc/etc/settings.yml,yaml:///opt/noc/etc/pool-default.yml,env:///NOC
               environment:

--- a/ansible/molecule/freebsd/inv.yml
+++ b/ansible/molecule/freebsd/inv.yml
@@ -27,7 +27,6 @@ all:
           chwriter_records_buffer: 1000000
           classifier_default_interface_profile: default
           classifier_loglevel: info
-          classifier_lookup_solution: noc.services.classifier.rulelookup.RuleLookup
           classifier_power: 2
           classifier_backup_power: 2
           clickhouse_db: noc
@@ -377,7 +376,6 @@ all:
             - config:
                 default_interface_profile: default
                 loglevel: info
-                lookup_solution: noc.services.classifier.rulelookup.RuleLookup
                 power: 2
               config_order: yaml:///opt/noc/etc/tower.yml,yaml:///opt/noc/etc/settings.yml,yaml:///opt/noc/etc/pool-default.yml,env:///NOC
               environment:

--- a/ansible/molecule/oel7/inv.yml
+++ b/ansible/molecule/oel7/inv.yml
@@ -26,7 +26,6 @@ all:
           chwriter_records_buffer: 1000000
           classifier_default_interface_profile: default
           classifier_loglevel: info
-          classifier_lookup_solution: noc.services.classifier.rulelookup.RuleLookup
           classifier_power: 2
           classifier_backup_power: 2
           clickhouse_db: noc
@@ -382,7 +381,6 @@ all:
             - config:
                 default_interface_profile: default
                 loglevel: info
-                lookup_solution: noc.services.classifier.rulelookup.RuleLookup
                 power: 2
               config_order: yaml:///opt/noc/etc/tower.yml,yaml:///opt/noc/etc/settings.yml,yaml:///opt/noc/etc/pool-default.yml,env:///NOC
               environment:

--- a/ansible/molecule/redos/inv.yml
+++ b/ansible/molecule/redos/inv.yml
@@ -26,7 +26,6 @@ all:
           chwriter_records_buffer: 1000000
           classifier_default_interface_profile: default
           classifier_loglevel: info
-          classifier_lookup_solution: noc.services.classifier.rulelookup.RuleLookup
           classifier_power: 2
           classifier_backup_power: 2
           clickhouse_db: noc
@@ -382,7 +381,6 @@ all:
             - config:
                 default_interface_profile: default
                 loglevel: info
-                lookup_solution: noc.services.classifier.rulelookup.RuleLookup
                 power: 2
               config_order: yaml:///opt/noc/etc/tower.yml,yaml:///opt/noc/etc/settings.yml,yaml:///opt/noc/etc/pool-default.yml,env:///NOC
               environment:

--- a/ansible/molecule/ubuntu20/inv.yml
+++ b/ansible/molecule/ubuntu20/inv.yml
@@ -26,7 +26,6 @@ all:
           chwriter_records_buffer: 1000000
           classifier_default_interface_profile: default
           classifier_loglevel: info
-          classifier_lookup_solution: noc.services.classifier.rulelookup.RuleLookup
           classifier_power: 2
           classifier_backup_power: 2
           clickhouse_db: noc
@@ -383,7 +382,6 @@ all:
             - config:
                 default_interface_profile: default
                 loglevel: info
-                lookup_solution: noc.services.classifier.rulelookup.RuleLookup
                 power: 2
               config_order: yaml:///opt/noc/etc/tower.yml,yaml:///opt/noc/etc/settings.yml,yaml:///opt/noc/etc/pool-default.yml,env:///NOC
               environment:

--- a/ansible/molecule/ubuntu22/inv.yml
+++ b/ansible/molecule/ubuntu22/inv.yml
@@ -26,7 +26,6 @@ all:
           chwriter_records_buffer: 1000000
           classifier_default_interface_profile: default
           classifier_loglevel: info
-          classifier_lookup_solution: noc.services.classifier.rulelookup.RuleLookup
           classifier_power: 2
           classifier_backup_power: 2
           clickhouse_db: noc
@@ -385,7 +384,6 @@ all:
             - config:
                 default_interface_profile: default
                 loglevel: info
-                lookup_solution: noc.services.classifier.rulelookup.RuleLookup
                 power: 2
               config_order: yaml:///opt/noc/etc/tower.yml,yaml:///opt/noc/etc/settings.yml,yaml:///opt/noc/etc/pool-default.yml,env:///NOC
               environment:

--- a/ansible/noc_roles/classifier/meta/tower.yml
+++ b/ansible/noc_roles/classifier/meta/tower.yml
@@ -35,10 +35,6 @@ forms:
       default: default
       label: "Default interface profile"
       type: str
-    lookup_solution:
-      default: "noc.services.classifier.rulelookup.RuleLookup"
-      label: "Lookup solution"
-      type: str
 
 services:
   classifier:


### PR DESCRIPTION
Remove the obsolete `lookup_solution` configuration parameter from the NOC classifier. The parameter pointed to `noc.services.classifier.rulelookup.RuleLookup`, but that class is now instantiated directly inside `RuleSet` and is no longer selected through configuration, so the parameter (and its deployment defaults) are dead.

## Key Changes

- `ansible/noc_roles/classifier/meta/tower.yml`: drop the `lookup_solution` Tower form field (label "Lookup solution", default `noc.services.classifier.rulelookup.RuleLookup`).
- `ansible/molecule/*/inv.yml` (all 8 scenarios: `debian10`, `debian11`, `default`, `freebsd`, `oel7`, `redos`, `ubuntu20`, `ubuntu22`): remove the mirrored `classifier_lookup_solution` and `lookup_solution` entries.

Net effect: −20 lines, 9 files, 0 additions.

## Implementation Details

- Pure deletion of dead configuration. Runtime behavior is unchanged: the `RuleLookup` class (`services/classifier/rulelookup.py`) is still used, instantiated directly in `services/classifier/ruleset.py` (`RuleLookup(rules[k])`) rather than via a config-driven lookup key.
- YAML structure is preserved in every edited file.
- No residual `lookup_solution` references remain anywhere in the repository after this change.