### PR TITLE
deploy: Check platform level

### DIFF
--- a/ansible/check_platform.yml
+++ b/ansible/check_platform.yml
@@ -3,12 +3,12 @@
     file: "{{ playbook_dir }}/vars/platforms.yml"
 
 - name: Check platform support
-  ansible.builtin.fail:
+  fail:
     msg: "Platform {{ platform }} is not supported"
   when: platform not in platforms
 
 - name: Check platform licence level
-  ansible.builtin.fail:
+  fail:
     msg: >-
       Platform {{ platform }} requires NOC licence level
       {{ platforms[platform].required_level }}, but {{ noc_level }} is used.

--- a/ansible/check_platform.yml
+++ b/ansible/check_platform.yml
@@ -1,0 +1,17 @@
+- name: Load supported platforms
+  include_vars:
+    file: "{{ playbook_dir }}/vars/platforms.yml"
+
+- name: Check platform support
+  ansible.builtin.fail:
+    msg: "Platform {{ platform }} is not supported"
+  when: platform not in platforms
+
+- name: Check platform licence level
+  ansible.builtin.fail:
+    msg: >-
+      Platform {{ platform }} requires NOC licence level
+      {{ platforms[platform].required_level }}, but {{ noc_level }} is used.
+  when:
+    - platforms[platform].required_level == "pro"
+    - noc_level != "pro"

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -2,6 +2,8 @@
 - name: Check platform
   hosts: all
   gather_facts: "True"
+  vars_files:
+    - "vars/main.yml"
   tasks:
     - include_tasks: "check_platform.yml"
 

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -1,4 +1,10 @@
 ---
+- name: Check platform
+  hosts: all
+  gather_facts: "True"
+  tasks:
+    - include_tasks: "check_platform.yml"
+
 - import_playbook: pre.yml
   vars:
     tower_run_checks: "False"
@@ -57,7 +63,6 @@
     - role: ui
     - role: mx
     - role: kafkasender
-
 
 - import_playbook: additional_roles/custom/service.yml
 

--- a/ansible/pre.yml
+++ b/ansible/pre.yml
@@ -1,4 +1,7 @@
 ---
+- name: Check platform
+  include_tasks: "tasks/check_platform.yml"
+
 - name: pre tasks
   hosts: all
   become: "False"

--- a/ansible/pre.yml
+++ b/ansible/pre.yml
@@ -10,8 +10,6 @@
     - "vars/main.yml"
     - "vars/{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.yml"
   pre_tasks:
-    - name: Check platform
-      include_tasks: "check_platform.yml"
     - name: Run pre installation checks
       include_tasks: "{{ item }}"
       with_fileglob:

--- a/ansible/pre.yml
+++ b/ansible/pre.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check platform
-  include_tasks: "tasks/check_platform.yml"
+  include_tasks: "check_platform.yml"
 
 - name: pre tasks
   hosts: all

--- a/ansible/pre.yml
+++ b/ansible/pre.yml
@@ -1,7 +1,4 @@
 ---
-- name: Check platform
-  include_tasks: "check_platform.yml"
-
 - name: pre tasks
   hosts: all
   become: "False"
@@ -13,6 +10,8 @@
     - "vars/main.yml"
     - "vars/{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.yml"
   pre_tasks:
+    - name: Check platform
+      include_tasks: "check_platform.yml"
     - name: Run pre installation checks
       include_tasks: "{{ item }}"
       with_fileglob:

--- a/ansible/vars/main.yml
+++ b/ansible/vars/main.yml
@@ -1,5 +1,15 @@
 ---
 # General settings
+
+# NOC level. Set by tower:
+#
+# `ce` - Community Edition
+# `pro` - Subscribtion/subbrands
+#
+# Do not change manually. Manual changes may result in undefined or
+# unsupported behavior.
+noc_level: "{{ noc_licence_level | default('ce') }}"
+
 # for os specific see pre role
 etc_prefix: /etc
 ansible_python_interpreter: auto

--- a/ansible/vars/platforms.yml
+++ b/ansible/vars/platforms.yml
@@ -25,3 +25,5 @@ platforms:
     required_level: pro
   OracleLinux_7:
     required_level: pro
+# Full platform name
+platform: "{{ ansible_distribution }}_{{ ansible_distribution_major_version }}"

--- a/ansible/vars/platforms.yml
+++ b/ansible/vars/platforms.yml
@@ -1,0 +1,27 @@
+# Supported NOC platforms.
+#
+# `required_level` defines the minimum NOC licence level required to use
+# the platform:
+#   `ce`  - Community Edition
+#   `pro` - Subscription / whitelabel / derived product
+#
+# A platform not listed here is not supported.
+platforms:
+  # CE level platforms
+  Debian_11:
+    required_level: ce
+  Ubuntu_22:
+    required_level: ce
+  FreeBSD_12:
+    required_level: ce
+  # Pro level platforms
+  Debian_10:
+    required_level: pro
+  Ubuntu_20:
+    required_level: pro
+  CentOS_7:
+    required_level: pro
+  RedHat_7:
+    required_level: pro
+  OracleLinux_7:
+    required_level: pro


### PR DESCRIPTION
Fail the deploy early when a target host's operating system is not a supported NOC
platform, or when the host requires a higher NOC licence level (`pro`) than the one
in use (`ce`). Surfaces unsupported-platform and licence-mismatch problems at the start
of the run instead of deep in role execution.

**Key changes**
- `ansible/check_platform.yml` (new) — reusable task file that runs two gates:
   - `fail` when the host's `platform` is not in the supported-platforms list,
   - `fail` when the platform's `required_level` is `pro` but the active `noc_level` is not `pro`.
- `ansible/vars/platforms.yml` (new) — supported-platform catalogue:
   - CE: `Debian_11`, `Ubuntu_22`, `FreeBSD_12`
   - Pro: `Debian_10`, `Ubuntu_20`, `CentOS_7`, `RedHat_7`, `OracleLinux_7`
   - Defines `platform = "{{ ansible_distribution }}_{{ ansible_distribution_major_version }}"`
     so the gate value is derived from gathered facts instead of an external variable.
- `ansible/vars/main.yml` — adds `noc_level` derived from the Tower variable
  `noc_licence_level` (default `ce`), with a comment explaining CE/Pro.
- `ansible/deploy.yml` — adds a top-of-playbook "Check platform" job
  (`hosts: all`, gathers facts, loads `vars/main.yml`, runs `check_platform.yml`)
  so the gate runs before `import_playbook: pre.yml`. Also removes one stray blank line.

**Implementation details**
- `platform` is now computed from `ansible_distribution` +
  `ansible_distribution_major_version` (e.g. `Debian_11`, `CentOS_7`), matching the
  distro var-file naming in `ansible/pre.yml`; the key resolves against `platforms.yml`.
- The gate runs as the first job, aborting unsupported / mismatched hosts immediately.
- `noc_level` falls back to `ce` when `noc_licence_level` is absent, keeping CE
  deployments working by default.