### PR TITLE
deploy: Remove legacy noc_python_interpreter variable

### DIFF
--- a/ansible/noc_roles/noc/defaults/main.yml
+++ b/ansible/noc_roles/noc/defaults/main.yml
@@ -11,7 +11,6 @@ noc_etc: "{{ noc_root }}/etc"
 noc_reports_dir: "{{ noc_var_lib }}/reports"
 noc_crashinfo_dir: "{{ noc_var_lib }}/var/cp/crashinfo/new"
 noc_services_file: "{{ noc_etc }}/noc_services.conf"
-noc_python_interpreter: python3
 noc_py3_ver: "3.11"
 bi_export_dir: "{{ noc_var_lib }}/bi"
 supervisorctl_key: "{{ lookup('supervisorctl_key', tower_data + '/noc/supervisorctl.key') }}"

--- a/ansible/noc_roles/noc/tasks/dirs.yml
+++ b/ansible/noc_roles/noc/tasks/dirs.yml
@@ -1,13 +1,4 @@
 ---
-- name: Create required directories on py3  #hack. have to be fixed
-  file:
-    path: "{{ noc_root }}/lib/python{{ noc_py3_ver }}/site-packages/__pycache__"
-    state: "directory"
-    owner: "{{ noc_user }}"
-    mode: 0755
-  when:
-    - noc_python_interpreter == "python3"
-
 - name: Create required directories
   file:
     path: "{{ item }}"
@@ -16,10 +7,10 @@
     group: "{{ noc_group }}"
     mode: 0755
   loop:
-    - "{{ noc_etc }}"             # /opt/noc/etc
-    - "{{ noc_root }}/var"        # /opt/noc/var
-    - "{{ noc_logs }}"            # /var/log/noc
-    - "{{ noc_var_lib }}"         # /var/lib/noc
-    - "{{ noc_reports_dir }}"     # /var/lib/noc/reports
-    - "{{ noc_crashinfo_dir }}"   # /var/lib/noc/var/cp/crashinfo/new
-    - "{{ bi_export_dir }}"       # /var/lib/noc/bi
+    - "{{ noc_etc }}" # /opt/noc/etc
+    - "{{ noc_root }}/var" # /opt/noc/var
+    - "{{ noc_logs }}" # /var/log/noc
+    - "{{ noc_var_lib }}" # /var/lib/noc
+    - "{{ noc_reports_dir }}" # /var/lib/noc/reports
+    - "{{ noc_crashinfo_dir }}" # /var/lib/noc/var/cp/crashinfo/new
+    - "{{ bi_export_dir }}" # /var/lib/noc/bi

--- a/ansible/noc_roles/noc/tasks/main.yml
+++ b/ansible/noc_roles/noc/tasks/main.yml
@@ -20,13 +20,14 @@
     comment: "NOC user"
     state: present
 
-- name: Include {{ install_method }} install method
-  include_tasks: "{{ install_method }}.yml"
+- name: Include Git install method
+  ansible.builtin.include_tasks: git.yml
+  when: install_method == "git"
   tags:
     - get_source
 
-- name: Include venv init for {{ noc_python_interpreter }}
-  include_tasks: "init_venv_{{ noc_python_interpreter }}.yml"
+- name: Include venv init for Python 3
+  include_tasks: "init_venv_python3.yml"
   tags:
     - requirements
     - config
@@ -42,4 +43,3 @@
 
 - name: Include noc hacks
   import_tasks: "hacks.yml"
-


### PR DESCRIPTION
Remove the legacy `noc_python_interpreter` variable and the `__pycache__` directory "hack" it gated on, finishing the byte-compilation cleanup started in #513. The NOC deployment path is Python 3 only, so the role no longer needs a dynamic interpreter/venv suffix.

**Key changes**
- `ansible/noc_roles/noc/defaults/main.yml`: drop `noc_python_interpreter: python3` (dead variable). `noc_py3_ver` (still used by `init_venv_python3.yml`, `bring_python.yml`, `checks.yml`) is retained.
- `tasks/dirs.yml`: remove the `#hack. have to be fixed` `__pycache__` pre-create task — its parent directories are already created by the looped "Create required directories" task. Comment alignment tidied while touching the block.
- `tasks/main.yml`: fix the two includes to their only live targets — `git.yml` (guarded `when: install_method == "git"`) and `init_venv_python3.yml` — instead of templating `"{{ install_method }}.yml"` / `"init_venv_{{ noc_python_interpreter }}.yml"`.

**Notable implementation details**
- `install_method` is not defined in the role; it comes from Tower's `Environment.install_method` (`CharField(default="git")`, always emitted into the generated inventory). The `git.yml` path is therefore the only live path, so the hardcoding is safe and the `when` guard is always true in a Tower-controlled deploy.
- No dangling references to `noc_python_interpreter` remain in the `ansible/` tree.
